### PR TITLE
add user_id and team_id as log facets

### DIFF
--- a/model-engine/model_engine_server/api/app.py
+++ b/model-engine/model_engine_server/api/app.py
@@ -22,9 +22,10 @@ from model_engine_server.api.model_endpoints_v1 import model_endpoint_router_v1
 from model_engine_server.api.tasks_v1 import inference_task_router_v1
 from model_engine_server.api.triggers_v1 import trigger_router_v1
 from model_engine_server.core.loggers import (
+    LoggerTagKey,
+    LoggerTagManager,
     filename_wo_ext,
     make_logger,
-    LoggerTagManager, LoggerTagKey
 )
 
 logger = make_logger(filename_wo_ext(__name__))

--- a/model-engine/model_engine_server/api/app.py
+++ b/model-engine/model_engine_server/api/app.py
@@ -23,9 +23,8 @@ from model_engine_server.api.tasks_v1 import inference_task_router_v1
 from model_engine_server.api.triggers_v1 import trigger_router_v1
 from model_engine_server.core.loggers import (
     filename_wo_ext,
-    get_request_id,
     make_logger,
-    set_request_id,
+    LoggerTagManager, LoggerTagKey
 )
 
 logger = make_logger(filename_wo_ext(__name__))
@@ -47,11 +46,11 @@ app.include_router(trigger_router_v1)
 @app.middleware("http")
 async def dispatch(request: Request, call_next):
     try:
-        set_request_id(str(uuid.uuid4()))
+        LoggerTagManager.set(LoggerTagKey.REQUEST_ID, str(uuid.uuid4()))
         return await call_next(request)
     except Exception as e:
         tb_str = traceback.format_exception(etype=type(e), value=e, tb=e.__traceback__)
