### PR TITLE
Change DATADOG_TRACE_ENABLED to DD_TRACE_ENABLED

### DIFF
--- a/charts/model-engine/templates/_helpers.tpl
+++ b/charts/model-engine/templates/_helpers.tpl
@@ -125,8 +125,8 @@ podAffinity:
 
 {{- define "modelEngine.baseServiceTemplateEnv" -}}
 env:
-  - name: DATADOG_TRACE_ENABLED
-    value: "${DATADOG_TRACE_ENABLED}"
+  - name: DD_TRACE_ENABLED
+    value: "${DD_TRACE_ENABLED}"
   - name: DD_REMOTE_CONFIGURATION_ENABLED
     value: "false"
   - name: DD_SERVICE
@@ -187,8 +187,8 @@ env:
 
 {{- define "modelEngine.baseForwarderTemplateEnv" -}}
 env:
-  - name: DATADOG_TRACE_ENABLED
-    value: "${DATADOG_TRACE_ENABLED}"
+  - name: DD_TRACE_ENABLED
+    value: "${DD_TRACE_ENABLED}"
   - name: DD_REMOTE_CONFIGURATION_ENABLED
     value: "false"
   - name: DD_SERVICE
@@ -235,8 +235,8 @@ env:
 
 {{- define "modelEngine.serviceEnvBase" }}
 env:
-  - name: DATADOG_TRACE_ENABLED
-    value: "{{ .Values.datadog_trace_enabled }}"
+  - name: DD_TRACE_ENABLED
+    value: "{{ .Values.dd_trace_enabled }}"
   - name: DD_REMOTE_CONFIGURATION_ENABLED
     value: "false"
   - name: DD_ENV

--- a/charts/model-engine/templates/service_config_map.yaml
+++ b/charts/model-engine/templates/service_config_map.yaml
@@ -10,7 +10,7 @@ metadata:
     "helm.sh/hook-weight": "-2"
 data:
   launch_service_config: |-
-    datadog_trace_enabled: {{ .Values.datadog_trace_enabled | default false | quote }}
+    dd_trace_enabled: {{ .Values.dd_trace_enabled | default false | quote }}
     {{- with .Values.config.values.launch }}
     {{- range $key, $value := . }}
     {{ $key }}: {{ $value | quote }}
@@ -38,7 +38,7 @@ metadata:
     "helm.sh/hook-weight": "-2"
 data:
   launch_service_config: |-
-    datadog_trace_enabled: {{ .Values.datadog_trace_enabled | default false | quote }}
+    dd_trace_enabled: {{ .Values.dd_trace_enabled | default false | quote }}
     {{- with .Values.config.values.launch }}
     {{- range $key, $value := . }}
     {{ $key }}: {{ $value | quote }}

--- a/charts/model-engine/values.yaml
+++ b/charts/model-engine/values.yaml
@@ -1,4 +1,4 @@
-datadog_trace_enabled: true
+dd_trace_enabled: true
 spellbook:
   enabled: false
 redis:

--- a/charts/model-engine/values_circleci.yaml
+++ b/charts/model-engine/values_circleci.yaml
@@ -141,7 +141,7 @@ config:
       billing_queue_arn: none
       cache_redis_url: redis://redis-message-broker-master.default/15
       s3_file_llm_fine_tune_repository: "s3://$CIRCLECI_AWS_S3_BUCKET"
-      datadog_trace_enabled: false
+      dd_trace_enabled: false
       istio_enabled: true
       tgi_repository: "text-generation-inference"
       vllm_repository: "vllm"

--- a/charts/model-engine/values_sample.yaml
+++ b/charts/model-engine/values_sample.yaml
@@ -118,8 +118,8 @@ config:
       cache_redis_url: redis://llm-engine-prod-cache.use1.cache.amazonaws.com:6379/15
       # s3_file_llm_fine_tuning_job_repository [required] is the S3 URI for the S3 bucket/key that you wish to save fine-tuned assests
       s3_file_llm_fine_tuning_job_repository: "s3://llm-engine/llm-ft-job-repository"
