### PR TITLE
Add pod disruption budget to all endpoints

### DIFF
--- a/charts/model-engine/templates/service_template_config_map.yaml
+++ b/charts/model-engine/templates/service_template_config_map.yaml
@@ -515,6 +515,19 @@ data:
               cpu: ${CPUS}
               memory: ${MEMORY}
             controlledResources: ["cpu", "memory"]
+  pod-disruption-budget.yaml: |-
+    apiVersion: policy/v1
+    kind: PodDisruptionBudget
+    metadata:
+      name: ${RESOURCE_NAME}
+      namespace: ${NAMESPACE}
+      labels:
+        {{- $service_template_labels | nindent 8 }}
+    spec:
+      minAvailable: 1
+      selector:
+        matchLabels:
+          app: ${RESOURCE_NAME}
   batch-job-orchestration-job.yaml: |-
     apiVersion: batch/v1
     kind: Job

--- a/model-engine/model_engine_server/infra/gateways/resources/image_cache_gateway.py
+++ b/model-engine/model_engine_server/infra/gateways/resources/image_cache_gateway.py
@@ -23,9 +23,6 @@ class CachedImages(TypedDict):
     t4: List[str]
 
 
-KUBERNETES_MAX_LENGTH = 64
-
-
 class ImageCacheGateway:
     async def create_or_update_image_cache(self, cached_images: CachedImages) -> None:
         """

--- a/model-engine/model_engine_server/infra/gateways/resources/k8s_resource_types.py
+++ b/model-engine/model_engine_server/infra/gateways/resources/k8s_resource_types.py
@@ -66,7 +66,7 @@ __all__: Sequence[str] = (
 LAUNCH_HIGH_PRIORITY_CLASS = "model-engine-high-priority"
 LAUNCH_DEFAULT_PRIORITY_CLASS = "model-engine-default-priority"
 
-KUBERNETES_MAX_LENGTH = 64
+IMAGE_HASH_MAX_LENGTH = 32
 FORWARDER_PORT = 5000
 USER_CONTAINER_PORT = 5005
 ARTIFACT_LIKE_CONTAINER_PORT = FORWARDER_PORT
@@ -329,6 +329,12 @@ class VerticalPodAutoscalerArguments(_BaseEndpointArguments):
     MEMORY: str
 
 
+class PodDisruptionBudgetArguments(_BaseEndpointArguments):
+    """Keyword-arguments for substituting into pod disruption budget templates."""
+
+    pass
+
+
 class VirtualServiceArguments(_BaseEndpointArguments):
     """Keyword-arguments for substituting into virtual-service templates."""
 
@@ -432,7 +438,7 @@ ResourceArguments = Union[
 
 
 def compute_image_hash(image: str) -> str:
-    return str(hashlib.md5(str(image).encode()).hexdigest())[:KUBERNETES_MAX_LENGTH]
+    return str(hashlib.sha256(str(image).encode()).hexdigest())[:IMAGE_HASH_MAX_LENGTH]
 
 
 def container_start_triton_cmd(
@@ -1183,6 +1189,19 @@ def get_endpoint_resource_arguments_from_request(
             GIT_TAG=GIT_TAG,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
+        )
+    elif endpoint_resource_name == "pod-disruption-budget":
+        return PodDisruptionBudgetArguments(
+            # Base resource arguments
+            RESOURCE_NAME=k8s_resource_group_name,
+            NAMESPACE=hmi_config.endpoint_namespace,
+            ENDPOINT_ID=model_endpoint_record.id,
+            ENDPOINT_NAME=model_endpoint_record.name,
+            TEAM=team,
+            PRODUCT=product,
+            CREATED_BY=created_by,
+            OWNER=owner,
+            GIT_TAG=GIT_TAG,
         )
     else:
         raise Exception(f"Unknown resource name: {endpoint_resource_name}")

--- a/model-engine/model_engine_server/infra/gateways/resources/templates/service_template_config_map_circleci.yaml
+++ b/model-engine/model_engine_server/infra/gateways/resources/templates/service_template_config_map_circleci.yaml
@@ -2728,6 +2728,31 @@ data:
               cpu: ${CPUS}
               memory: ${MEMORY}
             controlledResources: ["cpu", "memory"]
+  pod-disruption-budget.yaml: |-
+    apiVersion: policy/v1
+    kind: PodDisruptionBudget
+    metadata:
+      name: ${RESOURCE_NAME}
+      namespace: ${NAMESPACE}
+      labels:
+        user_id: ${OWNER}
+        team: ${TEAM}
+        product: ${PRODUCT}
+        created_by: ${CREATED_BY}
+        owner: ${OWNER}
+        env: circleci
+        managed-by: model-engine
+        use_scale_launch_endpoint_network_policy: "true"
+        tags.datadoghq.com/env: circleci
+        tags.datadoghq.com/version: ${GIT_TAG}
+        tags.datadoghq.com/service: ${ENDPOINT_NAME}
+        endpoint_id: ${ENDPOINT_ID}
+        endpoint_name: ${ENDPOINT_NAME}
+    spec:
+      minAvailable: 1
+      selector:
+        matchLabels:
+          app: ${RESOURCE_NAME}
   batch-job-orchestration-job.yaml: |-
     apiVersion: batch/v1
     kind: Job


### PR DESCRIPTION
For each endpoint, adds a pod disruption budget to make sure we at least have one available pod during disruption

tested by creating / deleting an endpoint locally