-        request_id = get_request_id()
+        request_id = LoggerTagManager.get(LoggerTagKey.REQUEST_ID)
         timestamp = datetime.now(pytz.timezone("US/Pacific")).strftime("%Y-%m-%d %H:%M:%S %Z")
         structured_log = {
             "error": str(e),

--- a/model-engine/model_engine_server/api/dependencies.py
+++ b/model-engine/model_engine_server/api/dependencies.py
@@ -13,7 +13,12 @@ from model_engine_server.core.auth.authentication_repository import Authenticati
 from model_engine_server.core.auth.fake_authentication_repository import (
     FakeAuthenticationRepository,
 )
-from model_engine_server.core.loggers import filename_wo_ext, make_logger, LoggerTagKey, LoggerTagManager
+from model_engine_server.core.loggers import (
+    LoggerTagKey,
+    LoggerTagManager,
+    filename_wo_ext,
+    make_logger,
+)
 from model_engine_server.db.base import SessionAsync, SessionReadOnlyAsync
 from model_engine_server.domain.gateways import (
     CronJobGateway,

--- a/model-engine/model_engine_server/api/dependencies.py
+++ b/model-engine/model_engine_server/api/dependencies.py
@@ -13,7 +13,7 @@ from model_engine_server.core.auth.authentication_repository import Authenticati
 from model_engine_server.core.auth.fake_authentication_repository import (
     FakeAuthenticationRepository,
 )
-from model_engine_server.core.loggers import filename_wo_ext, make_logger
+from model_engine_server.core.loggers import filename_wo_ext, make_logger, LoggerTagKey, LoggerTagManager
 from model_engine_server.db.base import SessionAsync, SessionReadOnlyAsync
 from model_engine_server.domain.gateways import (
     CronJobGateway,
@@ -329,6 +329,10 @@ async def verify_authentication(
             detail="Could not authenticate user",
             headers={"WWW-Authenticate": "Basic"},
         )
+
+    # set logger context with identity data
+    LoggerTagManager.set(LoggerTagKey.USER_ID, auth.user_id)
+    LoggerTagManager.set(LoggerTagKey.TEAM_ID, auth.team_id)
 
     return auth
 

--- a/model-engine/model_engine_server/api/llms_v1.py
+++ b/model-engine/model_engine_server/api/llms_v1.py
@@ -36,7 +36,12 @@ from model_engine_server.common.dtos.llms import (
 )
 from model_engine_server.common.dtos.model_endpoints import ModelEndpointOrderBy
 from model_engine_server.core.auth.authentication_repository import User
-from model_engine_server.core.loggers import filename_wo_ext, make_logger, LoggerTagManager, LoggerTagKey
+from model_engine_server.core.loggers import (
+    LoggerTagKey,
+    LoggerTagManager,
+    filename_wo_ext,
+    make_logger,
+)
 from model_engine_server.domain.exceptions import (
     EndpointDeleteFailedException,
     EndpointLabelsException,

--- a/model-engine/model_engine_server/api/llms_v1.py
+++ b/model-engine/model_engine_server/api/llms_v1.py
@@ -36,7 +36,7 @@ from model_engine_server.common.dtos.llms import (
 )
 from model_engine_server.common.dtos.model_endpoints import ModelEndpointOrderBy
 from model_engine_server.core.auth.authentication_repository import User
-from model_engine_server.core.loggers import filename_wo_ext, get_request_id, make_logger
+from model_engine_server.core.loggers import filename_wo_ext, make_logger, LoggerTagManager, LoggerTagKey
 from model_engine_server.domain.exceptions import (
     EndpointDeleteFailedException,
     EndpointLabelsException,
@@ -82,7 +82,7 @@ def handle_streaming_exception(
     message: str,
 ):
     tb_str = traceback.format_exception(etype=type(e), value=e, tb=e.__traceback__)
-    request_id = get_request_id()
+    request_id = LoggerTagManager.get(LoggerTagKey.REQUEST_ID)
     timestamp = datetime.now(pytz.timezone("US/Pacific")).strftime("%Y-%m-%d %H:%M:%S %Z")
     structured_log = {
         "error": message,
@@ -223,7 +223,7 @@ async def create_completion_sync_task(
             user=auth, model_endpoint_name=model_endpoint_name, request=request
         )
     except UpstreamServiceError:
-        request_id = get_request_id()
+        request_id = LoggerTagManager.get(LoggerTagKey.REQUEST_ID)
         logger.exception(f"Upstream service error for request {request_id}")
         raise HTTPException(
             status_code=500,

--- a/model-engine/model_engine_server/core/loggers.py
+++ b/model-engine/model_engine_server/core/loggers.py
@@ -1,11 +1,12 @@
 import contextvars
+from enum import Enum, auto
 import inspect
 import logging
 import os
 import sys
 import warnings
 from contextlib import contextmanager
-from typing import Optional, Sequence
+from typing import Dict, Optional, Sequence
 
 import ddtrace
 import json_log_formatter
@@ -15,8 +16,6 @@ from ddtrace import tracer
 # DO NOT CHANGE LOGGING FORMAT
 LOG_FORMAT: str = "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] - %(message)s"
 # REQUIRED FOR DATADOG COMPATIBILITY
-
-ctx_var_request_id = contextvars.ContextVar("ctx_var_request_id", default=None)
 
 __all__: Sequence[str] = (
     # most common imports
@@ -35,19 +34,35 @@ __all__: Sequence[str] = (
     "loggers_at_level",
     # utils
     "filename_wo_ext",
-    "get_request_id",
-    "set_request_id",
+    "LoggerTagKey",
+    "LoggerTagManager",
 )
 
+class LoggerTagKey(str, Enum):
+    REQUEST_ID = 'request_id'
+    TEAM_ID = 'team_id'
+    USER_ID = 'user_id'
 
-def get_request_id() -> Optional[str]:
-    """Get the request id from the context variable."""
-    return ctx_var_request_id.get()
+class LoggerTagManager:
+    _context_vars: Dict[LoggerTagKey, contextvars.ContextVar] = {}
+    
+    @classmethod
+    def get(cls, key: LoggerTagKey) -> Optional[str]:
+        """Get the value from the context variable."""
+        ctx_var = cls._context_vars.get(key)
+        if ctx_var is not None:
+            return ctx_var.get()
+        return None
 
-
-def set_request_id(request_id: str) -> None:
-    """Set the request id in the context variable."""
-    ctx_var_request_id.set(request_id)  # type: ignore
+    @classmethod
+    def set(cls, key: LoggerTagKey, value: Optional[str]) -> None:
+        """Set the value in the context variable."""
+        if value is not None:
+            ctx_var = cls._context_vars.get(key)
+            if ctx_var is None:
+                ctx_var = contextvars.ContextVar(f"ctx_var_{key.name.lower()}", default=None)
+                cls._context_vars[key] = ctx_var
+            ctx_var.set(value)
 
 
 def make_standard_logger(name: str, log_level: int = logging.INFO) -> logging.Logger:
@@ -77,10 +92,26 @@ class CustomJSONFormatter(json_log_formatter.JSONFormatter):
         extra["lineno"] = record.lineno
         extra["pathname"] = record.pathname
 
-        # add the http request id if it exists
-        request_id = ctx_var_request_id.get()
-        if request_id:
-            extra["request_id"] = request_id
+        # # add the http request id if it exists
+        # request_id = ctx_var_request_id.get()
+        # if request_id:
+        #     extra["request_id"] = request_id
+        
+        # # add the team id for the request if it exists
+        # team_id = ctx_var_team_id.get()
+        # if team_id:
+        #     extra["team_id"] = team_id
+
+        # # add the user id for the request if it exists
+        # user_id = ctx_var_user_id.get()
+        # if user_id:
+        #     extra["user_id"] = user_id
+
+        # 
+        for tag_key in LoggerTagKey:
+            tag_value = LoggerTagManager.get(tag_key)
+            if tag_value:
+                extra[tag_key.value] = tag_value
 
         current_span = tracer.current_span()
         extra["dd.trace_id"] = current_span.trace_id if current_span else 0

--- a/model-engine/model_engine_server/core/loggers.py
+++ b/model-engine/model_engine_server/core/loggers.py
@@ -1,11 +1,11 @@
 import contextvars
-from enum import Enum, auto
 import inspect
 import logging
 import os
 import sys
 import warnings
 from contextlib import contextmanager
+from enum import Enum
 from typing import Dict, Optional, Sequence
 
 import ddtrace
@@ -38,14 +38,16 @@ __all__: Sequence[str] = (
     "LoggerTagManager",
 )
 
+
 class LoggerTagKey(str, Enum):
-    REQUEST_ID = 'request_id'
-    TEAM_ID = 'team_id'
-    USER_ID = 'user_id'
+    REQUEST_ID = "request_id"
+    TEAM_ID = "team_id"
+    USER_ID = "user_id"
+
 
 class LoggerTagManager:
     _context_vars: Dict[LoggerTagKey, contextvars.ContextVar] = {}
-    
+
     @classmethod
     def get(cls, key: LoggerTagKey) -> Optional[str]:
         """Get the value from the context variable."""
@@ -92,22 +94,7 @@ class CustomJSONFormatter(json_log_formatter.JSONFormatter):
         extra["lineno"] = record.lineno
         extra["pathname"] = record.pathname
 
-        # # add the http request id if it exists
-        # request_id = ctx_var_request_id.get()
-        # if request_id:
-        #     extra["request_id"] = request_id
-        
-        # # add the team id for the request if it exists
-        # team_id = ctx_var_team_id.get()
-        # if team_id:
-        #     extra["team_id"] = team_id
-
-        # # add the user id for the request if it exists
-        # user_id = ctx_var_user_id.get()
-        # if user_id:
-        #     extra["user_id"] = user_id
-
-        # 
+        # add additional logger tags
         for tag_key in LoggerTagKey:
             tag_value = LoggerTagManager.get(tag_key)
             if tag_value:


### PR DESCRIPTION
Add `user_id` and `team_id` as additional log facets. Clean up the log tagging to be a bit more general. 


Tested `CustomJSONFormatter` locally and saw that request_id, user_id, and team_id are in the logger extras. 