### PR TITLE
bump the llm engine pypi version

### DIFF
--- a/clients/python/llmengine/__init__.py
+++ b/clients/python/llmengine/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.0.0b15"
+__version__ = "0.0.0b16"
 
 import os
 from typing import Sequence

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scale-llm-engine"
-version = "0.0.0.beta15"
+version = "0.0.0.beta16"
 description = "Scale LLM Engine Python client"
 license = "Apache-2.0"
 authors = ["Phil Chen <phil.chen@scale.com>"]

--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -3,6 +3,6 @@ from setuptools import find_packages, setup
 setup(
     name="scale-llm-engine",
     python_requires=">=3.7",
-    version="0.0.0.beta15",
+    version="0.0.0.beta16",
     packages=find_packages(),
 )


### PR DESCRIPTION
increase the version to be 0.0.0b16. I already increased it to 0.0.0b15 but there was a bug that caused issues with the version check update message, I wanted to address it prior to announcing the version bump.