### PR TITLE
fix celery worker profile for s3 access

### DIFF
--- a/model-engine/model_engine_server/core/celery/app.py
+++ b/model-engine/model_engine_server/core/celery/app.py
@@ -504,7 +504,7 @@ def _get_backend_url_and_conf(
     elif backend_protocol == "s3":
         backend_url = "s3://"
         if aws_role is None:
-            aws_profile = os.getenv("AWS_PROFILE", infra_config().profile_ml_worker)
+            aws_profile = os.getenv("S3_WRITE_AWS_PROFILE", infra_config().profile_ml_worker)
             aws_session = session(aws_profile)
         else:
             aws_session = session(aws_role)

--- a/model-engine/model_engine_server/core/celery/app.py
+++ b/model-engine/model_engine_server/core/celery/app.py
@@ -504,8 +504,7 @@ def _get_backend_url_and_conf(
     elif backend_protocol == "s3":
         backend_url = "s3://"
         if aws_role is None:
-            aws_profile = os.getenv("S3_WRITE_AWS_PROFILE", infra_config().profile_ml_worker)
-            aws_session = session(aws_profile)
+            aws_session = session(infra_config().profile_ml_worker)
         else:
             aws_session = session(aws_role)
         out_conf_changes.update(

--- a/model-engine/model_engine_server/inference/forwarding/celery_forwarder.py
+++ b/model-engine/model_engine_server/inference/forwarding/celery_forwarder.py
@@ -95,6 +95,7 @@ def create_celery_service(
     app: Celery = celery_app(
         name=None,
         s3_bucket=infra_config().s3_bucket,
+        aws_role=infra_config().profile_ml_inference_worker,
         task_visibility=task_visibility,
         broker_type=str(BrokerType.SQS.value if sqs_url else BrokerType.REDIS.value),
         broker_transport_options={"predefined_queues": {queue_name: {"url": sqs_url}}}

--- a/model-engine/model_engine_server/infra/gateways/celery_task_queue_gateway.py
+++ b/model-engine/model_engine_server/infra/gateways/celery_task_queue_gateway.py
@@ -11,9 +11,7 @@ from model_engine_server.core.config import infra_config
 from model_engine_server.domain.gateways.task_queue_gateway import TaskQueueGateway
 
 celery_redis = celery_app(
-    None,
-    s3_bucket=infra_config().s3_bucket,
-    broker_type=str(BrokerType.REDIS.value),
+    None, s3_bucket=infra_config().s3_bucket, broker_type=str(BrokerType.REDIS.value)
 )
 celery_redis_24h = celery_app(
     None,


### PR DESCRIPTION
Follow-up to https://github.com/scaleapi/llm-engine/pull/327

## Pull Request Summary
The celery task queue is instantiated with `aws_profile` provided in this line. Tasks were completed but the final state was not written to s3 and silently failed since the profile used was not the one with s3 write permissions. The real issue is only with the Celery forwarder that is created with the wrong profile. Change only for its instantiation.

### Testing Plan
Create a new deployment in our clusters and launched a batch job. The pods were built correctly and the job successfully completed.