-      # datadog_trace_enabled specifies whether to enable datadog tracing, datadog must be installed in the cluster
-      datadog_trace_enabled: false
+      # dd_trace_enabled specifies whether to enable datadog tracing, datadog must be installed in the cluster
+      dd_trace_enabled: false
 
       # Asynchronous endpoints configs (coming soon)
       sqs_profile: default

--- a/docs/guides/self_hosting.md
+++ b/docs/guides/self_hosting.md
@@ -114,7 +114,7 @@ Below are the configurations to specify in the `values_sample.yaml` file.
 | config.values.llm_engine.endpoint_namespace | K8s namespace the endpoints will be created in | Yes |
 | config.values.llm_engine.cache_redis_url | The full url for the redis cluster you wish to connect | Yes |
 | config.values.llm_engine.s3_file_llm_fine_tuning_job_repository | The S3 URI for the S3 bucket/key that you wish to save fine-tuned assets | Yes |
-| config.values.datadog_trace_enabled | Whether to enable datadog tracing, datadog must be installed in the cluster | No |
+| config.values.dd_trace_enabled | Whether to enable datadog tracing, datadog must be installed in the cluster | No |
 
 ## Play With It
 Once `helm install` succeeds, you can forward port `5000` from a `llm-engine` pod and test sending requests to it.

--- a/model-engine/model_engine_server/common/config.py
+++ b/model-engine/model_engine_server/common/config.py
@@ -53,7 +53,7 @@ class HostedModelInferenceServiceConfig:
     s3_file_llm_fine_tune_repository: str
     hf_user_fine_tuned_weights_prefix: str
     istio_enabled: bool
-    datadog_trace_enabled: bool
+    dd_trace_enabled: bool
     tgi_repository: str
     vllm_repository: str
     lightllm_repository: str

--- a/model-engine/model_engine_server/infra/gateways/resources/k8s_endpoint_resource_delegate.py
+++ b/model-engine/model_engine_server/infra/gateways/resources/k8s_endpoint_resource_delegate.py
@@ -60,7 +60,7 @@ HTTP_PORT = 5000
 # and where the user actually owns the files
 BASE_PATH_IN_ENDPOINT = "/app"
 
-DATADOG_ENV_VAR = {"DATADOG_TRACE_ENABLED", "DD_SERVICE", "DD_ENV", "DD_VERSION", "DD_AGENT_HOST"}
+DATADOG_ENV_VAR = {"DD_TRACE_ENABLED", "DD_SERVICE", "DD_ENV", "DD_VERSION", "DD_AGENT_HOST"}
 
 _lazy_load_kubernetes_clients = True
 _kubernetes_apps_api = None
