### PR TITLE
create celery worker with inference worker profile

### DIFF
--- a/model-engine/model_engine_server/core/celery/app.py
+++ b/model-engine/model_engine_server/core/celery/app.py
@@ -504,7 +504,7 @@ def _get_backend_url_and_conf(
     elif backend_protocol == "s3":
         backend_url = "s3://"
         if aws_role is None:
-            aws_session = session(infra_config().profile_ml_worker)
+            aws_session = session(infra_config().profile_ml_inference_worker)
         else:
             aws_session = session(aws_role)
         out_conf_changes.update(

--- a/model-engine/model_engine_server/core/celery/app.py
+++ b/model-engine/model_engine_server/core/celery/app.py
@@ -504,7 +504,8 @@ def _get_backend_url_and_conf(
     elif backend_protocol == "s3":
         backend_url = "s3://"
         if aws_role is None:
-            aws_session = session(infra_config().profile_ml_inference_worker)
+            aws_profile = os.getenv("AWS_PROFILE", infra_config().profile_ml_worker)
+            aws_session = session(aws_profile)
         else:
             aws_session = session(aws_role)
         out_conf_changes.update(


### PR DESCRIPTION
# Pull Request Summary
The endpoint-builder and celery forwarder both use this celery app sessions instantiations. However, they expect different profiles to be used. Force the celery worker to use the dynamic value in `AWS_PROFILE` instead of the static `profile_ml_worker`.

## Testing Plan
Create a new deployment in our clusters and launched a batch job. The pods were built correctly and the job succeeded.