### PR TITLE
Fix streaming endpoint failure handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,7 @@ repos:
     hooks:
       - id: mypy
         name: mypy-clients-python
+        files: clients/python/.*.py
         entry: mypy --config-file clients/python/mypy.ini
         language: system
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
     hooks:
       - id: mypy
         name: mypy-clients-python
-        files: clients/python/.*.py
+        files: clients/python/.*
         entry: mypy --config-file clients/python/mypy.ini
         language: system
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/clients/python/llmengine/data_types.py
+++ b/clients/python/llmengine/data_types.py
@@ -360,8 +360,6 @@ class StreamErrorContent(BaseModel):
     """Error message."""
     timestamp: str
     """Timestamp of the error."""
-    request_id: str
-    """Server generated unique ID of the corresponding request."""
 
 
 class StreamError(BaseModel):

--- a/clients/python/llmengine/data_types.py
+++ b/clients/python/llmengine/data_types.py
@@ -354,6 +354,26 @@ class CompletionStreamOutput(BaseModel):
     """Detailed token information."""
 
 
+class StreamErrorContent(BaseModel):
+    error: str
+    """Error message."""
+    timestamp: str
+    """Timestamp of the error."""
+    request_id: str
+    """Server generated unique ID of the corresponding request."""
+
+
+class StreamError(BaseModel):
+    """
+    Error object for a stream prompt completion task.
+    """
+
+    status_code: int
+    """The HTTP status code of the error."""
+    content: StreamErrorContent
+    """The error content."""
+
+
 class CompletionStreamResponse(BaseModel):
     """
     Response object for a stream prompt completion task.
@@ -370,6 +390,9 @@ class CompletionStreamResponse(BaseModel):
 
     output: Optional[CompletionStreamOutput] = None
     """Completion output."""
+
+    error: Optional[StreamError] = None
+    """Error of the response (if any)."""
 
 
 class CreateFineTuneRequest(BaseModel):

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -81,11 +81,10 @@ stream = Completion.create(
 )
 
 for response in stream:
-    try:
-        if response.output:
-            print(response.output.text, end="")
-            sys.stdout.flush()
-    except: # an error occurred
-        print(stream.text) # print the error message out 
+    if response.output:
+        print(response.output.text, end="")
+        sys.stdout.flush()
+    else: # an error occurred
+        print(response.error) # print the error message out 
         break
 ```

--- a/docs/guides/completions.md
+++ b/docs/guides/completions.md
@@ -87,12 +87,11 @@ stream = Completion.create(
 )
 
 for response in stream:
-    try:
-        if response.output:
-            print(response.output.text, end="")
-            sys.stdout.flush()
-    except: # an error occurred
-        print(stream.text) # print the error message out 
+    if response.output:
+        print(response.output.text, end="")
+        sys.stdout.flush()
+    else: # an error occurred
+        print(response.error) # print the error message out 
         break
 ```
 

--- a/model-engine/model_engine_server/api/llms_v1.py
+++ b/model-engine/model_engine_server/api/llms_v1.py
@@ -98,7 +98,6 @@ def handle_streaming_exception(
                     "content": {
                         "error": message,
                         "timestamp": timestamp,
-                        "request_id": request_id,
                     },
                 },
             }

--- a/model-engine/model_engine_server/api/llms_v1.py
+++ b/model-engine/model_engine_server/api/llms_v1.py
@@ -80,7 +80,7 @@ def handle_streaming_exception(
     code: int,
     message: str,
 ):
-    tb_str = traceback.format_exception(e)
+    tb_str = traceback.format_exception(etype=type(e), value=e, tb=e.__traceback__)
     request_id = get_request_id()
     timestamp = datetime.now(pytz.timezone("US/Pacific")).strftime("%Y-%m-%d %H:%M:%S %Z")
     structured_log = {

--- a/model-engine/model_engine_server/api/llms_v1.py
+++ b/model-engine/model_engine_server/api/llms_v1.py
@@ -1,6 +1,5 @@
 """LLM Model Endpoint routes for the hosted model inference service.
 """
-import json
 import traceback
 from datetime import datetime
 from typing import Optional
@@ -32,6 +31,8 @@ from model_engine_server.common.dtos.llms import (
     ListLLMModelEndpointsV1Response,
     ModelDownloadRequest,
     ModelDownloadResponse,
+    StreamError,
+    StreamErrorContent,
 )
 from model_engine_server.common.dtos.model_endpoints import ModelEndpointOrderBy
 from model_engine_server.core.auth.authentication_repository import User
@@ -90,18 +91,16 @@ def handle_streaming_exception(
     }
     logger.error("Exception: %s", structured_log)
     return {
-        "data": json.dumps(
-            {
-                "request_id": str(request_id),
-                "error": {
-                    "status_code": code,
-                    "content": {
-                        "error": message,
-                        "timestamp": timestamp,
-                    },
-                },
-            }
-        )
+        "data": CompletionStreamV1Response(
+            request_id=str(request_id),
+            error=StreamError(
+                status_code=code,
+                content=StreamErrorContent(
+                    error=message,
+                    timestamp=timestamp,
+                ),
+            ),
+        ).json()
     }
 
 

--- a/model-engine/model_engine_server/api/llms_v1.py
+++ b/model-engine/model_engine_server/api/llms_v1.py
@@ -243,7 +243,6 @@ async def create_completion_stream_task(
             logger.exception(f"Upstream service error for request {request_id}")
             yield {"data": {"error": {"status_code": 500, "detail": str(exc)}}}
         except (ObjectNotFoundException, ObjectNotAuthorizedException) as exc:
-            print(str(exc))
             yield {"data": {"error": {"status_code": 404, "detail": str(exc)}}}
         except ObjectHasInvalidValueException as exc:
             yield {"data": {"error": {"status_code": 400, "detail": str(exc)}}}

--- a/model-engine/model_engine_server/api/llms_v1.py
+++ b/model-engine/model_engine_server/api/llms_v1.py
@@ -238,10 +238,6 @@ async def create_completion_stream_task(
                 yield {"data": message.json()}
         except InvalidRequestException as exc:
             yield {"data": {"error": {"status_code": 400, "detail": str(exc)}}}
-        except UpstreamServiceError as exc:
-            request_id = get_request_id()
-            logger.exception(f"Upstream service error for request {request_id}")
-            yield {"data": {"error": {"status_code": 500, "detail": str(exc)}}}
         except (ObjectNotFoundException, ObjectNotAuthorizedException) as exc:
             yield {"data": {"error": {"status_code": 404, "detail": str(exc)}}}
         except ObjectHasInvalidValueException as exc:
@@ -255,6 +251,10 @@ async def create_completion_stream_task(
                     }
                 }
             }
+        except Exception as exc:
+            request_id = get_request_id()
+            logger.exception(f"Internal exception for request {request_id}")
+            yield {"data": {"error": {"status_code": 500, "detail": str(exc)}}}
 
     return EventSourceResponse(event_generator())
 

--- a/model-engine/model_engine_server/common/dtos/llms.py
+++ b/model-engine/model_engine_server/common/dtos/llms.py
@@ -202,6 +202,24 @@ class CompletionStreamOutput(BaseModel):
     token: Optional[TokenOutput] = None
 
 
+class StreamErrorContent(BaseModel):
+    error: str
+    """Error message."""
+    timestamp: str
+    """Timestamp of the error."""
+
+
+class StreamError(BaseModel):
+    """
+    Error object for a stream prompt completion task.
+    """
+
+    status_code: int
+    """The HTTP status code of the error."""
+    content: StreamErrorContent
+    """The error content."""
+
+
 class CompletionStreamV1Response(BaseModel):
     """
     Response object for a stream prompt completion task.