@@ -237,7 +237,7 @@ def add_datadog_env_to_main_container(deployment_template: Dict[str, Any]) -> No
     user_container_envs.extend(
         [
             {
-                "name": "DATADOG_TRACE_ENABLED",
+                "name": "DD_TRACE_ENABLED",
                 "value": "false" if CIRCLECI else "true",
             },
             {

--- a/model-engine/model_engine_server/infra/gateways/resources/k8s_resource_types.py
+++ b/model-engine/model_engine_server/infra/gateways/resources/k8s_resource_types.py
@@ -106,7 +106,7 @@ class _BaseDeploymentArguments(_BaseEndpointArguments):
     PRIORITY: str
     IMAGE: str
     IMAGE_HASH: str
-    DATADOG_TRACE_ENABLED: str
+    DD_TRACE_ENABLED: str
     CPUS: str
     MEMORY: str
     STORAGE_DICT: DictStrStr
@@ -510,7 +510,7 @@ def get_endpoint_resource_arguments_from_request(
     # In Circle CI, we use Redis on localhost instead of SQS
     broker_name = BrokerName.SQS.value if not CIRCLECI else BrokerName.REDIS.value
     broker_type = BrokerType.SQS.value if not CIRCLECI else BrokerType.REDIS.value
-    datadog_trace_enabled = hmi_config.datadog_trace_enabled
+    dd_trace_enabled = hmi_config.dd_trace_enabled
     if broker_type == BrokerType.REDIS.value:
         sqs_queue_url = ""
 
@@ -573,7 +573,7 @@ def get_endpoint_resource_arguments_from_request(
             PRIORITY=priority,
             IMAGE=request.image,
             IMAGE_HASH=image_hash,
-            DATADOG_TRACE_ENABLED=datadog_trace_enabled,
+            DD_TRACE_ENABLED=dd_trace_enabled,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
             STORAGE_DICT=storage_dict,
@@ -621,7 +621,7 @@ def get_endpoint_resource_arguments_from_request(
             PRIORITY=priority,
             IMAGE=request.image,
             IMAGE_HASH=image_hash,
-            DATADOG_TRACE_ENABLED=datadog_trace_enabled,
+            DD_TRACE_ENABLED=dd_trace_enabled,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
             STORAGE_DICT=storage_dict,
@@ -671,7 +671,7 @@ def get_endpoint_resource_arguments_from_request(
             PRIORITY=priority,
             IMAGE=request.image,
             IMAGE_HASH=image_hash,
-            DATADOG_TRACE_ENABLED=datadog_trace_enabled,
+            DD_TRACE_ENABLED=dd_trace_enabled,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
             STORAGE_DICT=storage_dict,
@@ -716,7 +716,7 @@ def get_endpoint_resource_arguments_from_request(
             PRIORITY=priority,
             IMAGE=request.image,
             IMAGE_HASH=image_hash,
-            DATADOG_TRACE_ENABLED=datadog_trace_enabled,
+            DD_TRACE_ENABLED=dd_trace_enabled,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
             STORAGE_DICT=storage_dict,
@@ -763,7 +763,7 @@ def get_endpoint_resource_arguments_from_request(
             PRIORITY=priority,
             IMAGE=request.image,
             IMAGE_HASH=image_hash,
-            DATADOG_TRACE_ENABLED=datadog_trace_enabled,
+            DD_TRACE_ENABLED=dd_trace_enabled,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
             STORAGE_DICT=storage_dict,
@@ -807,7 +807,7 @@ def get_endpoint_resource_arguments_from_request(
             PRIORITY=priority,
             IMAGE=request.image,
             IMAGE_HASH=image_hash,
-            DATADOG_TRACE_ENABLED=datadog_trace_enabled,
+            DD_TRACE_ENABLED=dd_trace_enabled,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
             STORAGE_DICT=storage_dict,
@@ -853,7 +853,7 @@ def get_endpoint_resource_arguments_from_request(
             PRIORITY=priority,
             IMAGE=request.image,
             IMAGE_HASH=image_hash,
-            DATADOG_TRACE_ENABLED=datadog_trace_enabled,
+            DD_TRACE_ENABLED=dd_trace_enabled,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
             STORAGE_DICT=storage_dict,
@@ -909,7 +909,7 @@ def get_endpoint_resource_arguments_from_request(
             PRIORITY=priority,
             IMAGE=request.image,
             IMAGE_HASH=image_hash,
-            DATADOG_TRACE_ENABLED=datadog_trace_enabled,
+            DD_TRACE_ENABLED=dd_trace_enabled,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
             STORAGE_DICT=storage_dict,
@@ -967,7 +967,7 @@ def get_endpoint_resource_arguments_from_request(
             PRIORITY=priority,
             IMAGE=request.image,
             IMAGE_HASH=image_hash,
-            DATADOG_TRACE_ENABLED=datadog_trace_enabled,
+            DD_TRACE_ENABLED=dd_trace_enabled,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
             STORAGE_DICT=storage_dict,
@@ -1019,7 +1019,7 @@ def get_endpoint_resource_arguments_from_request(
             PRIORITY=priority,
             IMAGE=request.image,
             IMAGE_HASH=image_hash,
-            DATADOG_TRACE_ENABLED=datadog_trace_enabled,
+            DD_TRACE_ENABLED=dd_trace_enabled,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
             STORAGE_DICT=storage_dict,

--- a/model-engine/model_engine_server/infra/gateways/resources/templates/service_template_config_map_circleci.yaml
+++ b/model-engine/model_engine_server/infra/gateways/resources/templates/service_template_config_map_circleci.yaml
@@ -128,8 +128,8 @@ data:
                 - --num-workers
                 - "${PER_WORKER}"
               env:
-                - name: DATADOG_TRACE_ENABLED
-                  value: "${DATADOG_TRACE_ENABLED}"
+                - name: DD_TRACE_ENABLED
+                  value: "${DD_TRACE_ENABLED}"
                 - name: DD_SERVICE
                   value: "${ENDPOINT_NAME}"
                 - name: DD_ENV
@@ -399,8 +399,8 @@ data:
                 - --num-workers
                 - "${PER_WORKER}"
               env:
-                - name: DATADOG_TRACE_ENABLED
-                  value: "${DATADOG_TRACE_ENABLED}"
+                - name: DD_TRACE_ENABLED
+                  value: "${DD_TRACE_ENABLED}"
                 - name: DD_SERVICE
                   value: "${ENDPOINT_NAME}"
                 - name: DD_ENV
@@ -618,8 +618,8 @@ data:
                 - --set
                 - "forwarder.stream.healthcheck_route=${HEALTHCHECK_ROUTE}"
               env:
-                - name: DATADOG_TRACE_ENABLED
-                  value: "${DATADOG_TRACE_ENABLED}"
+                - name: DD_TRACE_ENABLED
+                  value: "${DD_TRACE_ENABLED}"
                 - name: DD_SERVICE
                   value: "${ENDPOINT_NAME}"
                 - name: DD_ENV
@@ -886,8 +886,8 @@ data:
                 - --set
                 - "forwarder.stream.healthcheck_route=${HEALTHCHECK_ROUTE}"
               env:
-                - name: DATADOG_TRACE_ENABLED
-                  value: "${DATADOG_TRACE_ENABLED}"
+                - name: DD_TRACE_ENABLED
+                  value: "${DD_TRACE_ENABLED}"
                 - name: DD_SERVICE
                   value: "${ENDPOINT_NAME}"
                 - name: DD_ENV
@@ -1112,8 +1112,8 @@ data:
                 - --set
                 - "forwarder.stream.healthcheck_route=${HEALTHCHECK_ROUTE}"
               env:
-                - name: DATADOG_TRACE_ENABLED
-                  value: "${DATADOG_TRACE_ENABLED}"
+                - name: DD_TRACE_ENABLED
+                  value: "${DD_TRACE_ENABLED}"
                 - name: DD_SERVICE
                   value: "${ENDPOINT_NAME}"
                 - name: DD_ENV
@@ -1349,8 +1349,8 @@ data:
                 - --num-workers
                 - "${PER_WORKER}"
               env:
-                - name: DATADOG_TRACE_ENABLED
-                  value: "${DATADOG_TRACE_ENABLED}"
+                - name: DD_TRACE_ENABLED
+                  value: "${DD_TRACE_ENABLED}"
                 - name: DD_SERVICE
                   value: "${ENDPOINT_NAME}"
                 - name: DD_ENV
@@ -1627,8 +1627,8 @@ data:
                 - --num-workers
                 - "${PER_WORKER}"
               env:
-                - name: DATADOG_TRACE_ENABLED
-                  value: "${DATADOG_TRACE_ENABLED}"
+                - name: DD_TRACE_ENABLED
+                  value: "${DD_TRACE_ENABLED}"
                 - name: DD_SERVICE
                   value: "${ENDPOINT_NAME}"
                 - name: DD_ENV
@@ -1853,8 +1853,8 @@ data:
                 - --set
                 - "forwarder.stream.healthcheck_route=${HEALTHCHECK_ROUTE}"
               env:
-                - name: DATADOG_TRACE_ENABLED
-                  value: "${DATADOG_TRACE_ENABLED}"
+                - name: DD_TRACE_ENABLED
+                  value: "${DD_TRACE_ENABLED}"
                 - name: DD_SERVICE
                   value: "${ENDPOINT_NAME}"
                 - name: DD_ENV
@@ -2128,8 +2128,8 @@ data:
                 - --set
                 - "forwarder.stream.healthcheck_route=${HEALTHCHECK_ROUTE}"
               env:
-                - name: DATADOG_TRACE_ENABLED
-                  value: "${DATADOG_TRACE_ENABLED}"
+                - name: DD_TRACE_ENABLED
+                  value: "${DD_TRACE_ENABLED}"
                 - name: DD_SERVICE
                   value: "${ENDPOINT_NAME}"
                 - name: DD_ENV
@@ -2361,8 +2361,8 @@ data:
                 - --set
                 - "forwarder.stream.healthcheck_route=${HEALTHCHECK_ROUTE}"
               env:
-                - name: DATADOG_TRACE_ENABLED
-                  value: "${DATADOG_TRACE_ENABLED}"
+                - name: DD_TRACE_ENABLED
+                  value: "${DD_TRACE_ENABLED}"
                 - name: DD_SERVICE
                   value: "${ENDPOINT_NAME}"
                 - name: DD_ENV
@@ -2810,7 +2810,7 @@ data:
               env:
                 - name: DD_SERVICE
                   value: ${RESOURCE_NAME}
-                - name: DATADOG_TRACE_ENABLED
+                - name: DD_TRACE_ENABLED
                   value: "false"
                 - name: DD_ENV
                   value: circleci
@@ -2935,7 +2935,7 @@ data:
               env:
                 - name: DD_SERVICE
                   value: ${RESOURCE_NAME}
-                - name: DATADOG_TRACE_ENABLED
+                - name: DD_TRACE_ENABLED
                   value: "false"
                 - name: DD_ENV
                   value: circleci
@@ -3081,7 +3081,7 @@ data:
               env:
                 - name: DD_SERVICE
                   value: ${RESOURCE_NAME}
-                - name: DATADOG_TRACE_ENABLED
+                - name: DD_TRACE_ENABLED
                   value: "false"
                 - name: DD_ENV
                   value: circleci

--- a/model-engine/model_engine_server/infra/services/live_endpoint_builder_service.py
+++ b/model-engine/model_engine_server/infra/services/live_endpoint_builder_service.py
@@ -83,7 +83,7 @@ MAX_IMAGE_TAG_LEN = 128
 
 RESTRICTED_ENV_VARS_KEYS = {
     "BASE": [
-        "DATADOG_TRACE_ENABLED",
+        "DD_TRACE_ENABLED",
         "DD_AGENT_HOST",
         "DD_ENV",
         "DD_SERVICE",

--- a/model-engine/service_configs/service_config_circleci.yaml
+++ b/model-engine/service_configs/service_config_circleci.yaml
@@ -52,7 +52,7 @@ cache_redis_url: redis://127.0.0.1:6379/15
 
 s3_file_llm_fine_tune_repository: "s3://model-engine-integration-tests/fine_tune_repository/circleci"
 
-datadog_trace_enabled: false
+dd_trace_enabled: false
 istio_enabled: true
 tgi_repository: "text-generation-inference"
 vllm_repository: "vllm"


### PR DESCRIPTION
<img width="1175" alt="image" src="https://github.com/scaleapi/llm-engine/assets/14102305/916ae537-3537-47db-ac09-ea3fe3f626b8">
confirmed that setting DATADOG_TRACE_ENABLED=false in a pod does nothing, but setting DD_TRACE_ENABLED=false in a pod successfully turns off datadog logging