### PR TITLE
Replace docker-compose with docker compose in make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,11 @@ autogen-templates:
 	&& popd
 
 build:
-	docker-compose build spellbook-serve
+	docker compose build spellbook-serve
 
 dev:
 	# TODO: add env variables to make this work.
-	docker-compose up spellbook-serve-gateway-dev spellbook-serve-service-builder-dev
+	docker compose up spellbook-serve-gateway-dev spellbook-serve-service-builder-dev
 
 build-docs:
 	mkdocs build


### PR DESCRIPTION
`docker compose` is a new command that is integrated into the Docker CLI (as of Docker version 20.10.0).

`docker-compose` is a standalone, open-source Python tool that was developed early on as a way to define multi-container Docker applications. To use it, you have to install it separately from Docker.

So I think it's better to just use `docker compose` given it's part of Docker CLI so that people do need extra pip installation 