### PR TITLE
Fix TGI repo name

### DIFF
--- a/charts/llm-engine/values_sample.yaml
+++ b/charts/llm-engine/values_sample.yaml
@@ -1,7 +1,7 @@
 # This is a YAML-formatted file.
 
 # tag [required] is the LLM Engine docker image tag
-tag: 1defd4f9c5376149e27673e154731a0c7820fe5d
+tag: 41ecada1b51ce3a46bbc3190a36ed7890db370d3
 # context is a user-specified deployment tag. Can be used to 
 context: production
 image:

--- a/server/llm_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
+++ b/server/llm_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
@@ -227,7 +227,7 @@ class CreateLLMModelEndpointV1UseCase:
                     schema_location="TBA",
                     flavor=StreamingEnhancedRunnableImageFlavor(
                         flavor=ModelBundleFlavorType.STREAMING_ENHANCED_RUNNABLE_IMAGE,
-                        repository="text-generation-inference",  # TODO: let user choose repo
+                        repository="ghcr.io/huggingface/text-generation-inference",  # TODO: let user choose repo
                         tag=framework_image_tag,
                         command=command,
                         streaming_command=command,


### PR DESCRIPTION
# Summary 
Use `ghcr.io/huggingface/text-generation-inference` as TGI repo name in `CreateLLMModelEndpointV1UseCase`

# Test Plan

```python
data = {
    "name": "llama-7b",
    "model_name": "llama-7b",
    "source": "hugging_face",
    "inference_framework": "text_generation_inference",
    "inference_framework_image_tag": "0.9.1",
    "num_shards": 4,
    "endpoint_type": "streaming",
    "cpus": 32,
    "gpus": 4,
    "memory": "20Gi",
    "storage": "20Gi",
    "gpu_type": "nvidia-ampere-a10",
    "min_workers": 1,
    "max_workers": 12,
    "per_worker": 1,
    "labels": {"team": "infra", "product": "llm_model_zoo"},
    "metadata": {}
}
headers = {'Content-Type': 'application/json'}
response = requests.post("http://localhost:5000/v1/llm/model-endpoints", headers=headers, data=json.dumps(data), auth=('test_user_id', ''))
print(response.status_code)
print(response.json())
---------------------------------------
200
{'endpoint_creation_task_id': '2a678225-e432-40f6-aa10-aa126bf563dc'}
```

```
(launch) ➜  devbox ~ kubectl get pods -n llm-engine
NAME                                                              READY   STATUS    RESTARTS   AGE
llm-engine-5b55946b9d-t5977                                       1/1     Running   0          12m
llm-engine-5b55946b9d-xj68v                                       1/1     Running   0          11m
llm-engine-cacher-74c54c6457-xqkgw                                1/1     Running   0          12m
llm-engine-endpoint-builder-7567f599cf-cxc26                      1/1     Running   0          12m
llm-engine-endpoint-id-end-cirlrdmho4cg03q2v980-55ddd99f7c94drl   0/2     Pending   0          6m3s
llm-engine-image-cache-a10-sw4pg                                  1/1     Running   0          24h
(launch) ➜  devbox ~ kubectl describe deployment llm-engine-endpoint-id-end -n llm-engine
Name:                   llm-engine-endpoint-id-end-cirlrdmho4cg03q2v980
Namespace:              llm-engine
CreationTimestamp:      Wed, 19 Jul 2023 03:51:18 +0000
Labels:                 created_by=test_user_id
                        endpoint_id=end_cirlrdmho4cg03q2v980
                        endpoint_name=llama-7b
                        env=production
                        managed-by=llm-engine
                        owner=test_user_id
                        product=llm_model_zoo
                        tags.datadoghq.com/env=production
                        tags.datadoghq.com/service=llama-7b
                        tags.datadoghq.com/version=41ecada1b51ce3a46bbc3190a36ed7890db370d3
                        team=infra
                        use_scale_llm_engine_endpoint_network_policy=true
                        user_id=test_user_id
Annotations:            deployment.kubernetes.io/revision: 1
Selector:               app=llm-engine-endpoint-id-end-cirlrdmho4cg03q2v980,version=v1
Replicas:               1 desired | 1 updated | 1 total | 0 available | 1 unavailable
StrategyType:           RollingUpdate
MinReadySeconds:        0
RollingUpdateStrategy:  0 max unavailable, 1 max surge
Pod Template:
  Labels:           app=llm-engine-endpoint-id-end-cirlrdmho4cg03q2v980
                    created_by=test_user_id
                    endpoint_id=end_cirlrdmho4cg03q2v980
                    endpoint_name=llama-7b
                    env=production
                    managed-by=llm-engine
                    owner=test_user_id
                    product=llm_model_zoo
                    tags.datadoghq.com/env=production
                    tags.datadoghq.com/service=llama-7b
                    tags.datadoghq.com/version=41ecada1b51ce3a46bbc3190a36ed7890db370d3
                    team=infra
                    use_scale_llm_engine_endpoint_network_policy=true
                    user_id=test_user_id
                    version=v1
  Annotations:      ad.datadoghq.com/main.logs: [{"service": "llama-7b", "source": "python"}]
                    kubernetes.io/change-cause:
                      Deployment at 2023-07-19 03:51:18.763455 UTC. Using deployment constructed from model bundle ID: bun_cirlrdmho4cg03q2v97g, model bundle na...
  Service Account:  llm-engine
  Containers:
   http-forwarder:
    Image:      public.ecr.aws/b2z8n5q1/llm-engine:41ecada1b51ce3a46bbc3190a36ed7890db370d3
    Port:       5000/TCP
    Host Port:  0/TCP
    Command:
      /usr/bin/dumb-init
      --
      ddtrace-run
      python
      -m
      llm_engine.inference.forwarding.http_forwarder
      --config
      /workspace/llm_engine/llm_engine/inference/configs/service--http_forwarder.yaml
      --port
      5000
      --num-workers
      1
      --set
      forwarder.sync.predict_route=/generate
      --set
      forwarder.stream.predict_route=/generate_stream
      --set
      forwarder.sync.healthcheck_route=/health
      --set
      forwarder.stream.healthcheck_route=/health
    Limits:
      cpu:                500m
      ephemeral-storage:  1G
      memory:             1Gi
    Requests:
      cpu:                100m
      ephemeral-storage:  100M
      memory:             100M
    Readiness:            http-get http://:5000/readyz delay=60s timeout=1s period=5s #success=1 #failure=3
    Environment:
      DATADOG_TRACE_ENABLED:          false
      DD_SERVICE:                     llama-7b
      DD_ENV:                         production
      DD_VERSION:                     41ecada1b51ce3a46bbc3190a36ed7890db370d3
      DD_AGENT_HOST:                   (v1:status.hostIP)
      AWS_PROFILE:                    default
      RESULTS_S3_BUCKET:              scale-ml-egp-test
      BASE_PATH:                      /workspace
      ML_INFRA_SERVICES_CONFIG_PATH:  /workspace/ml_infra_core/llm_engine.core/llm_engine.core/configs/config.yaml
    Mounts:
      /root/.aws/config from config-volume (rw,path="config")
      /workspace/endpoint_config from endpoint-config (rw,path="raw_data")
      /workspace/ml_infra_core/llm_engine.core/llm_engine.core/configs from infra-service-config-volume (rw)
      /workspace/user_config from user-config (rw,path="raw_data")
   main:
    Image:      ghcr.io/huggingface/text-generation-inference:0.9.1
    Port:       5005/TCP
    Host Port:  0/TCP
    Command:
      text-generation-launcher
      --model-id
      decapoda-research/llama-7b-hf
      --num-shard
      4
      --port
      5005
      --hostname
      ::
    Limits:
      cpu:                32
      ephemeral-storage:  94Gi
      memory:             192Gi
      nvidia.com/gpu:     4
    Requests:
      cpu:                32
      ephemeral-storage:  94Gi
      memory:             192Gi
    Readiness:            http-get http://:5005/health delay=60s timeout=1s period=5s #success=1 #failure=3
    Environment:
      DATADOG_TRACE_ENABLED:  true
      DD_SERVICE:             llama-7b
      DD_ENV:                 production
      DD_VERSION:             41ecada1b51ce3a46bbc3190a36ed7890db370d3
      DD_AGENT_HOST:           (v1:status.hostIP)
    Mounts:
      /app/endpoint_config from endpoint-config (rw,path="raw_data")
      /app/user_config from user-config (rw,path="raw_data")
      /dev/shm from dshm (rw)
      /home/llmengine/.aws/config from config-volume (rw,path="config")
      /infra-config from infra-service-config-volume (rw)
      /root/.aws/config from config-volume (rw,path="config")
  Volumes:
   config-volume:
    Type:      ConfigMap (a volume populated by a ConfigMap)
    Name:      default-config
    Optional:  false
   user-config:
    Type:      ConfigMap (a volume populated by a ConfigMap)
    Name:      llm-engine-endpoint-id-end-cirlrdmho4cg03q2v980
    Optional:  false
   endpoint-config:
    Type:      ConfigMap (a volume populated by a ConfigMap)
    Name:      llm-engine-endpoint-id-end-cirlrdmho4cg03q2v980-endpoint-config
    Optional:  false
   dshm:
    Type:       EmptyDir (a temporary directory that shares a pod's lifetime)
    Medium:     Memory
    SizeLimit:  <unset>
   infra-service-config-volume:
    Type:               ConfigMap (a volume populated by a ConfigMap)
    Name:               llm-engine-service-config
    Optional:           false
  Priority Class Name:  llm-engine-default-priority
Conditions:
  Type           Status  Reason
  ----           ------  ------
  Available      False   MinimumReplicasUnavailable
  Progressing    True    ReplicaSetUpdated
OldReplicaSets:  <none>
NewReplicaSet:   llm-engine-endpoint-id-end-cirlrdmho4cg03q2v980-55ddd99f7c (1/1 replicas created)
Events:
  Type    Reason             Age    From                   Message
  ----    ------             ----   ----                   -------
  Normal  ScalingReplicaSet  7m18s  deployment-controller  Scaled up replica set llm-engine-endpoint-id-end-cirlrdmho4cg03q2v980-55ddd99f7c to 1

(launch) ➜  devbox ~ 

```