### PR TITLE
Patch Integration Test in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
           name: Install helm chart
           command: |
             cd $HOME/project/charts
-            helm install llm-engine llm-engine --values llm-engine/values_sample.yaml
+            helm install llm-engine llm-engine --values llm-engine/values_circleci.yaml --set tag=$CIRCLE_SHA1
 
 executors:
   ubuntu-large:


### PR DESCRIPTION
Helm Install was previously failing in CI. Use CI values and set image tag.