### PR TITLE
updating api key settings so that we can set api key without environm…

### DIFF
--- a/clients/python/llmengine/api_engine.py
+++ b/clients/python/llmengine/api_engine.py
@@ -13,8 +13,15 @@ SPELLBOOK_API_URL = "https://api.spellbook.scale.com/llm-engine"
 LLM_ENGINE_BASE_PATH = os.getenv("LLM_ENGINE_BASE_PATH", SPELLBOOK_API_URL)
 DEFAULT_TIMEOUT: int = 10
 
+api_key = None
+
+def set_api_key(key): 
+    global api_key
+    api_key = key
 
 def get_api_key() -> str:
+    if api_key is not None: 
+        return api_key
     env_api_key = os.getenv("SCALE_API_KEY")
     return env_api_key or "root"
 


### PR DESCRIPTION
…ent var


Explanation on why we want this change: currently we only allow for the api key to be set via the SCALE_API_KEY environment variable, we may want slightly more flexibility in the future.

The new changes here allow for the following use patterns: 

`llmengine.api_engine.api_key = "abc"`
`llmengine.api_engine.set_api_key("abc")`

both are still maybe not ideal since they aren't quite as simple as `llmengine.api_key`, we might want to continue to change / simplify.