### PR TITLE
Check for plugins.dependencies

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -44,6 +44,7 @@ RUN pip install -r requirements.txt --no-cache-dir
 RUN pip install -r requirements_override.txt --no-cache-dir
 COPY server/pyproject.toml /workspace/server/pyproject.toml
 COPY server/setup.py /workspace/server/setup.py
+COPY server/service_configs /workspace/server/service_configs
 COPY server/llm_engine_server /workspace/server/llm_engine_server
 RUN pip install -e .
 

--- a/server/llm_engine_server/infra/gateways/__init__.py
+++ b/server/llm_engine_server/infra/gateways/__init__.py
@@ -4,6 +4,7 @@ from .batch_job_orchestration_gateway import BatchJobOrchestrationGateway
 from .batch_job_progress_gateway import BatchJobProgressGateway
 from .celery_task_queue_gateway import CeleryTaskQueueGateway
 from .datadog_monitoring_metrics_gateway import DatadogMonitoringMetricsGateway
+from .fake_model_primitive_gateway import FakeModelPrimitiveGateway
 from .fake_monitoring_metrics_gateway import FakeMonitoringMetricsGateway
 from .filesystem_gateway import FilesystemGateway
 from .live_async_model_endpoint_inference_gateway import LiveAsyncModelEndpointInferenceGateway
@@ -24,6 +25,7 @@ __all__: Sequence[str] = [
     "BatchJobProgressGateway",
     "CeleryTaskQueueGateway",
     "DatadogMonitoringMetricsGateway",
+    "FakeModelPrimitiveGateway",
     "FakeMonitoringMetricsGateway",
     "FilesystemGateway",
     "LiveAsyncModelEndpointInferenceGateway",


### PR DESCRIPTION
Allow `plugins.dependencies` to override `get_external_interfaces`, `get_external_interfaces_read_only`, `verify_authentication`