### PR TITLE
Refactor docs navigation to split out API and Data Type references

### DIFF
--- a/docs/api/data_types.md
+++ b/docs/api/data_types.md
@@ -1,0 +1,28 @@
+# 🐍 Python Client Data Type Reference
+
+::: llmengine.CompletionOutput
+    selection:
+        members:
+            - text
+            - num_prompt_tokens
+            - num_completion_tokens
+
+::: llmengine.CompletionStreamOutput
+    selection:
+        members:
+            - text
+            - finished
+            - num_prompt_tokens
+            - num_completion_tokens
+
+::: llmengine.CompletionSyncV1Response
+
+::: llmengine.CompletionStreamV1Response
+
+::: llmengine.CreateFineTuneResponse
+
+::: llmengine.GetFineTuneResponse
+
+::: llmengine.ListFineTunesResponse
+
+::: llmengine.CancelFineTuneResponse

--- a/docs/api/python_client.md
+++ b/docs/api/python_client.md
@@ -6,26 +6,6 @@
             - create
             - acreate
 
-::: llmengine.CompletionOutput
-    selection:
-        members:
-            - text
-            - num_prompt_tokens
-            - num_completion_tokens
-
-::: llmengine.CompletionSyncV1Response
-
-::: llmengine.CompletionStreamOutput
-    selection:
-        members:
-            - text
-            - finished
-            - num_prompt_tokens
-            - num_completion_tokens
-
-
-::: llmengine.CompletionStreamV1Response
-
 ::: llmengine.FineTune
     selection:
         members:
@@ -33,11 +13,3 @@
             - list
             - retrieve
             - cancel
-
-::: llmengine.CreateFineTuneResponse
-
-::: llmengine.GetFineTuneResponse
-
-::: llmengine.ListFineTunesResponse
-
-::: llmengine.CancelFineTuneResponse

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,7 +41,7 @@ nav:
       - "Fine-tuning": guides/fine_tuning.md
       - "Rate limits": guides/rate_limits.md
   - "API":
-      - "Python Client API Reference": api/python_client.md
+      - "API Reference": api/python_client.md
       - "Data Type Reference": api/data_types.md
       - "Error handling": api/error_handling.md
 #  - "FAQ": faq.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,9 +41,9 @@ nav:
       - "Fine-tuning": guides/fine_tuning.md
       - "Rate limits": guides/rate_limits.md
   - "API":
-      - "Error handling": api/error_handling.md
       - "Python Client API Reference": api/python_client.md
-      - "Langchain": api/langchain.md
+      - "Data Type Reference": api/data_types.md
+      - "Error handling": api/error_handling.md
 #  - "FAQ": faq.md
 
 markdown_extensions:


### PR DESCRIPTION
<img width="1306" alt="image" src="https://github.com/scaleapi/llm-engine/assets/1389330/6622fd7c-732b-4302-8727-66fdb222e130">
<img width="1384" alt="image" src="https://github.com/scaleapi/llm-engine/assets/1389330/234ff01b-80a5-42ac-b94b-716e311be3a6">
