### PR TITLE
Fixes to docs:

### DIFF
--- a/clients/python/llmengine/data_types.py
+++ b/clients/python/llmengine/data_types.py
@@ -109,6 +109,12 @@ class GetModelEndpointV1Response(BaseModel):
 
 
 class TaskStatus(str, Enum):
+    """
+    Specifies the status of a request as an enumeration.
+
+    Valid values are one of PENDING, STARTED, SUCCESS, FAILURE, and UNDEFINED
+    """
+
     PENDING = "PENDING"
     STARTED = "STARTED"
     SUCCESS = "SUCCESS"

--- a/docs/api/python_client.md
+++ b/docs/api/python_client.md
@@ -14,6 +14,10 @@
             - num_completion_tokens
 
 ::: llmengine.CompletionSyncV1Response
+    selection:
+        members:
+            - status
+            - outputs
 
 ::: llmengine.CompletionStreamOutput
     selection:
@@ -25,6 +29,10 @@
 
 
 ::: llmengine.CompletionStreamV1Response
+    selection:
+        members:
+            - status
+            - output
 
 ::: llmengine.FineTune
     selection:
@@ -41,3 +49,6 @@
 ::: llmengine.ListFineTunesResponse
 
 ::: llmengine.CancelFineTuneResponse
+
+::: llmengine.TaskStatus
+

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,6 +1,8 @@
 # 🚀 Getting Started
 
-To start using LLM Engine's public inference and fine-tuning APIs:
+The fastest way to get started with LLMEngine is to use the python client in this repository to run inference and fine-tuning on Scale's infrastructure. This path does not require you to install anything on your infrastructure, and Scale's free tier gives you access to experimentation using open source LLMs.
+
+To start with, install LLMEngine via pip or conda:
 
 === "Install using pip"
     ```commandline
@@ -11,28 +13,25 @@ To start using LLM Engine's public inference and fine-tuning APIs:
     conda install scale-llm-engine -c conda-forge
     ```
 
