### PR TITLE
License attribution for OpenAI

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-This project contains client code that was copied and modified from Hugging Face's text-generation-inference client
-library: https://github.com/huggingface/text-generation-inference/tree/main/clients/python
+This project contains client code that was copied and modified from OpenAI's python client library: 
+https://github.com/openai/openai-python
 
 The copied client code lives in clients/python/spellbook_serve_client/api_engine.py.

--- a/clients/python/spellbook_serve_client/api_engine.py
+++ b/clients/python/spellbook_serve_client/api_engine.py
@@ -1,5 +1,5 @@
 # NOTICE - per Apache 2.0 license:
-# This file was copied and modified from the Hugging Face text-generation-inference client library.
+# This file was copied and modified from the OpenAI Python client library: https://github.com/openai/openai-python
 import json
 import os
 from functools import wraps


### PR DESCRIPTION
OpenAI uses the MIT license, but we're using the Apache 2.0 license. We should attribute anyway.