### PR TITLE
Sync scale from zero, part 1

### DIFF
--- a/model-engine/model_engine_server/api/dependencies.py
+++ b/model-engine/model_engine_server/api/dependencies.py
@@ -49,6 +49,7 @@ from model_engine_server.infra.gateways import (
     LiveStreamingModelEndpointInferenceGateway,
     LiveSyncModelEndpointInferenceGateway,
     ModelEndpointInfraGateway,
+    RedisInferenceAutoscalingMetricsGateway,
     S3FilesystemGateway,
     S3LLMArtifactGateway,
 )
@@ -179,6 +180,9 @@ def _get_external_interfaces(
     model_endpoints_schema_gateway = LiveModelEndpointsSchemaGateway(
         filesystem_gateway=filesystem_gateway
     )
+    inference_autoscaling_metrics_gateway = RedisInferenceAutoscalingMetricsGateway(
+        redis_client=redis_client
+    )  # we can just reuse the existing redis client, we shouldn't get key collisions because of the prefix
     model_endpoint_service = LiveModelEndpointService(
         model_endpoint_record_repository=model_endpoint_record_repo,
         model_endpoint_infra_gateway=model_endpoint_infra_gateway,
@@ -187,6 +191,7 @@ def _get_external_interfaces(
         streaming_model_endpoint_inference_gateway=streaming_model_endpoint_inference_gateway,
         sync_model_endpoint_inference_gateway=sync_model_endpoint_inference_gateway,
         model_endpoints_schema_gateway=model_endpoints_schema_gateway,
+        inference_autoscaling_metrics_gateway=inference_autoscaling_metrics_gateway,
     )
     llm_model_endpoint_service = LiveLLMModelEndpointService(
         model_endpoint_record_repository=model_endpoint_record_repo,

--- a/model-engine/model_engine_server/api/tasks_v1.py
+++ b/model-engine/model_engine_server/api/tasks_v1.py
@@ -11,6 +11,7 @@ from model_engine_server.common.dtos.tasks import (
     CreateAsyncTaskV1Response,
     EndpointPredictV1Request,
     GetAsyncTaskV1Response,
+    SyncEndpointPredictV1Request,
     SyncEndpointPredictV1Response,
     TaskStatus,
 )
@@ -97,7 +98,7 @@ def get_async_inference_task(
 @inference_task_router_v1.post("/sync-tasks", response_model=SyncEndpointPredictV1Response)
 async def create_sync_inference_task(
     model_endpoint_id: str,
-    request: EndpointPredictV1Request,
+    request: SyncEndpointPredictV1Request,
     auth: User = Depends(verify_authentication),
     external_interfaces: ExternalInterfaces = Depends(get_external_interfaces_read_only),
 ) -> SyncEndpointPredictV1Response:
@@ -137,7 +138,7 @@ async def create_sync_inference_task(
 @inference_task_router_v1.post("/streaming-tasks")
 async def create_streaming_inference_task(
     model_endpoint_id: str,
-    request: EndpointPredictV1Request,
+    request: SyncEndpointPredictV1Request,
     auth: User = Depends(verify_authentication),
     external_interfaces: ExternalInterfaces = Depends(get_external_interfaces_read_only),
 ) -> EventSourceResponse:

--- a/model-engine/model_engine_server/common/config.py
+++ b/model-engine/model_engine_server/common/config.py
@@ -45,7 +45,7 @@ def get_model_cache_directory_name(model_name: str):
 class HostedModelInferenceServiceConfig:
     endpoint_namespace: str
     billing_queue_arn: str
-    cache_redis_url: str
+    cache_redis_url: str  # also using this to store sync autoscaling metrics
     sqs_profile: str
     sqs_queue_policy_template: str
     sqs_queue_tag_template: str

--- a/model-engine/model_engine_server/common/dtos/tasks.py
+++ b/model-engine/model_engine_server/common/dtos/tasks.py
@@ -6,7 +6,7 @@ from enum import Enum
 from typing import Any, Optional
 
 from model_engine_server.domain.entities import CallbackAuth
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class ResponseSchema(BaseModel):
@@ -49,3 +49,10 @@ class EndpointPredictV1Request(BaseModel):
     callback_url: Optional[str] = None
     callback_auth: Optional[CallbackAuth] = None
     return_pickled: bool = False
+
+
+class SyncEndpointPredictV1Request(EndpointPredictV1Request):
+    timeout_seconds: Optional[float] = Field(default=None, gt=0)
+    num_retries: Optional[int] = Field(default=None, ge=0)
+    # See live_{sync,streaming}_model_endpoint_inference_gateway to see how timeout_seconds/num_retries interact.
+    # Also these fields are only relevant for sync endpoints

--- a/model-engine/model_engine_server/domain/exceptions.py
+++ b/model-engine/model_engine_server/domain/exceptions.py
@@ -59,6 +59,13 @@ class TooManyRequestsException(DomainException):
     """
 
 
+class NoHealthyUpstreamException(DomainException):
+    """
+    Thrown if an endpoint returns a 503 exception for no healthy upstream. This can happen if there are zero pods
+    available to serve the request.
+    """
+
+
 class CorruptRecordInfraStateException(DomainException):
     """
     Thrown if the data from existing state (i.e. the db, k8s, etc.) is somehow uninterpretable

--- a/model-engine/model_engine_server/domain/gateways/__init__.py
+++ b/model-engine/model_engine_server/domain/gateways/__init__.py
@@ -2,6 +2,7 @@ from .async_model_endpoint_inference_gateway import AsyncModelEndpointInferenceG
 from .cron_job_gateway import CronJobGateway
 from .docker_image_batch_job_gateway import DockerImageBatchJobGateway
 from .file_storage_gateway import FileStorageGateway
+from .inference_autoscaling_metrics_gateway import InferenceAutoscalingMetricsGateway
 from .llm_artifact_gateway import LLMArtifactGateway
 from .model_endpoints_schema_gateway import ModelEndpointsSchemaGateway
 from .model_primitive_gateway import ModelPrimitiveGateway

--- a/model-engine/model_engine_server/domain/gateways/__init__.py
+++ b/model-engine/model_engine_server/domain/gateways/__init__.py
@@ -16,6 +16,7 @@ __all__ = (
     "CronJobGateway",
     "DockerImageBatchJobGateway",
     "FileStorageGateway",
+    "InferenceAutoscalingMetricsGateway",
     "LLMArtifactGateway",
     "ModelEndpointsSchemaGateway",
     "ModelPrimitiveGateway",

--- a/model-engine/model_engine_server/domain/gateways/inference_autoscaling_metrics_gateway.py
+++ b/model-engine/model_engine_server/domain/gateways/inference_autoscaling_metrics_gateway.py
@@ -1,0 +1,22 @@
+from abc import ABC, abstractmethod
+
+
+class InferenceAutoscalingMetricsGateway(ABC):
+    """
+    Abstract Base Class for a gateway that emits autoscaling metrics for inference requests. Can be used in conjunction
+    with various autoscaler resources, e.g. a Keda ScaledObject, to autoscale inference endpoints.
+    """
+
+    @abstractmethod
+    async def emit_inference_autoscaling_metric(self, endpoint_id: str):
+        """
+        On an inference request, emit a metric
+        """
+        pass
+
+    @abstractmethod
+    async def emit_prewarm_metric(self, endpoint_id: str):
+        """
+        If you want to prewarm an endpoint, emit a metric here
+        """
+        pass

--- a/model-engine/model_engine_server/domain/gateways/streaming_model_endpoint_inference_gateway.py
+++ b/model-engine/model_engine_server/domain/gateways/streaming_model_endpoint_inference_gateway.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import AsyncIterable
 
 from model_engine_server.common.dtos.tasks import (
-    EndpointPredictV1Request,
+    SyncEndpointPredictV1Request,
     SyncEndpointPredictV1Response,
 )
 
@@ -17,7 +17,7 @@ class StreamingModelEndpointInferenceGateway(ABC):
 
     @abstractmethod
     def streaming_predict(
-        self, topic: str, predict_request: EndpointPredictV1Request
+        self, topic: str, predict_request: SyncEndpointPredictV1Request
     ) -> AsyncIterable[SyncEndpointPredictV1Response]:
         """
         Runs a prediction request and returns a streaming response.

--- a/model-engine/model_engine_server/domain/gateways/sync_model_endpoint_inference_gateway.py
+++ b/model-engine/model_engine_server/domain/gateways/sync_model_endpoint_inference_gateway.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 
 from model_engine_server.common.dtos.tasks import (
-    EndpointPredictV1Request,
+    SyncEndpointPredictV1Request,
     SyncEndpointPredictV1Response,
 )
 
@@ -16,7 +16,7 @@ class SyncModelEndpointInferenceGateway(ABC):
 
     @abstractmethod
     async def predict(
-        self, topic: str, predict_request: EndpointPredictV1Request
+        self, topic: str, predict_request: SyncEndpointPredictV1Request
     ) -> SyncEndpointPredictV1Response:
         """
         Runs a prediction request and returns a response.

--- a/model-engine/model_engine_server/domain/services/model_endpoint_service.py
+++ b/model-engine/model_engine_server/domain/services/model_endpoint_service.py
@@ -18,6 +18,9 @@ from model_engine_server.domain.gateways import (
     StreamingModelEndpointInferenceGateway,
     SyncModelEndpointInferenceGateway,
 )
+from model_engine_server.domain.gateways.inference_autoscaling_metrics_gateway import (
+    InferenceAutoscalingMetricsGateway,
+)
 
 
 class ModelEndpointService(ABC):
@@ -47,6 +50,14 @@ class ModelEndpointService(ABC):
     ) -> StreamingModelEndpointInferenceGateway:
         """
         Returns the sync model endpoint inference gateway.
+        """
+
+    @abstractmethod
+    def get_inference_auto_scaling_metrics_gateway(
+        self,
+    ) -> InferenceAutoscalingMetricsGateway:
+        """
+        Returns the inference autoscaling metrics gateway.
         """
 
     @abstractmethod

--- a/model-engine/model_engine_server/entrypoints/start_batch_job_orchestration.py
+++ b/model-engine/model_engine_server/entrypoints/start_batch_job_orchestration.py
@@ -20,6 +20,7 @@ from model_engine_server.infra.gateways import (
     LiveModelEndpointsSchemaGateway,
     LiveStreamingModelEndpointInferenceGateway,
     LiveSyncModelEndpointInferenceGateway,
+    RedisInferenceAutoscalingMetricsGateway,
     S3FilesystemGateway,
 )
 from model_engine_server.infra.gateways.resources.fake_sqs_endpoint_resource_delegate import (
@@ -95,6 +96,9 @@ async def run_batch_job(
     model_endpoints_schema_gateway = LiveModelEndpointsSchemaGateway(
         filesystem_gateway=filesystem_gateway
     )
+    inference_autoscaling_metrics_gateway = RedisInferenceAutoscalingMetricsGateway(
+        redis_client=redis,
+    )
     model_endpoint_service = LiveModelEndpointService(
         model_endpoint_record_repository=model_endpoint_record_repo,
         model_endpoint_infra_gateway=model_endpoint_infra_gateway,
@@ -103,6 +107,7 @@ async def run_batch_job(
         streaming_model_endpoint_inference_gateway=streaming_model_endpoint_inference_gateway,
         sync_model_endpoint_inference_gateway=sync_model_endpoint_inference_gateway,
         model_endpoints_schema_gateway=model_endpoints_schema_gateway,
+        inference_autoscaling_metrics_gateway=inference_autoscaling_metrics_gateway,
     )
     batch_job_record_repository = DbBatchJobRecordRepository(session=session, read_only=False)
     batch_job_progress_gateway = LiveBatchJobProgressGateway(filesystem_gateway=filesystem_gateway)

--- a/model-engine/model_engine_server/infra/gateways/__init__.py
+++ b/model-engine/model_engine_server/infra/gateways/__init__.py
@@ -18,6 +18,7 @@ from .live_streaming_model_endpoint_inference_gateway import (
 )
 from .live_sync_model_endpoint_inference_gateway import LiveSyncModelEndpointInferenceGateway
 from .model_endpoint_infra_gateway import ModelEndpointInfraGateway
+from .redis_inference_autoscaling_metrics_gateway import RedisInferenceAutoscalingMetricsGateway
 from .s3_filesystem_gateway import S3FilesystemGateway
 from .s3_llm_artifact_gateway import S3LLMArtifactGateway
 
@@ -38,6 +39,7 @@ __all__: Sequence[str] = [
     "LiveStreamingModelEndpointInferenceGateway",
     "LiveSyncModelEndpointInferenceGateway",
     "ModelEndpointInfraGateway",
+    "RedisInferenceAutoscalingMetricsGateway",
     "S3FilesystemGateway",
     "S3LLMArtifactGateway",
 ]

--- a/model-engine/model_engine_server/infra/gateways/redis_inference_autoscaling_metrics_gateway.py
+++ b/model-engine/model_engine_server/infra/gateways/redis_inference_autoscaling_metrics_gateway.py
@@ -1,0 +1,48 @@
+from typing import Optional
+
+import aioredis
+from model_engine_server.domain.gateways.inference_autoscaling_metrics_gateway import (
+    InferenceAutoscalingMetricsGateway,
+)
+
+EXPIRY_SECONDS = 60  # 1 minute; this gets added to the cooldown time present in the keda ScaledObject to get total
+# scaledown time. This also needs to be larger than the keda ScaledObject's refresh rate.
+PREWARM_EXPIRY_SECONDS = 60 * 60  # 1 hour
+
+
+class RedisInferenceAutoscalingMetricsGateway(InferenceAutoscalingMetricsGateway):
+    def __init__(
+        self, redis_info: Optional[str] = None, redis_client: Optional[aioredis.Redis] = None
+    ):
+        assert redis_info or redis_client, "Either redis_info or redis_client must be defined."
+        if redis_info:
+            # If aioredis cannot create a connection pool, reraise that as an error because the
+            # default error message is cryptic and not obvious.
+            try:
+                self._redis = aioredis.from_url(redis_info, health_check_interval=60)
+            except Exception as exc:
+                raise RuntimeError(
+                    "If redis_info is specified, RedisInferenceAutoscalingMetricsGateway must be"
+                    "initialized within a coroutine. Please specify the redis_client directly."
+                ) from exc
+        else:
+            assert redis_client is not None  # for mypy
+            self._redis = redis_client
+
+    @staticmethod
+    def _find_redis_key(endpoint_id: str):
+        return f"launch-endpoint-autoscaling:{endpoint_id}"
+
+    async def _emit_metric(self, endpoint_id: str, expiry_time: int):
+        key = self._find_redis_key(endpoint_id)
+        await self._redis.expire(key, expiry_time)  # does nothing if key doesn't exist,
+        # but avoids a race condition where the key expires in between the lpush and subsequent expire commands
+        await self._redis.lpush(key, 1)  # we only care about the length of the list, not the values
+        await self._redis.ltrim(key, 0, 0)  # we only want to scale from 0 to 1 for redis
+        await self._redis.expire(key, expiry_time)
+
+    async def emit_inference_autoscaling_metric(self, endpoint_id: str):
+        await self._emit_metric(endpoint_id, EXPIRY_SECONDS)
+
+    async def emit_prewarm_metric(self, endpoint_id: str):
+        await self._emit_metric(endpoint_id, PREWARM_EXPIRY_SECONDS)

--- a/model-engine/model_engine_server/infra/services/live_model_endpoint_service.py
+++ b/model-engine/model_engine_server/infra/services/live_model_endpoint_service.py
@@ -27,6 +27,9 @@ from model_engine_server.domain.gateways import (
     StreamingModelEndpointInferenceGateway,
     SyncModelEndpointInferenceGateway,
 )
+from model_engine_server.domain.gateways.inference_autoscaling_metrics_gateway import (
+    InferenceAutoscalingMetricsGateway,
+)
 from model_engine_server.domain.services import ModelEndpointService
 from model_engine_server.domain.use_cases.model_endpoint_use_cases import MODEL_BUNDLE_CHANGED_KEY
 from model_engine_server.infra.gateways import ModelEndpointInfraGateway
@@ -51,6 +54,7 @@ class LiveModelEndpointService(ModelEndpointService):
         streaming_model_endpoint_inference_gateway: StreamingModelEndpointInferenceGateway,
         sync_model_endpoint_inference_gateway: SyncModelEndpointInferenceGateway,
         model_endpoints_schema_gateway: ModelEndpointsSchemaGateway,
+        inference_autoscaling_metrics_gateway: InferenceAutoscalingMetricsGateway,
     ):
         self.model_endpoint_record_repository = model_endpoint_record_repository
         self.model_endpoint_infra_gateway = model_endpoint_infra_gateway
@@ -59,6 +63,7 @@ class LiveModelEndpointService(ModelEndpointService):
         self.streaming_model_endpoint_inference_gateway = streaming_model_endpoint_inference_gateway
         self.sync_model_endpoint_inference_gateway = sync_model_endpoint_inference_gateway
         self.model_endpoints_schema_gateway = model_endpoints_schema_gateway
+        self.inference_autoscaling_metrics_gateway = inference_autoscaling_metrics_gateway
 
     def get_async_model_endpoint_inference_gateway(
         self,
@@ -74,6 +79,11 @@ class LiveModelEndpointService(ModelEndpointService):
         self,
     ) -> StreamingModelEndpointInferenceGateway:
         return self.streaming_model_endpoint_inference_gateway
+
+    def get_inference_auto_scaling_metrics_gateway(
+        self,
+    ) -> InferenceAutoscalingMetricsGateway:
+        return self.inference_autoscaling_metrics_gateway
 
     async def _get_model_endpoint_infra_state(
         self, record: ModelEndpointRecord, use_cache: bool

--- a/model-engine/tests/unit/infra/gateways/test_live_streaming_model_endpoint_inference_gateway.py
+++ b/model-engine/tests/unit/infra/gateways/test_live_streaming_model_endpoint_inference_gateway.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from model_engine_server.common.dtos.tasks import (
-    EndpointPredictV1Request,
+    SyncEndpointPredictV1Request,
     SyncEndpointPredictV1Response,
 )
 from model_engine_server.domain.exceptions import UpstreamServiceError
@@ -104,7 +104,7 @@ async def test_make_request_with_retries_failed_traceback():
 
 @pytest.mark.asyncio
 async def test_streaming_predict_success(
-    endpoint_predict_request_1: Tuple[EndpointPredictV1Request, Dict[str, Any]]
+    sync_endpoint_predict_request_1: Tuple[SyncEndpointPredictV1Request, Dict[str, Any]]
 ):
     gateway = LiveStreamingModelEndpointInferenceGateway(use_asyncio=True)
 
@@ -115,7 +115,7 @@ async def test_streaming_predict_success(
         mock_client_session,
     ):
         response = gateway.streaming_predict(
-            topic="test_topic", predict_request=endpoint_predict_request_1[0]
+            topic="test_topic", predict_request=sync_endpoint_predict_request_1[0]
         )
         count = 0
         async for message in response:
@@ -131,7 +131,7 @@ async def test_streaming_predict_success(
 
 @pytest.mark.asyncio
 async def test_predict_raises_traceback_json(
-    endpoint_predict_request_1: Tuple[EndpointPredictV1Request, Dict[str, Any]]
+    sync_endpoint_predict_request_1: Tuple[SyncEndpointPredictV1Request, Dict[str, Any]]
 ):
     gateway = LiveStreamingModelEndpointInferenceGateway(use_asyncio=True)
 
@@ -143,7 +143,7 @@ async def test_predict_raises_traceback_json(
         mock_client_session,
     ):
         response = gateway.streaming_predict(
-            topic="test_topic", predict_request=endpoint_predict_request_1[0]
+            topic="test_topic", predict_request=sync_endpoint_predict_request_1[0]
         )
         count = 0
         async for message in response:
@@ -159,7 +159,7 @@ async def test_predict_raises_traceback_json(
 
 @pytest.mark.asyncio
 async def test_predict_raises_traceback_not_json(
-    endpoint_predict_request_1: Tuple[EndpointPredictV1Request, Dict[str, Any]]
+    sync_endpoint_predict_request_1: Tuple[SyncEndpointPredictV1Request, Dict[str, Any]]
 ):
     gateway = LiveStreamingModelEndpointInferenceGateway(use_asyncio=True)
 
@@ -171,7 +171,7 @@ async def test_predict_raises_traceback_not_json(
         mock_client_session,
     ):
         response = gateway.streaming_predict(
-            topic="test_topic", predict_request=endpoint_predict_request_1[0]
+            topic="test_topic", predict_request=sync_endpoint_predict_request_1[0]
         )
         count = 0
         async for message in response:

--- a/model-engine/tests/unit/infra/gateways/test_live_sync_model_endpoint_inference_gateway.py
+++ b/model-engine/tests/unit/infra/gateways/test_live_sync_model_endpoint_inference_gateway.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from model_engine_server.common.dtos.tasks import (
-    EndpointPredictV1Request,
+    SyncEndpointPredictV1Request,
     SyncEndpointPredictV1Response,
 )
 from model_engine_server.domain.exceptions import UpstreamServiceError
@@ -82,7 +82,7 @@ async def test_make_request_with_retries_failed_traceback():
 
 @pytest.mark.asyncio
 async def test_predict_success(
-    endpoint_predict_request_1: Tuple[EndpointPredictV1Request, Dict[str, Any]]
+    sync_endpoint_predict_request_1: Tuple[SyncEndpointPredictV1Request, Dict[str, Any]]
 ):
     gateway = LiveSyncModelEndpointInferenceGateway(use_asyncio=True)
 
@@ -93,7 +93,7 @@ async def test_predict_success(
         mock_client_session,
     ):
         response = await gateway.predict(
-            topic="test_topic", predict_request=endpoint_predict_request_1[0]
+            topic="test_topic", predict_request=sync_endpoint_predict_request_1[0]
         )
         assert isinstance(response, SyncEndpointPredictV1Response)
         assert response.dict() == {
@@ -105,7 +105,7 @@ async def test_predict_success(
 
 @pytest.mark.asyncio
 async def test_predict_raises_traceback_json(
-    endpoint_predict_request_1: Tuple[EndpointPredictV1Request, Dict[str, Any]]
+    sync_endpoint_predict_request_1: Tuple[SyncEndpointPredictV1Request, Dict[str, Any]]
 ):
     gateway = LiveSyncModelEndpointInferenceGateway(use_asyncio=True)
 
@@ -117,7 +117,7 @@ async def test_predict_raises_traceback_json(
         mock_client_session,
     ):
         response = await gateway.predict(
-            topic="test_topic", predict_request=endpoint_predict_request_1[0]
+            topic="test_topic", predict_request=sync_endpoint_predict_request_1[0]
         )
         assert isinstance(response, SyncEndpointPredictV1Response)
         assert response.dict() == {
@@ -129,7 +129,7 @@ async def test_predict_raises_traceback_json(
 
 @pytest.mark.asyncio
 async def test_predict_raises_traceback_not_json(
-    endpoint_predict_request_1: Tuple[EndpointPredictV1Request, Dict[str, Any]]
+    sync_endpoint_predict_request_1: Tuple[SyncEndpointPredictV1Request, Dict[str, Any]]
 ):
     gateway = LiveSyncModelEndpointInferenceGateway(use_asyncio=True)
 
@@ -141,7 +141,7 @@ async def test_predict_raises_traceback_not_json(
         mock_client_session,
     ):
         response = await gateway.predict(
-            topic="test_topic", predict_request=endpoint_predict_request_1[0]
+            topic="test_topic", predict_request=sync_endpoint_predict_request_1[0]
         )
         assert isinstance(response, SyncEndpointPredictV1Response)
         assert response.dict() == {

--- a/model-engine/tests/unit/infra/services/conftest.py
+++ b/model-engine/tests/unit/infra/services/conftest.py
@@ -16,6 +16,7 @@ def fake_live_model_endpoint_service(
     fake_async_model_endpoint_inference_gateway,
     fake_streaming_model_endpoint_inference_gateway,
     fake_sync_model_endpoint_inference_gateway,
+    fake_inference_autoscaling_metrics_gateway,
     fake_filesystem_gateway,
     model_bundle_1: ModelBundle,
     model_bundle_2: ModelBundle,
@@ -37,6 +38,7 @@ def fake_live_model_endpoint_service(
         async_model_endpoint_inference_gateway=fake_async_model_endpoint_inference_gateway,
         streaming_model_endpoint_inference_gateway=fake_streaming_model_endpoint_inference_gateway,
         sync_model_endpoint_inference_gateway=fake_sync_model_endpoint_inference_gateway,
+        inference_autoscaling_metrics_gateway=fake_inference_autoscaling_metrics_gateway,
         model_endpoints_schema_gateway=model_endpoints_schema_gateway,
     )
     return service


### PR DESCRIPTION
Emit autoscaling metrics from gateway
Have sync endpoints poll + wait if it gets upstream not found
Next pr: make endpoints created with the keda object if we're scaling from zero
Also change how we're doing retries for sync endpoints in general, and add some optional fields to have some user control over retry behavior.

Note: this scales pods from 0 to 1, not 1 to N. Autoscaling works by looking at the length of a redis list, and the implementation intentionally keeps the list at length 1. We also set a timeout for the redis list at 1 minute.