-Navigate to [https://spellbook.scale.com](https://spellbook.scale.com) where
+Next, navigate to [https://spellbook.scale.com](https://spellbook.scale.com) where
 you will get a Scale API key on the [settings](https://spellbook.scale.com/settings) page.
-Set this API key as the `SCALE_API_KEY` environment variable by adding the
-following line to your `.zshrc` or `.bash_profile`:
+Set this API key as the `SCALE_API_KEY` environment variable:
 
 === "Set API key"
     ```commandline
-    export SCALE_API_KEY = "[Your API key]"
+    export SCALE_API_KEY="[Your API key]"
     ```
 
-With your API key set, you can now send LLM Engine requests using the Python client:
+With your API key set, you can now send LLMEngine requests using the Python client.
+
+Here is an example of inference using the llama-7b model:
 
 === "Using the Python Client"
-    ```py
-    from llmengine import Completion
+```py
+from llmengine import Completion
 
-    response = Completion.create(
-        model_name="llama-7b",
-        prompt="Hello, my name is",
-        max_new_tokens=10,
-        temperature=0.2,
-    )
-    print(response.outputs[0].text)
-    ```
- 
+response = Completion.create(
+  model_name="llama-7b",
+  prompt="Suggest a name for a new icecream shop")
+print(response.outputs[0].text)
+```

--- a/docs/guides/completions.md
+++ b/docs/guides/completions.md
@@ -1,45 +1,90 @@
-LLM Engine provides access to open source language models (see [Model Zoo](/model_zoo)) that can be used for producing 
-Completions.  An example API call looks as follows:
-```python
+An LLM is a Machine Learning model that is given an initial text prompt and then generates a completion for that prompt. LLMs generate completions in different ways - foundation models pick the most likely completion based on their training over a large corpus of documents, instruction-tuned models complete text by trying to follow instructions provided in the prompt, and other models can be fine-tuned to respond in distinct ways.
+
+The LLMEngine repository contains a `Completion` API that is used to get a response from an LLM.
+
+A full reference of the Completions API is [here](/api/python_client/#llmengine.Completion)
+
+There are two primary entry points to the API - `Completion.create` for synchronous calls and `Completion.acreate` for asynchronous calls via python `asyncio`.
+
+Both methods in the API are given the name of the model and the initial prompt as mandatory input parameters.
+
+Optional parameters can be specified for max_new_tokens, temperature, timeout in seconds, and whether responses from the model should be streamed or returned when completed.
+
+## Sync API
+
+In the [Getting Started](./getting_started) guide, we provided a very simple way of using the Completion API to make a call to a model:
+
+=== "Basic example"
+```py
 from llmengine import Completion
 
 response = Completion.create(
-    model_name="llama-7b",
-    prompt="Hello, my name is",
-    max_new_tokens=10,
-    temperature=0.2,
-)
+  model_name="llama-7b",
+  prompt="Suggest a name for an icecream shop")
+print(response.outputs[0].text)
 ```
 
-See the full [API reference documentation](/api/python_client/#llmengine.Completion) to learn more.
+Different models from the [Model Zoo](./model_zoo) can be referenced in a similar manner:
 
-## Completions response format
+=== "Using different LLMs"
+```py
+from llmengine import Completion
 
-An example Completions API response looks as follows:
-
-```json
-{
-    "outputs":
-    [
-        {
-            "text": "_______ and I am a _______",
-            "num_completion_tokens": 10
-        }
-    ],
-}
+# Iterate over a few models in the Model Zoo
+for model_name in ["llama-7b", "falcon-7b", "falcon-7b-instruct"]:
+  response = Completion.create(
+    model_name=model_name,
+    prompt="Suggest a name for an icecream shop",
+    max_new_tokens=100)
+  print(f"Model: {model_name}\nResponse: {response.outputs[0].text}")
 ```
 
-In Python, the response is of type [CompletionSyncV1Response](/api/python_client/#llmengine.CompletionSyncV1Response), 
-which maps to the above JSON structure.
+Similarly, we can vary the maximum number of output tokens, the temperature, and the timeouts for these calls:
 
-## Token streaming
+=== "Using different LLMs and temperatures"
+```py
+from llmengine import Completion
 
-The Completions API support token streaming to reduce perceived latency for certain applications. When streaming, 
-tokens will be sent as data-only [server-side events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format).
+# Iterate over a few models in the Model Zoo
+for model_name in ["llama-7b", "falcon-7b", "falcon-7b-instruct"]:
+  for temperature in [0.1, 0.5, 0.9]:
+    response = Completion.create(
+      model_name=model_name,
+      prompt="Suggest a name for an icecream shop",
+      max_new_tokens=100,
+      temperature=temperature,
+      timeout=100)
+    print(f"Model: {model_name} Temperature: {temperature}\nResponse: {response.outputs[0].text}")
+```
 
-To enable token streaming, pass `stream=True` to either `Completion.create` or `Completion.acreate`.
+For synchronous calls like the ones above, the response is of type `CompletionSyncV1Response`.
 
-An example of token streaming using the synchronous Completions API looks as follows:
+The full reference of that class is [here](/api/python_client/#llmengine.CompletionSyncV1Response).
+
+The `status` field says whether the operation was successful. It contains one value from an enumeration of [states](/api/python_client/#llmengine.TaskStatus)
+
+The `outputs` field contains a list of elements of type [`CompletionOutput`](/api/python_client/#llmengine.CompletionOutput), each element of which contains a `text` string with the completion, and optional elements for the number of tokens in the prompt and in the completion.
+
+=== "Response Format"
+```py
+from llmengine import Completion
+
+response = Completion.create(
+  model_name="falcon-7b-instruct",
+  prompt="Suggest a name for an icecream shop")
+print(response.status)
+print(response.outputs)
+
+# The output of this command is
+# TaskStatus.SUCCESS
+# [CompletionOutput(text='\nIcy Creamery', num_prompt_tokens=None, num_completion_tokens=6)]
+```
+
+### Sync API with streaming responses
+
+It is also possible to set the `stream` argument in `Completion.create` to `True` in order to get streaming responses back from the LLM. The API supports token streaming to reduce perceived latency for certain applications. When streaming, tokens will be sent as data-only [server-side events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format).
+
+=== "Streaming responses"
 ```python
 from llmengine import Completion
 
@@ -54,30 +99,63 @@ stream = Completion.create(
 for response in stream:
     if response.output:
         print(response.json())
+
+# JSON responses here are of this form:
+# {"status": "SUCCESS", "output": {"text": "\\n", "finished": false, "num_prompt_tokens": null, "num_completion_tokens": 1 }, "traceback": null }
+# {"status": "SUCCESS", "output": {"text": "I", "finished": false, "num_prompt_tokens": null, "num_completion_tokens": 2 }, "traceback": null }
+# {"status": "SUCCESS", "output": {"text": " don", "finished": false, "num_prompt_tokens": null, "num_completion_tokens": 3 }, "traceback": null }
+# {"status": "SUCCESS", "output": {"text": "’", "finished": false, "num_prompt_tokens": null, "num_completion_tokens": 4 }, "traceback": null }
+# {"status": "SUCCESS", "output": {"text": "t", "finished": true, "num_prompt_tokens": null, "num_completion_tokens": 5 }, "traceback": null }
 ```
 
-## Async requests
+## Async API
 
-The Python client supports `asyncio` for creating Completions. Use `Completion.acreate` instead of `Completion.create` 
-to utilize async processing. The function signatures are otherwise identical.
+Python's `asyncio` module can be used to make Completion calls asynchronously via `Completion.acreate`. The function signature is otherwise identical to `Completion.create`.
 
-An example of async Completions looks as follows:
+=== "Using python `async`"
 ```python
 import asyncio
 from llmengine import Completion
 
 async def main():
-    response = await Completion.acreate(
-        model_name="llama-7b",
-        prompt="Hello, my name is",
-        max_new_tokens=10,
-        temperature=0.2,
-    )
-    print(response.json())
+  response = await Completion.acreate(
+    model_name="falcon-7b-instruct",
+    prompt="Suggest a name for an icecream shop")
+  print(response.json())
 
 asyncio.run(main())
+
+# JSON response here is:
+# {"status": "SUCCESS", "outputs": [{"text": "\nI scream, you scream, we all scream for ice cream!", "num_prompt_tokens": null, "num_completion_tokens": 15}], "traceback": null}
 ```
 
-## Which model should I use?
+### Async API with streaming responses
 
-See the [Model Zoo](/model_zoo) for more information on best practices for which model to use for Completions.
+It is also possible to set the `stream` argument in `Completion.acreate` to `True` in order to get streaming responses back from the LLM:
+
+=== "Using python `async` and streaming responses"
+```python
+import asyncio
+from llmengine import Completion
+
+async def main():
+  stream = await Completion.acreate(
+    model_name="falcon-7b-instruct",
+    prompt="Suggest a name for an icecream shop",
+    stream=True)
+  async for response in stream:
+    if response.output:
+      print(response.json())
+
+asyncio.run(main())
+
+# JSON responses:
+# {"status": "SUCCESS", "output": {"text": "\n", "finished": false, "num_prompt_tokens": null, "num_completion_tokens": 1}, "traceback": null}
+# {"status": "SUCCESS", "output": {"text": "I", "finished": false, "num_prompt_tokens": null, "num_completion_tokens": 2}, "traceback": null}
+# {"status": "SUCCESS", "output": {"text": "gl", "finished": false, "num_prompt_tokens": null, "num_completion_tokens": 3}, "traceback": null}
+# {"status": "SUCCESS", "output": {"text": "oo", "finished": false, "num_prompt_tokens": null, "num_completion_tokens": 4}, "traceback": null}
+# {"status": "SUCCESS", "output": {"text": " Cream", "finished": false, "num_prompt_tokens": null, "num_completion_tokens": 5}, "traceback": null}
+# {"status": "SUCCESS", "output": {"text": "ery", "finished": false, "num_prompt_tokens": null, "num_completion_tokens": 6}, "traceback": null}
+# {"status": "SUCCESS", "output": {"text": "<|endoftext|>", "finished": true, "num_prompt_tokens": null, "num_completion_tokens": 7}, "traceback": null}
+```
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,34 +1,36 @@
-# ⚡ LLM Engine ⚡
+# ⚡ LLMEngine ⚡
 
-**The open source engine for fine-tuning large language models**. LLM Engine is the easiest way to customize and serve LLMs.
-Use Scale's hosted version or run it in your own cloud.
+**The k8s based open source engine for inference and fine-tuning of Large Language Models**.
 
-## 💻 Quick Install
+LLMEngine is the easiest way to customize and serve LLMs.
 
-=== "Install using pip"
-    ```commandline
-    pip install scale-llm-engine
-    ```
+LLMs can be accessed via Scale's hosted version or by using the helm charts in this repository to run model inference and fine-tuning in your own infrastructure.
 
 ## 🤔 About
 
 Foundation models are emerging as the building blocks of AI. However, deploying
 these models to the cloud and fine-tuning them still requires infrastructure and
-ML expertise, and can be expensive.
+ML expertise. It is also difficult to maintain over time as new models are released
+and new techniques for both inference and fine-tuning are made available.
 
-LLM Engine is a Python library, CLI, and Helm chart that provides
-everything you need to fine-tune and serve foundation models in the cloud
-using Kubernetes. Key features include:
+LLMEngine is a Python library, CLI, and Helm chart that provides everything you need to
+fine-tune and serve open-source foundation models in the cloud using k8s.
+
+If you get a [Scale API key](./getting_started), you can use LLMEngine's python client to access inference and fine-tuning APIs for all supported [models](./model_zoo)
+
+If you instead want to self-host, you can use LLMEngine's helm charts to install LLMEngine server-side code on a k8s cluster of your choice. Note that the current documentation does not cover this use-case, but we will be documenting this path over the next few days.
+
+Key features include:
 
 🚀 **Ready-to-use Fine-Tuning and Inference APIs for your favorite models**:
-LLM Engine comes with ready-to-use APIs for your favorite
-open-source models, including MPT, Falcon, and LLaMA. Use Scale-hosted endpoints
+LLMEngine comes with ready-to-use APIs for your favorite
+open-source [models](./model_zoo), including MPT, Falcon, and LLaMA. Use Scale-hosted endpoints
 or deploy to your own infrastructure.
 
 🐳 **Deploying from any docker image**: Turn any Docker image into an
 auto-scaling deployment with simple APIs.
 
-🎙️**Optimized Inference**: LLM Engine provides inference APIs
+🎙️**Optimized Inference**: LLMEngine provides inference APIs
 for streaming responses and dynamically batching inputs for higher throughput
 and lower latency.
 
@@ -37,9 +39,8 @@ model with a single command.
 
 ### 🔥 Features Coming Soon
 
-❄ **Fast Cold-Start Times**: To prevent GPUs from idling, LLM Engine
-automatically scales your model to zero when it's not in use and scales up
+❄ **Fast Cold-Start Times**: To prevent GPUs from idling, LLMEngine
+automatically scales your active models to zero when they are not in use and scales up
 within seconds, even for large foundation models.
 
-💸 **Cost-Optimized**: Deploy AI models cheaper than commercial ones,
-including cold-start and warm-down times.
+💸 **Cost-Optimized**: Use cold-start and warm-down times to Deploy AI models in a cost-optimized manner.

--- a/docs/model_zoo.md
+++ b/docs/model_zoo.md
@@ -1,6 +1,6 @@
 # 🦙 Public Model Zoo
 
-Scale hosts the following models in a model zoo:
+LLMEngine hosts the following models for use:
 
 | Model Name | Inference APIs Available | Fine-tuning APIs Available |
 | --- | --- | --- |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
-site_name: LLM Engine
-site_description: The open source engine for fine-tuning large language models.
+site_name: LLMEngine
+site_description: The k8s based open source engine for inference and fine-tuning of large language models.
 
 theme:
   name: material
@@ -41,9 +41,8 @@ nav:
       - "Fine-tuning": guides/fine_tuning.md
       - "Rate limits": guides/rate_limits.md
   - "API":
-      - "Error handling": api/error_handling.md
       - "Python Client API Reference": api/python_client.md
-      - "Langchain": api/langchain.md
+      - "Error handling": api/error_handling.md
 #  - "FAQ": faq.md
 
 markdown_extensions:


### PR DESCRIPTION
- Much richer 'Completions' how-to guide
- document 'TaskStatus', remove documentation of 'traceback' in completion status
- examples using an instruct model for friendlier outputs
- remove empty langchain section from main page