### PR TITLE
add vllm to inference framework enum

### DIFF
--- a/clients/python/llmengine/data_types.py
+++ b/clients/python/llmengine/data_types.py
@@ -14,6 +14,7 @@ StorageSpecificationType = Union[str, int, float]  # TODO(phil): we can make thi
 class LLMInferenceFramework(str, Enum):
     DEEPSPEED = "deepspeed"
     TEXT_GENERATION_INFERENCE = "text_generation_inference"
+    VLLM = "vllm"
 
 
 class LLMSource(str, Enum):


### PR DESCRIPTION
previously, due to this not being implemented on the client side we had a bug where `vllm` based endpoints would raise errors during `Model.get()` and `Model.list()`, eg: 

<img width="1142" alt="Screenshot 2023-09-18 at 10 21 21 AM" src="https://github.com/scaleapi/llm-engine/assets/139901935/ee002fa0-4fca-43f9-b96d-b7969a2c1e07">

after this change we have: 
```
GetLLMEndpointResponse(..., status=<ModelEndpointStatus.READY: 'READY'>, inference_framework=<LLMInferenceFramework.VLLM: 'vllm'>...
```