### PR TITLE
Higher concurrency limit for gunicorn

### DIFF
--- a/model-engine/model_engine_server/api/worker.py
+++ b/model-engine/model_engine_server/api/worker.py
@@ -1,8 +1,6 @@
 from uvicorn.workers import UvicornWorker
 
-# The target concurrency is around 50, so we set the limit to 32 with 4 workers
-# for a total concurrency of 128 to allow for some headroom.
-CONCURRENCY_LIMIT = 32
+CONCURRENCY_LIMIT = 1000
 
 
 class LaunchWorker(UvicornWorker):


### PR DESCRIPTION
Gunicorn returns 503 instead of 429 when concurrency exceeds the limit, before adding rate limiting just increase the concurrency and see if that's good enough