### PR TITLE
Properly return PENDING status for docker image batch jobs/fine tune jobs

### DIFF
--- a/model-engine/model_engine_server/infra/gateways/live_cron_job_gateway.py
+++ b/model-engine/model_engine_server/infra/gateways/live_cron_job_gateway.py
@@ -111,7 +111,7 @@ class LiveCronJobGateway(CronJobGateway):
             logger.exception("Got an exception when trying to list the Pods")
             raise EndpointResourceInfraException from exc
 
-        pods_per_job = make_job_id_to_pods_mapping(pods)
+        pods_per_job = make_job_id_to_pods_mapping(pods.items)
 
         return [
             DockerImageBatchJob(

--- a/model-engine/model_engine_server/infra/gateways/live_cron_job_gateway.py
+++ b/model-engine/model_engine_server/infra/gateways/live_cron_job_gateway.py
@@ -102,7 +102,9 @@ class LiveCronJobGateway(CronJobGateway):
         core_client = get_kubernetes_core_client()
 
         try:
-            label_selector = f"trigger_id={trigger_id}" if trigger_id else f"owner={owner}"
+            label_selector = (
+                f"trigger_id={trigger_id}" if trigger_id else f"owner={owner}"
+            )  # TODO filter out endpoint pods
             pods = await core_client.list_namespaced_pod(
                 namespace=hmi_config.endpoint_namespace,
                 label_selector=label_selector,

--- a/model-engine/model_engine_server/infra/gateways/live_cron_job_gateway.py
+++ b/model-engine/model_engine_server/infra/gateways/live_cron_job_gateway.py
@@ -102,9 +102,7 @@ class LiveCronJobGateway(CronJobGateway):
         core_client = get_kubernetes_core_client()
 
         try:
-            label_selector = (
-                f"trigger_id={trigger_id}" if trigger_id else f"owner={owner},job-name"
-            )  # TODO filter out endpoint pods
+            label_selector = f"trigger_id={trigger_id}" if trigger_id else f"owner={owner},job-name"
             pods = await core_client.list_namespaced_pod(
                 namespace=hmi_config.endpoint_namespace,
                 label_selector=label_selector,

--- a/model-engine/model_engine_server/infra/gateways/live_cron_job_gateway.py
+++ b/model-engine/model_engine_server/infra/gateways/live_cron_job_gateway.py
@@ -103,7 +103,7 @@ class LiveCronJobGateway(CronJobGateway):
 
         try:
             label_selector = (
-                f"trigger_id={trigger_id}" if trigger_id else f"owner={owner}"
+                f"trigger_id={trigger_id}" if trigger_id else f"owner={owner},job-name"
             )  # TODO filter out endpoint pods
             pods = await core_client.list_namespaced_pod(
                 namespace=hmi_config.endpoint_namespace,

--- a/model-engine/model_engine_server/infra/gateways/live_docker_image_batch_job_gateway.py
+++ b/model-engine/model_engine_server/infra/gateways/live_docker_image_batch_job_gateway.py
@@ -343,7 +343,7 @@ class LiveDockerImageBatchJobGateway(DockerImageBatchJobGateway):
         try:
             pods = await core_client.list_namespaced_pod(
                 namespace=hmi_config.endpoint_namespace,
-                label_selector=f"{OWNER_LABEL_SELECTOR}={owner}",
+                label_selector=f"{OWNER_LABEL_SELECTOR}={owner}",  # TODO filter out endpoint pods oops
             )
         except ApiException as exc:
             logger.exception("Got an exception when trying to read pods for the Job")

--- a/model-engine/model_engine_server/infra/gateways/live_docker_image_batch_job_gateway.py
+++ b/model-engine/model_engine_server/infra/gateways/live_docker_image_batch_job_gateway.py
@@ -310,7 +310,8 @@ class LiveDockerImageBatchJobGateway(DockerImageBatchJobGateway):
             )
         except ApiException as exc:
             logger.exception("Got an exception when trying to read pods for the Job")
-            raise EndpointResourceInfraException from exc  # TODO is this going to cause problems?
+            raise EndpointResourceInfraException from exc
+            # This pod list isn't always needed, but it's simpler code-wise to always make the request
 
         job_labels = job.metadata.labels
         annotations = job.metadata.annotations

--- a/model-engine/model_engine_server/infra/gateways/live_docker_image_batch_job_gateway.py
+++ b/model-engine/model_engine_server/infra/gateways/live_docker_image_batch_job_gateway.py
@@ -98,6 +98,9 @@ def _parse_job_status_from_k8s_obj(job: V1Job, pods: List[V1Pod]) -> BatchJobSta
         return BatchJobStatus.RUNNING  # empirically this doesn't happen
     if status.active is not None and status.active > 0:
         for pod in pods:
+            # In case there are multiple pods for a given job (e.g. if a pod gets shut down)
+            # let's interpret the job as running if any of the pods are running
+            # I haven't empirically seen this, but guard against it just in case.
             if pod.status.phase == "Running":
                 return BatchJobStatus.RUNNING
         return BatchJobStatus.PENDING

--- a/model-engine/model_engine_server/infra/gateways/live_docker_image_batch_job_gateway.py
+++ b/model-engine/model_engine_server/infra/gateways/live_docker_image_batch_job_gateway.py
@@ -343,7 +343,7 @@ class LiveDockerImageBatchJobGateway(DockerImageBatchJobGateway):
         try:
             pods = await core_client.list_namespaced_pod(
                 namespace=hmi_config.endpoint_namespace,
-                label_selector=f"{OWNER_LABEL_SELECTOR}={owner}",  # TODO filter out endpoint pods oops
+                label_selector=f"{OWNER_LABEL_SELECTOR}={owner},job-name",  # get only pods associated with a job
             )
         except ApiException as exc:
             logger.exception("Got an exception when trying to read pods for the Job")

--- a/model-engine/model_engine_server/infra/gateways/live_docker_image_batch_job_gateway.py
+++ b/model-engine/model_engine_server/infra/gateways/live_docker_image_batch_job_gateway.py
@@ -1,9 +1,11 @@
 import os
 import re
+from collections import defaultdict
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, TypedDict, Union
 
 from kubernetes_asyncio.client.models.v1_job import V1Job
+from kubernetes_asyncio.client.models.v1_pod import V1Pod
 from kubernetes_asyncio.client.rest import ApiException
 from model_engine_server.common.config import hmi_config
 from model_engine_server.common.dtos.batch_jobs import CreateDockerImageBatchJobResourceRequests
@@ -17,6 +19,7 @@ from model_engine_server.domain.gateways.docker_image_batch_job_gateway import (
 )
 from model_engine_server.infra.gateways.resources.k8s_endpoint_resource_delegate import (
     get_kubernetes_batch_client,
+    get_kubernetes_core_client,
     load_k8s_yaml,
     maybe_load_kube_config,
 )
@@ -84,7 +87,7 @@ def _k8s_job_name_from_id(job_id: str):
     return f"launch-di-batch-job-{job_id}"
 
 
-def _parse_job_status_from_k8s_obj(job: V1Job) -> BatchJobStatus:
+def _parse_job_status_from_k8s_obj(job: V1Job, pods: List[V1Pod]) -> BatchJobStatus:
     status = job.status
     # these counts are the number of pods in some given status
     if status.failed is not None and status.failed > 0:
@@ -94,7 +97,10 @@ def _parse_job_status_from_k8s_obj(job: V1Job) -> BatchJobStatus:
     if status.ready is not None and status.ready > 0:
         return BatchJobStatus.RUNNING  # empirically this doesn't happen
     if status.active is not None and status.active > 0:
-        return BatchJobStatus.RUNNING  # TODO this might be a mix of pending and running
+        for pod in pods:
+            if pod.status.phase == "Running":
+                return BatchJobStatus.RUNNING
+        return BatchJobStatus.PENDING
     return BatchJobStatus.PENDING
 
 
@@ -282,10 +288,20 @@ class LiveDockerImageBatchJobGateway(DockerImageBatchJobGateway):
             logger.exception("Got an exception when trying to read the Job")
             raise EndpointResourceInfraException from exc
 
+        core_client = get_kubernetes_core_client()
+        try:
+            pods = await core_client.list_namespaced_pod(
+                namespace=hmi_config.endpoint_namespace,
+                label_selector=f"{LAUNCH_JOB_ID_LABEL_SELECTOR}={batch_job_id}",
+            )
+        except ApiException as exc:
+            logger.exception("Got an exception when trying to read pods for the Job")
+            raise EndpointResourceInfraException from exc  # TODO is this going to cause problems?
+
         job_labels = job.metadata.labels
         annotations = job.metadata.annotations
 
-        status = _parse_job_status_from_k8s_obj(job)
+        status = _parse_job_status_from_k8s_obj(job, pods.items)
 
         return DockerImageBatchJob(
             id=batch_job_id,
@@ -309,6 +325,21 @@ class LiveDockerImageBatchJobGateway(DockerImageBatchJobGateway):
             logger.exception("Got an exception when trying to list the Jobs")
             raise EndpointResourceInfraException from exc
 
+        core_client = get_kubernetes_core_client()
+        try:
+            pods = await core_client.list_namespaced_pod(
+                namespace=hmi_config.endpoint_namespace,
+                label_selector=f"{OWNER_LABEL_SELECTOR}={owner}",
+            )
+        except ApiException as exc:
+            logger.exception("Got an exception when trying to read pods for the Job")
+            raise EndpointResourceInfraException from exc
+
+        # Join jobs + pods
+        pods_per_job = defaultdict(list)
+        for pod in pods.items:
+            pods_per_job[pod.metadata.labels.get(LAUNCH_JOB_ID_LABEL_SELECTOR)].append(pod)
+
         return [
             DockerImageBatchJob(
                 id=job.metadata.labels.get(LAUNCH_JOB_ID_LABEL_SELECTOR),
@@ -317,7 +348,9 @@ class LiveDockerImageBatchJobGateway(DockerImageBatchJobGateway):
                 created_at=job.metadata.creation_timestamp,
                 completed_at=job.status.completion_time,
                 annotations=job.metadata.annotations,
-                status=_parse_job_status_from_k8s_obj(job),
+                status=_parse_job_status_from_k8s_obj(
+                    job, pods_per_job[job.metadata.labels.get(LAUNCH_JOB_ID_LABEL_SELECTOR)]
+                ),
             )
             for job in jobs.items
         ]

--- a/model-engine/tests/unit/infra/gateways/k8s_fake_objects.py
+++ b/model-engine/tests/unit/infra/gateways/k8s_fake_objects.py
@@ -1,0 +1,68 @@
+# Various fake k8s objects to be used in mocking out the python k8s api client
+# Only classes are defined here. If you need to add various fields to the classes, please do so here.
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List, Optional
+
+
+@dataclass
+class FakeK8sV1ObjectMeta:
+    name: str = "fake_name"
+    namespace: str = "fake_namespace"
+    annotations: dict = field(default_factory=dict)
+    labels: dict = field(default_factory=dict)
+    creation_timestamp: datetime = datetime(2021, 1, 1, 0, 0, 0, 0)
+    # completion_time: datetime = datetime(2021, 1, 1, 1, 0, 0, 0)
+    # TODO: everything else
+
+
+@dataclass
+class FakeK8sV1PodStatus:
+    phase: str = "Running"
+    # TODO: everything else
+
+
+@dataclass
+class FakeK8sV1JobStatus:
+    active: int = 0
+    succeeded: int = 0
+    failed: int = 0
+    ready: int = 0
+    terminating: int = 0
+    completion_time: Optional[datetime] = None
+
+
+@dataclass
+class FakeK8sV1Job:
+    metadata: FakeK8sV1ObjectMeta = FakeK8sV1ObjectMeta()
+    status: FakeK8sV1JobStatus = FakeK8sV1JobStatus()
+    # TODO: spec, api_version, kind
+
+
+@dataclass
+class FakeK8sV1JobList:
+    items: List[FakeK8sV1Job] = field(default_factory=list)
+
+
+@dataclass
+class FakeK8sV1Pod:
+    metadata: FakeK8sV1ObjectMeta = FakeK8sV1ObjectMeta()
+    status: FakeK8sV1PodStatus = FakeK8sV1PodStatus()
+    # TODO: spec, api_version, kind
+
+
+@dataclass
+class FakeK8sV1PodList:
+    items: List[FakeK8sV1Pod] = field(default_factory=list)
+
+
+@dataclass
+class FakeK8sEnvVar:
+    name: str
+    value: str
+
+
+@dataclass
+class FakeK8sDeploymentContainer:
+    env: List[FakeK8sEnvVar]

--- a/model-engine/tests/unit/infra/gateways/k8s_fake_objects.py
+++ b/model-engine/tests/unit/infra/gateways/k8s_fake_objects.py
@@ -13,7 +13,6 @@ class FakeK8sV1ObjectMeta:
     annotations: dict = field(default_factory=dict)
     labels: dict = field(default_factory=dict)
     creation_timestamp: datetime = datetime(2021, 1, 1, 0, 0, 0, 0)
-    # completion_time: datetime = datetime(2021, 1, 1, 1, 0, 0, 0)
     # TODO: everything else
 
 

--- a/model-engine/tests/unit/infra/gateways/resources/test_k8s_endpoint_resource_delegate.py
+++ b/model-engine/tests/unit/infra/gateways/resources/test_k8s_endpoint_resource_delegate.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from typing import Any, Dict, List
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -25,19 +24,9 @@ from model_engine_server.infra.gateways.resources.k8s_resource_types import (
     DictStrStr,
     ResourceArguments,
 )
+from tests.unit.infra.gateways.k8s_fake_objects import FakeK8sDeploymentContainer, FakeK8sEnvVar
 
 MODULE_PATH = "model_engine_server.infra.gateways.resources.k8s_endpoint_resource_delegate"
-
-
-@dataclass
-class FakeK8sEnvVar:
-    name: str
-    value: str
-
-
-@dataclass
-class FakeK8sDeploymentContainer:
-    env: List[FakeK8sEnvVar]
 
 
 @pytest.fixture

--- a/model-engine/tests/unit/infra/gateways/test_live_docker_image_batch_job_gateway.py
+++ b/model-engine/tests/unit/infra/gateways/test_live_docker_image_batch_job_gateway.py
@@ -1,11 +1,123 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from model_engine_server.domain.entities import BatchJobStatus
 from model_engine_server.infra.gateways.live_docker_image_batch_job_gateway import (
     K8sEnvDict,
+    LiveDockerImageBatchJobGateway,
     _add_list_values,
     _check_batch_job_id_valid,
     _get_job_id,
 )
+from tests.unit.infra.gateways.k8s_fake_objects import (
+    FakeK8sV1Job,
+    FakeK8sV1JobList,
+    FakeK8sV1JobStatus,
+    FakeK8sV1ObjectMeta,
+    FakeK8sV1Pod,
+    FakeK8sV1PodList,
+    FakeK8sV1PodStatus,
+)
+
+MODULE_PATH = "model_engine_server.infra.gateways.live_docker_image_batch_job_gateway"
 
 
+@pytest.fixture
+def mock_core_client():
+    mock_client = AsyncMock()
+    with patch(
+        f"{MODULE_PATH}.get_kubernetes_core_client",
+        return_value=mock_client,
+    ):
+        yield mock_client
+
+
+@pytest.fixture
+def mock_batch_client():
+    mock_client = AsyncMock()
+    with patch(
+        f"{MODULE_PATH}.get_kubernetes_batch_client",
+        return_value=mock_client,
+    ):
+        yield mock_client
+
+
+@pytest.fixture
+def docker_image_batch_job_gateway():
+    gateway = LiveDockerImageBatchJobGateway()
+    return gateway
+
+
+@pytest.mark.parametrize(
+    "active, succeeded, failed, pod_phase, pod_exists, expected_status",
+    [
+        [1, 0, 0, "Running", True, BatchJobStatus.RUNNING],
+        [0, 1, 0, "Succeeded", True, BatchJobStatus.SUCCESS],
+        [0, 0, 1, "Failed", True, BatchJobStatus.FAILURE],
+        [1, 0, 0, "Pending", True, BatchJobStatus.PENDING],
+        [0, 0, 0, "Pending", False, BatchJobStatus.PENDING],
+    ],
+)
+@pytest.mark.asyncio
+async def test_get_docker_image_batch_job_phase(
+    active,
+    succeeded,
+    failed,
+    pod_phase,
+    pod_exists,
+    expected_status,
+    docker_image_batch_job_gateway,
+    mock_core_client,
+    mock_batch_client,
+):
+    if pod_exists:
+        pod_items = [
+            FakeK8sV1Pod(
+                metadata=FakeK8sV1ObjectMeta(
+                    labels={
+                        "job-name": "job-name",
+                        "owner": "owner",
+                        "created_by": "created_by",
+                        "trigger_id": "trigger_id",
+                        "launch_job_id": "launch_job_id",
+                    }
+                ),
+                status=FakeK8sV1PodStatus(
+                    phase=pod_phase,
+                ),
+            )
+        ]
+    else:
+        pod_items = []
+
+    mock_core_client.list_namespaced_pod.return_value = FakeK8sV1PodList(items=pod_items)
+    mock_batch_client.list_namespaced_job.return_value = FakeK8sV1JobList(
+        items=[
+            FakeK8sV1Job(
+                metadata=FakeK8sV1ObjectMeta(
+                    name="job-name",
+                    labels={
+                        "owner": "owner",
+                        "created_by": "created_by",
+                        "trigger_id": "trigger_id",
+                        "launch_job_id": "launch_job_id",
+                    },
+                ),
+                status=FakeK8sV1JobStatus(
+                    active=active,
+                    succeeded=succeeded,
+                    failed=failed,
+                ),
+            )
+        ]
+    )
+
+    job = await docker_image_batch_job_gateway.get_docker_image_batch_job("launch_job_id")
+    assert job is not None
+    assert job.status == expected_status
+
+
+# Small function functionality tests
 def test_valid_job_ids_are_valid():
     for _ in range(20):
         # _get_job_id() is nondeterministic


### PR DESCRIPTION
Before, jobs would immediately start as RUNNING even if no pods were allocated, or if pods were PENDING.

testing:
started gateway on devbox, made requests to get/list docker image batch jobs on our clusters, saw that a RUNNING job had changed to PENDING correctly.
also unit tests