### PR TITLE
Track LLM Metrics

### DIFF
--- a/model-engine/model_engine_server/api/dependencies.py
+++ b/model-engine/model_engine_server/api/dependencies.py
@@ -133,6 +133,7 @@ class ExternalInterfaces:
     filesystem_gateway: FilesystemGateway
     llm_artifact_gateway: LLMArtifactGateway
     cron_job_gateway: CronJobGateway
+    monitoring_metrics_gateway: MonitoringMetricsGateway
 
 
 def get_default_monitoring_metrics_gateway() -> MonitoringMetricsGateway:
@@ -279,6 +280,7 @@ def _get_external_interfaces(
         llm_artifact_gateway=llm_artifact_gateway,
         trigger_repository=trigger_repository,
         cron_job_gateway=cron_job_gateway,
+        monitoring_metrics_gateway=monitoring_metrics_gateway,
     )
     return external_interfaces
 

--- a/model-engine/model_engine_server/api/llms_v1.py
+++ b/model-engine/model_engine_server/api/llms_v1.py
@@ -88,7 +88,7 @@ async def record_route_call(
     model_name = request.query_params.get("model_endpoint_name", None)
 
     external_interfaces.monitoring_metrics_gateway.emit_route_call_metric(
-        route=route, metadata=MetricMetadata(user=auth, model_name=model_name)
+        route, MetricMetadata(user=auth, model_name=model_name)
     )
 
 

--- a/model-engine/model_engine_server/api/llms_v1.py
+++ b/model-engine/model_engine_server/api/llms_v1.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from typing import Optional
 
 import pytz
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from model_engine_server.api.dependencies import (
     ExternalInterfaces,
     get_external_interfaces,
@@ -78,7 +78,21 @@ from model_engine_server.domain.use_cases.llm_model_endpoint_use_cases import (
 from model_engine_server.domain.use_cases.model_bundle_use_cases import CreateModelBundleV2UseCase
 from sse_starlette.sse import EventSourceResponse
 
-llm_router_v1 = APIRouter(prefix="/v1/llm")
+
+async def record_route_call(
+    request: Request,
+    auth: User = Depends(verify_authentication),
+    external_interfaces: ExternalInterfaces = Depends(get_external_interfaces_read_only),
+):
+    route = f"{request.method}_{request.url.path}".lower()
+    model_name = request.query_params.get("model_endpoint_name", None)
+
+    external_interfaces.monitoring_metrics_gateway.emit_route_call_metric(
+        route=route, metadata=MetricMetadata(user=auth, model_name=model_name)
+    )
+
+
+llm_router_v1 = APIRouter(prefix="/v1/llm", dependencies=[Depends(record_route_call)])
 logger = make_logger(logger_name())
 
 
@@ -119,9 +133,6 @@ async def create_model_endpoint(
     """
     Creates an LLM endpoint for the current user.
     """
-    external_interfaces.monitoring_metrics_gateway.emit_route_call_metric(
-        "create_model_endpoint", MetricMetadata(user=auth)
-    )
     add_trace_resource_name("llm_model_endpoints_post")
     logger.info(f"POST /llm/model-endpoints with {request} for {auth}")
     try:
@@ -176,9 +187,6 @@ async def list_model_endpoints(
     """
     Lists the LLM model endpoints owned by the current owner, plus all public_inference LLMs.
     """
-    external_interfaces.monitoring_metrics_gateway.emit_route_call_metric(
-        "list_model_endpoints", MetricMetadata(user=auth)
-    )
     add_trace_resource_name("llm_model_endpoints_get")
     logger.info(f"GET /llm/model-endpoints?name={name}&order_by={order_by} for {auth}")
     use_case = ListLLMModelEndpointsV1UseCase(
@@ -198,9 +206,6 @@ async def get_model_endpoint(
     """
     Describe the LLM Model endpoint with given name.
     """
-    external_interfaces.monitoring_metrics_gateway.emit_route_call_metric(
-        "get_model_endpoint", MetricMetadata(user=auth)
-    )
     add_trace_resource_name("llm_model_endpoints_name_get")
     logger.info(f"GET /llm/model-endpoints/{model_endpoint_name} for {auth}")
     try:
@@ -225,9 +230,6 @@ async def create_completion_sync_task(
     """
     Runs a sync prompt completion on an LLM.
     """
-    external_interfaces.monitoring_metrics_gateway.emit_route_call_metric(
-        "create_completion_sync_task", MetricMetadata(user=auth, model_name=model_endpoint_name)
-    )
     add_trace_resource_name("llm_completion_sync_post")
     logger.info(
         f"POST /completion_sync with {request} to endpoint {model_endpoint_name} for {auth}"
@@ -273,9 +275,6 @@ async def create_completion_stream_task(
     """
     Runs a stream prompt completion on an LLM.
     """
-    external_interfaces.monitoring_metrics_gateway.emit_route_call_metric(
-        "create_completion_stream_task", MetricMetadata(user=auth, model_name=model_endpoint_name)
-    )
     add_trace_resource_name("llm_completion_stream_post")
     logger.info(
         f"POST /completion_stream with {request} to endpoint {model_endpoint_name} for {auth}"
@@ -312,9 +311,6 @@ async def create_fine_tune(
     auth: User = Depends(verify_authentication),
     external_interfaces: ExternalInterfaces = Depends(get_external_interfaces),
 ) -> CreateFineTuneResponse:
-    external_interfaces.monitoring_metrics_gateway.emit_route_call_metric(
-        "create_fine_tune", MetricMetadata(user=auth)
-    )
     add_trace_resource_name("fine_tunes_create")
     logger.info(f"POST /fine-tunes with {request} for {auth}")
     try:
@@ -344,9 +340,6 @@ async def get_fine_tune(
     auth: User = Depends(verify_authentication),
     external_interfaces: ExternalInterfaces = Depends(get_external_interfaces_read_only),
 ) -> GetFineTuneResponse:
-    external_interfaces.monitoring_metrics_gateway.emit_route_call_metric(
-        "get_fine_tune", MetricMetadata(user=auth)
-    )
     add_trace_resource_name("fine_tunes_get")
     logger.info(f"GET /fine-tunes/{fine_tune_id} for {auth}")
     try:
@@ -366,9 +359,6 @@ async def list_fine_tunes(
     auth: User = Depends(verify_authentication),
     external_interfaces: ExternalInterfaces = Depends(get_external_interfaces_read_only),
 ) -> ListFineTunesResponse:
-    external_interfaces.monitoring_metrics_gateway.emit_route_call_metric(
-        "list_fine_tunes", MetricMetadata(user=auth)
-    )
     add_trace_resource_name("fine_tunes_list")
     logger.info(f"GET /fine-tunes for {auth}")
     use_case = ListFineTunesV1UseCase(
@@ -383,9 +373,6 @@ async def cancel_fine_tune(
     auth: User = Depends(verify_authentication),
     external_interfaces: ExternalInterfaces = Depends(get_external_interfaces),
 ) -> CancelFineTuneResponse:
-    external_interfaces.monitoring_metrics_gateway.emit_route_call_metric(
-        "cancel_fine_tune", MetricMetadata(user=auth)
-    )
     add_trace_resource_name("fine_tunes_cancel")
     logger.info(f"PUT /fine-tunes/{fine_tune_id}/cancel for {auth}")
     try:
@@ -406,9 +393,6 @@ async def get_fine_tune_events(
     auth: User = Depends(verify_authentication),
     external_interfaces: ExternalInterfaces = Depends(get_external_interfaces_read_only),
 ) -> GetFineTuneEventsResponse:
-    external_interfaces.monitoring_metrics_gateway.emit_route_call_metric(
-        "get_fine_tune_events", MetricMetadata(user=auth)
-    )
     add_trace_resource_name("fine_tunes_events_get")
     logger.info(f"GET /fine-tunes/{fine_tune_id}/events for {auth}")
     try:
@@ -430,9 +414,6 @@ async def download_model_endpoint(
     auth: User = Depends(verify_authentication),
     external_interfaces: ExternalInterfaces = Depends(get_external_interfaces),
 ) -> ModelDownloadResponse:
-    external_interfaces.monitoring_metrics_gateway.emit_route_call_metric(
-        "download_model_endpoint", MetricMetadata(user=auth)
-    )
     add_trace_resource_name("model_endpoints_download")
     logger.info(f"POST /model-endpoints/download with {request} for {auth}")
     try:
@@ -457,9 +438,6 @@ async def delete_llm_model_endpoint(
     auth: User = Depends(verify_authentication),
     external_interfaces: ExternalInterfaces = Depends(get_external_interfaces),
 ) -> DeleteLLMEndpointResponse:
-    external_interfaces.monitoring_metrics_gateway.emit_route_call_metric(
-        "delete_llm_model_endpoint", MetricMetadata(user=auth)
-    )
     add_trace_resource_name("llm_model_endpoints_delete")
     logger.info(f"DELETE /model-endpoints/{model_endpoint_name} for {auth}")
     try:

--- a/model-engine/model_engine_server/api/llms_v1.py
+++ b/model-engine/model_engine_server/api/llms_v1.py
@@ -58,6 +58,7 @@ from model_engine_server.domain.exceptions import (
     ObjectNotFoundException,
     UpstreamServiceError,
 )
+from model_engine_server.domain.gateways.monitoring_metrics_gateway import MetricMetadata
 from model_engine_server.domain.use_cases.llm_fine_tuning_use_cases import (
     CancelFineTuneV1UseCase,
     CreateFineTuneV1UseCase,
@@ -118,6 +119,9 @@ async def create_model_endpoint(
     """
     Creates an LLM endpoint for the current user.
     """
+    external_interfaces.monitoring_metrics_gateway.emit_route_call_metric(
+        "create_model_endpoint", MetricMetadata(user=auth)
+    )
     add_trace_resource_name("llm_model_endpoints_post")
     logger.info(f"POST /llm/model-endpoints with {request} for {auth}")
     try:
@@ -172,6 +176,9 @@ async def list_model_endpoints(
     """
     Lists the LLM model endpoints owned by the current owner, plus all public_inference LLMs.
     """
+    external_interfaces.monitoring_metrics_gateway.emit_route_call_metric(
+        "list_model_endpoints", MetricMetadata(user=auth)
+    )
     add_trace_resource_name("llm_model_endpoints_get")
     logger.info(f"GET /llm/model-endpoints?name={name}&order_by={order_by} for {auth}")
     use_case = ListLLMModelEndpointsV1UseCase(
@@ -191,6 +198,9 @@ async def get_model_endpoint(
     """
     Describe the LLM Model endpoint with given name.
     """
+    external_interfaces.monitoring_metrics_gateway.emit_route_call_metric(
+        "get_model_endpoint", MetricMetadata(user=auth)
+    )
     add_trace_resource_name("llm_model_endpoints_name_get")
     logger.info(f"GET /llm/model-endpoints/{model_endpoint_name} for {auth}")
     try:
@@ -215,6 +225,9 @@ async def create_completion_sync_task(
     """
     Runs a sync prompt completion on an LLM.
     """
+    external_interfaces.monitoring_metrics_gateway.emit_route_call_metric(
+        "create_completion_sync_task", MetricMetadata(user=auth, model_name=model_endpoint_name)
+    )
     add_trace_resource_name("llm_completion_sync_post")
     logger.info(
         f"POST /completion_sync with {request} to endpoint {model_endpoint_name} for {auth}"
@@ -260,6 +273,9 @@ async def create_completion_stream_task(
     """
     Runs a stream prompt completion on an LLM.
     """
+    external_interfaces.monitoring_metrics_gateway.emit_route_call_metric(
+        "create_completion_stream_task", MetricMetadata(user=auth, model_name=model_endpoint_name)
+    )
     add_trace_resource_name("llm_completion_stream_post")
     logger.info(
         f"POST /completion_stream with {request} to endpoint {model_endpoint_name} for {auth}"
@@ -296,6 +312,9 @@ async def create_fine_tune(
     auth: User = Depends(verify_authentication),
     external_interfaces: ExternalInterfaces = Depends(get_external_interfaces),
 ) -> CreateFineTuneResponse:
+    external_interfaces.monitoring_metrics_gateway.emit_route_call_metric(
+        "create_fine_tune", MetricMetadata(user=auth)
+    )
     add_trace_resource_name("fine_tunes_create")
     logger.info(f"POST /fine-tunes with {request} for {auth}")
     try:
@@ -325,6 +344,9 @@ async def get_fine_tune(
     auth: User = Depends(verify_authentication),
     external_interfaces: ExternalInterfaces = Depends(get_external_interfaces_read_only),
 ) -> GetFineTuneResponse:
+    external_interfaces.monitoring_metrics_gateway.emit_route_call_metric(
+        "get_fine_tune", MetricMetadata(user=auth)
+    )
     add_trace_resource_name("fine_tunes_get")
     logger.info(f"GET /fine-tunes/{fine_tune_id} for {auth}")
     try:
@@ -344,6 +366,9 @@ async def list_fine_tunes(
     auth: User = Depends(verify_authentication),
     external_interfaces: ExternalInterfaces = Depends(get_external_interfaces_read_only),
 ) -> ListFineTunesResponse:
+    external_interfaces.monitoring_metrics_gateway.emit_route_call_metric(
+        "list_fine_tunes", MetricMetadata(user=auth)
+    )
     add_trace_resource_name("fine_tunes_list")
     logger.info(f"GET /fine-tunes for {auth}")
     use_case = ListFineTunesV1UseCase(
@@ -358,6 +383,9 @@ async def cancel_fine_tune(
     auth: User = Depends(verify_authentication),
     external_interfaces: ExternalInterfaces = Depends(get_external_interfaces),
 ) -> CancelFineTuneResponse:
+    external_interfaces.monitoring_metrics_gateway.emit_route_call_metric(
+        "cancel_fine_tune", MetricMetadata(user=auth)
+    )
     add_trace_resource_name("fine_tunes_cancel")
     logger.info(f"PUT /fine-tunes/{fine_tune_id}/cancel for {auth}")
     try:
@@ -378,6 +406,9 @@ async def get_fine_tune_events(
     auth: User = Depends(verify_authentication),
     external_interfaces: ExternalInterfaces = Depends(get_external_interfaces_read_only),
 ) -> GetFineTuneEventsResponse:
+    external_interfaces.monitoring_metrics_gateway.emit_route_call_metric(
+        "get_fine_tune_events", MetricMetadata(user=auth)
+    )
     add_trace_resource_name("fine_tunes_events_get")
     logger.info(f"GET /fine-tunes/{fine_tune_id}/events for {auth}")
     try:
@@ -399,6 +430,9 @@ async def download_model_endpoint(
     auth: User = Depends(verify_authentication),
     external_interfaces: ExternalInterfaces = Depends(get_external_interfaces),
 ) -> ModelDownloadResponse:
+    external_interfaces.monitoring_metrics_gateway.emit_route_call_metric(
+        "download_model_endpoint", MetricMetadata(user=auth)
+    )
     add_trace_resource_name("model_endpoints_download")
     logger.info(f"POST /model-endpoints/download with {request} for {auth}")
     try:
@@ -423,6 +457,9 @@ async def delete_llm_model_endpoint(
     auth: User = Depends(verify_authentication),
     external_interfaces: ExternalInterfaces = Depends(get_external_interfaces),
 ) -> DeleteLLMEndpointResponse:
+    external_interfaces.monitoring_metrics_gateway.emit_route_call_metric(
+        "delete_llm_model_endpoint", MetricMetadata(user=auth)
+    )
     add_trace_resource_name("llm_model_endpoints_delete")
     logger.info(f"DELETE /model-endpoints/{model_endpoint_name} for {auth}")
     try:

--- a/model-engine/model_engine_server/core/auth/authentication_repository.py
+++ b/model-engine/model_engine_server/core/auth/authentication_repository.py
@@ -7,7 +7,7 @@ from typing import Optional
 class User:
     user_id: str
     team_id: str
-    email: Optional[str]
+    email: Optional[str] = None
     is_privileged_user: bool
 
 

--- a/model-engine/model_engine_server/core/auth/authentication_repository.py
+++ b/model-engine/model_engine_server/core/auth/authentication_repository.py
@@ -8,7 +8,7 @@ class User:
     user_id: str
     team_id: str
     email: Optional[str] = None
-    is_privileged_user: bool
+    is_privileged_user: bool = False
 
 
 class AuthenticationRepository(ABC):

--- a/model-engine/model_engine_server/core/auth/authentication_repository.py
+++ b/model-engine/model_engine_server/core/auth/authentication_repository.py
@@ -7,6 +7,7 @@ from typing import Optional
 class User:
     user_id: str
     team_id: str
+    email: Optional[str]
     is_privileged_user: bool
 
 

--- a/model-engine/model_engine_server/domain/gateways/monitoring_metrics_gateway.py
+++ b/model-engine/model_engine_server/domain/gateways/monitoring_metrics_gateway.py
@@ -7,6 +7,15 @@ docker build vs other errors
 """
 
 from abc import ABC, abstractmethod
+from typing import Optional
+
+from model_engine_server.core.auth.authentication_repository import User
+from pydantic import BaseModel
+
+
+class MetricMetadata(BaseModel):
+    user: User
+    model_name: Optional[str]
 
 
 class MonitoringMetricsGateway(ABC):
@@ -64,3 +73,11 @@ class MonitoringMetricsGateway(ABC):
         Missed database cache metric
 
         """
+
+    @abstractmethod
+    def emit_route_call_metric(self, route: str, metadata: MetricMetadata):
+        """
+        Route call metric
+
+        """
+        pass

--- a/model-engine/model_engine_server/infra/gateways/fake_monitoring_metrics_gateway.py
+++ b/model-engine/model_engine_server/infra/gateways/fake_monitoring_metrics_gateway.py
@@ -1,6 +1,9 @@
 from collections import defaultdict
 
-from model_engine_server.domain.gateways import MonitoringMetricsGateway
+from model_engine_server.domain.gateways.monitoring_metrics_gateway import (
+    MetricMetadata,
+    MonitoringMetricsGateway,
+)
 
 
 class FakeMonitoringMetricsGateway(MonitoringMetricsGateway):
@@ -15,6 +18,7 @@ class FakeMonitoringMetricsGateway(MonitoringMetricsGateway):
         self.successful_hook = defaultdict(int)
         self.database_cache_hit = 0
         self.database_cache_miss = 0
+        self.route_call = defaultdict(int)
 
     def reset(self):
         self.attempted_build = 0
@@ -27,6 +31,7 @@ class FakeMonitoringMetricsGateway(MonitoringMetricsGateway):
         self.successful_hook = defaultdict(int)
         self.database_cache_hit = 0
         self.database_cache_miss = 0
+        self.route_call = defaultdict(int)
 
     def emit_attempted_build_metric(self):
         self.attempted_build += 1
@@ -57,3 +62,6 @@ class FakeMonitoringMetricsGateway(MonitoringMetricsGateway):
 
     def emit_database_cache_miss_metric(self):
         self.database_cache_miss += 1
+
+    def emit_route_call_metric(self, route: str, _metadata: MetricMetadata):
+        self.route_call[route] += 1

--- a/model-engine/tests/unit/conftest.py
+++ b/model-engine/tests/unit/conftest.py
@@ -2093,6 +2093,7 @@ def get_repositories_generator_wrapper():
             fake_model_bundle_repository = FakeModelBundleRepository(
                 contents=fake_model_bundle_repository_contents
             )
+            fake_monitoring_metrics_gateway = FakeMonitoringMetricsGateway()
             fake_model_endpoint_record_repository = FakeModelEndpointRecordRepository(
                 contents=fake_model_endpoint_record_repository_contents,
                 model_bundle_repository=fake_model_bundle_repository,
@@ -2176,6 +2177,7 @@ def get_repositories_generator_wrapper():
                 cron_job_gateway=fake_cron_job_gateway,
                 filesystem_gateway=fake_file_system_gateway,
                 llm_artifact_gateway=fake_llm_artifact_gateway,
+                monitoring_metrics_gateway=fake_monitoring_metrics_gateway,
             )
             try:
                 yield repositories


### PR DESCRIPTION
Emit metrics on each route calls for the LLM endpoints.

Tested locally with:
```bash
curl -H "Authorization: <AUTH>" http://localhost:5001/v1/llm/model-endpoints
```

```bash
curl -H "Content-Type: application/json" -H "Authorization: <AUTH>" -d '{ "prompt": "Hello!", "max_new_tokens": 10, "temperature": 0.1 }' http://localhost:5001/v1/llm/completions-sync?model_endpoint_name=llama-2-7b-test-vllm
```