@@ -209,6 +227,8 @@ class CompletionStreamV1Response(BaseModel):
 
     request_id: str
     output: Optional[CompletionStreamOutput] = None
+    error: Optional[StreamError] = None
+    """Error of the response (if any)."""
 
 
 class CreateFineTuneRequest(BaseModel):

--- a/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
+++ b/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
@@ -1296,7 +1296,7 @@ class CompletionStreamV1UseCase:
         )
 
         if len(model_endpoints) == 0:
-            raise ObjectNotFoundException
+            raise ObjectNotFoundException(f"Model endpoint {model_endpoint_name} not found.")
 
         if len(model_endpoints) > 1:
             raise ObjectHasInvalidValueException(

--- a/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
+++ b/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
@@ -102,6 +102,9 @@ _SUPPORTED_MODEL_NAMES = {
         "falcon-7b-instruct": "tiiuae/falcon-7b-instruct",
         "falcon-40b": "tiiuae/falcon-40b",
         "falcon-40b-instruct": "tiiuae/falcon-40b-instruct",
+        "code-llama-7b": "codellama/CodeLlama-7b-hf",
+        "code-llama-13b": "codellama/CodeLlama-13b-hf",
+        "code-llama-34b": "codellama/CodeLlama-34b-hf",
     },
     LLMInferenceFramework.VLLM: {
         "mpt-7b": "mosaicml/mpt-7b",

--- a/model-engine/tests/unit/api/test_llms.py
+++ b/model-engine/tests/unit/api/test_llms.py
@@ -202,5 +202,4 @@ def test_completion_stream_endpoint_not_found_returns_404(
     assert response_1.status_code == 200
 
     for message in response_1:
-        print(message)
         assert "404" in message.decode("utf-8")

--- a/model-engine/tests/unit/api/test_llms.py
+++ b/model-engine/tests/unit/api/test_llms.py
@@ -113,6 +113,32 @@ def test_completion_sync_success(
     assert response_1.json().keys() == {"output", "request_id"}
 
 
+def test_completion_sync_endpoint_not_found_returns_404(
+    llm_model_endpoint_sync: Tuple[ModelEndpoint, Any],
+    completion_sync_request: Dict[str, Any],
+    get_test_client_wrapper,
+):
+    client = get_test_client_wrapper(
+        fake_docker_repository_image_always_exists=True,
+        fake_model_bundle_repository_contents={},
+        fake_model_endpoint_record_repository_contents={},
+        fake_model_endpoint_infra_gateway_contents={
+            llm_model_endpoint_sync[0]
+            .infra_state.deployment_name: llm_model_endpoint_sync[0]
+            .infra_state,
+        },
+        fake_batch_job_record_repository_contents={},
+        fake_batch_job_progress_gateway_contents={},
+        fake_docker_image_batch_job_bundle_repository_contents={},
+    )
+    response_1 = client.post(
+        f"/v1/llm/completions-sync?model_endpoint_name={llm_model_endpoint_sync[0].record.name}",
+        auth=("no_user", ""),
+        json=completion_sync_request,
+    )
+    assert response_1.status_code == 404
+
+
 @pytest.mark.skip(reason="Need to figure out FastAPI test client asyncio funkiness")
 def test_completion_stream_success(
     llm_model_endpoint_streaming: ModelEndpoint,
@@ -136,6 +162,7 @@ def test_completion_stream_success(
         f"/v1/llm/completions-stream?model_endpoint_name={llm_model_endpoint_streaming.record.name}",
         auth=("no_user", ""),
         json=completion_stream_request,
+        stream=True,
     )
     assert response_1.status_code == 200
     count = 0
@@ -146,3 +173,34 @@ def test_completion_stream_success(
         )
         count += 1
     assert count == 1
+
+
+@pytest.mark.skip(reason="Need to figure out FastAPI test client asyncio funkiness")
+def test_completion_stream_endpoint_not_found_returns_404(
+    llm_model_endpoint_streaming: ModelEndpoint,
+    completion_stream_request: Dict[str, Any],
+    get_test_client_wrapper,
+):
+    client = get_test_client_wrapper(
+        fake_docker_repository_image_always_exists=True,
+        fake_model_bundle_repository_contents={},
+        fake_model_endpoint_record_repository_contents={},
+        fake_model_endpoint_infra_gateway_contents={
+            llm_model_endpoint_streaming.infra_state.deployment_name: llm_model_endpoint_streaming.infra_state,
+        },
+        fake_batch_job_record_repository_contents={},
+        fake_batch_job_progress_gateway_contents={},
+        fake_docker_image_batch_job_bundle_repository_contents={},
+    )
+    response_1 = client.post(
+        f"/v1/llm/completions-stream?model_endpoint_name={llm_model_endpoint_streaming.record.name}",
+        auth=("no_user", ""),
+        json=completion_stream_request,
+        stream=True,
+    )
+
+    assert response_1.status_code == 200
+
+    for message in response_1:
+        print(message)
+        assert "404" in message.decode("utf-8")

--- a/model-engine/tests/unit/api/test_tasks.py
+++ b/model-engine/tests/unit/api/test_tasks.py
@@ -364,6 +364,7 @@ def test_create_streaming_task_success(
         f"/v1/streaming-tasks?model_endpoint_id={model_endpoint_streaming.record.id}",
         auth=(test_api_key, ""),
         json=endpoint_predict_request_1[1],
+        stream=True,
     )
     assert response.status_code == 200
     count = 0


### PR DESCRIPTION
- Fix streaming endpoint failure handling

before the fix, getting error:
```
urllib3.exceptions.ProtocolError: ("Connection broken: InvalidChunkLength(got length b'', 0 bytes read)", InvalidChunkLength(got length b'', 0 bytes read))
```

after the fix, getting response:
```
b"data: {'error': {'status_code': 404, 'detail': 'Model endpoint a not found.'}}\r\n\r\n"
```