### PR TITLE
Allow external users to read Scale-hosted endpoints

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "spellbook-serve-client"
-version = "0.0.0.alpha1"
+version = "0.0.0.alpha2"
 description = "Spellbok Serve Python Client"
 license = "Apache-2.0"
 authors = ["Phil Chen <phil.chen@scale.com>"]

--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -3,6 +3,6 @@ from setuptools import find_packages, setup
 setup(
     name="spellbook-serve-client",
     python_requires=">=3.7",
-    version="0.0.0.alpha1",
+    version="0.0.0.alpha2",
     packages=find_packages(),
 )

--- a/clients/python/spellbook_serve_client/__init__.py
+++ b/clients/python/spellbook_serve_client/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.0.0.alpha1"
+__version__ = "0.0.0.alpha2"
 
 from spellbook_serve_client.completion import Completion
 from spellbook_serve_client.data_types import (

--- a/clients/python/spellbook_serve_client/model.py
+++ b/clients/python/spellbook_serve_client/model.py
@@ -8,8 +8,6 @@ class Model(APIEngine):
     """
     Model API. This API is used to retrieve, list, and create models.
 
-    Note:
-        This feature is only available for self-hosted users.
 
     Example:
         ```python
@@ -26,14 +24,14 @@ class Model(APIEngine):
         model_name: str,
     ) -> CreateLLMModelEndpointV1Response:
         """
-        Create a fine-tuning job
+        Create a Model Endpoint. Note: This feature is only available for self-hosted users.
 
         Args:
             model_name (`str`):
                 Name of the model
 
         Returns:
-            response: ID of the created fine-tuning job
+            response: ID of the created Model Endpoint.
         """
         request = CreateLLMModelEndpointV1Request(
             model_name=model_name,
@@ -46,7 +44,6 @@ class Model(APIEngine):
         return CreateLLMModelEndpointV1Response.parse_obj(response)
 
     @classmethod
-    @assert_self_hosted
     def retrieve(
         cls,
         model_name: str,
@@ -65,7 +62,6 @@ class Model(APIEngine):
         return GetLLMModelEndpointV1Response.parse_obj(response)
 
     @classmethod
-    @assert_self_hosted
     def list(cls) -> ListLLMModelEndpointsV1Response:
         """
         List model endpoints


### PR DESCRIPTION
https://app.shortcut.com/scaleai/story/782287/external-users-should-be-allowed-to-list-llm-models