### PR TITLE
Remove extra trace facet "launch.resource_name"

### DIFF
--- a/model-engine/model_engine_server/api/batch_jobs_v1.py
+++ b/model-engine/model_engine_server/api/batch_jobs_v1.py
@@ -7,7 +7,6 @@ from model_engine_server.api.dependencies import (
     get_external_interfaces_read_only,
     verify_authentication,
 )
-from model_engine_server.common.datadog_utils import add_trace_resource_name
 from model_engine_server.common.dtos.batch_jobs import (
     CreateBatchJobV1Request,
     CreateBatchJobV1Response,
@@ -55,7 +54,6 @@ async def create_batch_job(
     """
     Runs a batch job.
     """
-    add_trace_resource_name("batch_jobs_post")
     logger.info(f"POST /batch-jobs with {request} for {auth}")
     try:
         use_case = CreateBatchJobV1UseCase(
@@ -85,7 +83,6 @@ async def get_batch_job(
     """
     Gets a batch job.
     """
-    add_trace_resource_name("batch_jobs_get")
     logger.info(f"GET /batch-jobs/{batch_job_id} for {auth}")
     try:
         use_case = GetBatchJobV1UseCase(batch_job_service=external_interfaces.batch_job_service)
@@ -107,7 +104,6 @@ async def update_batch_job(
     """
     Updates a batch job.
     """
-    add_trace_resource_name("batch_jobs_put")
     logger.info(f"PUT /batch-jobs/{batch_job_id} for {auth}")
     try:
         use_case = UpdateBatchJobV1UseCase(batch_job_service=external_interfaces.batch_job_service)
@@ -127,7 +123,6 @@ async def create_docker_image_batch_job(
     auth: User = Depends(verify_authentication),
     external_interfaces: ExternalInterfaces = Depends(get_external_interfaces),
 ) -> CreateDockerImageBatchJobV1Response:
-    add_trace_resource_name("batch_jobs_di_create")
     logger.info(f"POST /docker-image-batch-jobs with {request} for {auth}")
     try:
         use_case = CreateDockerImageBatchJobV1UseCase(
@@ -166,7 +161,6 @@ async def get_docker_image_batch_job(
     auth: User = Depends(verify_authentication),
     external_interfaces: ExternalInterfaces = Depends(get_external_interfaces_read_only),
 ) -> GetDockerImageBatchJobV1Response:
-    add_trace_resource_name("batch_jobs_di_get")
     logger.info(f"GET /docker-image-batch-jobs/{batch_job_id} for {auth}")
     try:
         use_case = GetDockerImageBatchJobV1UseCase(
@@ -191,7 +185,6 @@ async def list_docker_image_batch_jobs(
     """
     Lists docker image batch jobs spawned by trigger with given ID
     """
-    add_trace_resource_name("batch_jobs_di_get_trigger")
     logger.info(f"GET /docker-image-batch-jobs?trigger_id={trigger_id}")
     try:
         use_case = ListDockerImageBatchJobsV1UseCase(
@@ -212,7 +205,6 @@ async def update_docker_image_batch_job(
     auth: User = Depends(verify_authentication),
     external_interfaces: ExternalInterfaces = Depends(get_external_interfaces),
 ) -> UpdateDockerImageBatchJobV1Response:
-    add_trace_resource_name("batch_jobs_di_put")
     logger.info(f"PUT /docker-image-batch-jobs/{batch_job_id} with {request} for {auth}")
     try:
         use_case = UpdateDockerImageBatchJobV1UseCase(

--- a/model-engine/model_engine_server/api/docker_image_batch_job_bundles_v1.py
+++ b/model-engine/model_engine_server/api/docker_image_batch_job_bundles_v1.py
@@ -6,7 +6,6 @@ from model_engine_server.api.dependencies import (
     get_external_interfaces,
     verify_authentication,
 )
-from model_engine_server.common.datadog_utils import add_trace_resource_name
 from model_engine_server.common.dtos.batch_jobs import (
     CreateDockerImageBatchJobBundleV1Request,
     CreateDockerImageBatchJobBundleV1Response,
@@ -44,7 +43,6 @@ async def create_docker_image_batch_job_bundle(
     """
     Creates a docker iamge batch job bundle
     """
-    add_trace_resource_name("docker_image_batch_job_bundle_post")
     logger.info(f"POST /docker-image-batch-job-bundles with {request} for {auth}")
     try:
         use_case = CreateDockerImageBatchJobBundleV1UseCase(
@@ -71,7 +69,6 @@ async def list_docker_image_batch_job_model_bundles(
     Lists docker image batch job bundles owned by current owner
 
     """
-    add_trace_resource_name("docker_image_batch_job_bundle_get")
     logger.info(
         f"GET /docker-image-batch-job-bundles?bundle_name={bundle_name}&order_by={order_by} for auth"
     )
@@ -90,7 +87,6 @@ async def get_latest_docker_image_batch_job_bundle(
     external_interfaces: ExternalInterfaces = Depends(get_external_interfaces),
 ) -> DockerImageBatchJobBundleV1Response:
     """Gets latest Docker Image Batch Job Bundle with given name owned by the current owner"""
-    add_trace_resource_name("docker_image_batch_job_bundle_latest_get")
     logger.info(f"GET /docker-image-batch-job-bundles/latest?bundle_name={bundle_name} for {auth}")
     try:
         use_case = GetLatestDockerImageBatchJobBundleByNameV1UseCase(
@@ -114,7 +110,6 @@ async def get_docker_image_batch_job_model_bundle(
     external_interfaces: ExternalInterfaces = Depends(get_external_interfaces),
 ) -> DockerImageBatchJobBundleV1Response:
     """Get details for a given DockerImageBatchJobBundle owned by the current owner"""
-    add_trace_resource_name("docker_image_batch_job_bundle_id_get")
     logger.info(
         f"GET /docker-image-batch-job-bundles/{docker_image_batch_job_bundle_id} for {auth}"
     )

--- a/model-engine/model_engine_server/api/files_v1.py
+++ b/model-engine/model_engine_server/api/files_v1.py
@@ -7,7 +7,6 @@ from model_engine_server.api.dependencies import (
     get_external_interfaces_read_only,
     verify_authentication,
 )
-from model_engine_server.common.datadog_utils import add_trace_resource_name
 from model_engine_server.common.dtos.files import (
     DeleteFileResponse,
     GetFileContentResponse,
@@ -39,7 +38,6 @@ async def upload_file(
     auth: User = Depends(verify_authentication),
     external_interfaces: ExternalInterfaces = Depends(get_external_interfaces),
 ) -> UploadFileResponse:
-    add_trace_resource_name("files_upload")
     logger.info(f"POST /files with filename {file.filename} for {auth}")
     use_case = UploadFileUseCase(
         file_storage_gateway=external_interfaces.file_storage_gateway,
@@ -57,7 +55,6 @@ async def get_file(
     auth: User = Depends(verify_authentication),
     external_interfaces: ExternalInterfaces = Depends(get_external_interfaces_read_only),
 ) -> GetFileResponse:
-    add_trace_resource_name("files_get")
     logger.info(f"GET /files/{file_id} for {auth}")
     try:
         use_case = GetFileUseCase(
@@ -76,7 +73,6 @@ async def list_files(
     auth: User = Depends(verify_authentication),
     external_interfaces: ExternalInterfaces = Depends(get_external_interfaces_read_only),
 ) -> ListFilesResponse:
-    add_trace_resource_name("files_list")
     logger.info(f"GET /files for {auth}")
     use_case = ListFilesUseCase(
         file_storage_gateway=external_interfaces.file_storage_gateway,
@@ -90,7 +86,6 @@ async def delete_file(
     auth: User = Depends(verify_authentication),
     external_interfaces: ExternalInterfaces = Depends(get_external_interfaces),
 ) -> DeleteFileResponse:
-    add_trace_resource_name("files_delete")
     logger.info(f"DELETE /files/{file_id} for {auth}")
     try:
         use_case = DeleteFileUseCase(
@@ -113,7 +108,6 @@ async def get_file_content(
     """
     Describe the LLM Model endpoint with given name.
     """
-    add_trace_resource_name("files_content_get")
     logger.info(f"GET /files/{file_id}/content for {auth}")
     try:
         use_case = GetFileContentUseCase(

--- a/model-engine/model_engine_server/api/llms_v1.py
+++ b/model-engine/model_engine_server/api/llms_v1.py
@@ -12,7 +12,6 @@ from model_engine_server.api.dependencies import (
     get_external_interfaces_read_only,
     verify_authentication,
 )
-from model_engine_server.common.datadog_utils import add_trace_resource_name
 from model_engine_server.common.dtos.llms import (
     CancelFineTuneResponse,
     CompletionStreamV1Request,
@@ -118,7 +117,6 @@ async def create_model_endpoint(
     """
     Creates an LLM endpoint for the current user.
     """
-    add_trace_resource_name("llm_model_endpoints_post")
     logger.info(f"POST /llm/model-endpoints with {request} for {auth}")
     try:
         create_model_bundle_use_case = CreateModelBundleV2UseCase(
@@ -172,7 +170,6 @@ async def list_model_endpoints(
     """
     Lists the LLM model endpoints owned by the current owner, plus all public_inference LLMs.
     """
-    add_trace_resource_name("llm_model_endpoints_get")
     logger.info(f"GET /llm/model-endpoints?name={name}&order_by={order_by} for {auth}")
     use_case = ListLLMModelEndpointsV1UseCase(
         llm_model_endpoint_service=external_interfaces.llm_model_endpoint_service,
@@ -191,7 +188,6 @@ async def get_model_endpoint(
     """
     Describe the LLM Model endpoint with given name.
     """
-    add_trace_resource_name("llm_model_endpoints_name_get")
     logger.info(f"GET /llm/model-endpoints/{model_endpoint_name} for {auth}")
     try:
         use_case = GetLLMModelEndpointByNameV1UseCase(
@@ -215,7 +211,6 @@ async def create_completion_sync_task(
     """
     Runs a sync prompt completion on an LLM.
     """
-    add_trace_resource_name("llm_completion_sync_post")
     logger.info(
         f"POST /completion_sync with {request} to endpoint {model_endpoint_name} for {auth}"
     )
@@ -260,7 +255,6 @@ async def create_completion_stream_task(
     """
     Runs a stream prompt completion on an LLM.
     """
-    add_trace_resource_name("llm_completion_stream_post")
     logger.info(
         f"POST /completion_stream with {request} to endpoint {model_endpoint_name} for {auth}"
     )
@@ -296,7 +290,6 @@ async def create_fine_tune(
     auth: User = Depends(verify_authentication),
     external_interfaces: ExternalInterfaces = Depends(get_external_interfaces),
 ) -> CreateFineTuneResponse:
-    add_trace_resource_name("fine_tunes_create")
     logger.info(f"POST /fine-tunes with {request} for {auth}")
     try:
         use_case = CreateFineTuneV1UseCase(
@@ -325,7 +318,6 @@ async def get_fine_tune(
     auth: User = Depends(verify_authentication),
     external_interfaces: ExternalInterfaces = Depends(get_external_interfaces_read_only),
 ) -> GetFineTuneResponse:
-    add_trace_resource_name("fine_tunes_get")
     logger.info(f"GET /fine-tunes/{fine_tune_id} for {auth}")
     try:
         use_case = GetFineTuneV1UseCase(
@@ -344,7 +336,6 @@ async def list_fine_tunes(
     auth: User = Depends(verify_authentication),
     external_interfaces: ExternalInterfaces = Depends(get_external_interfaces_read_only),
 ) -> ListFineTunesResponse:
-    add_trace_resource_name("fine_tunes_list")
     logger.info(f"GET /fine-tunes for {auth}")
     use_case = ListFineTunesV1UseCase(
         llm_fine_tuning_service=external_interfaces.llm_fine_tuning_service,
@@ -358,7 +349,6 @@ async def cancel_fine_tune(
     auth: User = Depends(verify_authentication),
     external_interfaces: ExternalInterfaces = Depends(get_external_interfaces),
 ) -> CancelFineTuneResponse:
-    add_trace_resource_name("fine_tunes_cancel")
     logger.info(f"PUT /fine-tunes/{fine_tune_id}/cancel for {auth}")
     try:
         use_case = CancelFineTuneV1UseCase(
@@ -378,7 +368,6 @@ async def get_fine_tune_events(
     auth: User = Depends(verify_authentication),
     external_interfaces: ExternalInterfaces = Depends(get_external_interfaces_read_only),
 ) -> GetFineTuneEventsResponse:
-    add_trace_resource_name("fine_tunes_events_get")
     logger.info(f"GET /fine-tunes/{fine_tune_id}/events for {auth}")
     try:
         use_case = GetFineTuneEventsV1UseCase(
@@ -399,7 +388,6 @@ async def download_model_endpoint(
     auth: User = Depends(verify_authentication),
     external_interfaces: ExternalInterfaces = Depends(get_external_interfaces),
 ) -> ModelDownloadResponse:
-    add_trace_resource_name("model_endpoints_download")
     logger.info(f"POST /model-endpoints/download with {request} for {auth}")
     try:
         use_case = ModelDownloadV1UseCase(
@@ -423,7 +411,6 @@ async def delete_llm_model_endpoint(
     auth: User = Depends(verify_authentication),
     external_interfaces: ExternalInterfaces = Depends(get_external_interfaces),
 ) -> DeleteLLMEndpointResponse:
-    add_trace_resource_name("llm_model_endpoints_delete")
     logger.info(f"DELETE /model-endpoints/{model_endpoint_name} for {auth}")
     try:
         use_case = DeleteLLMEndpointByNameUseCase(

--- a/model-engine/model_engine_server/api/model_bundles_v1.py
+++ b/model-engine/model_engine_server/api/model_bundles_v1.py
@@ -9,7 +9,6 @@ from model_engine_server.api.dependencies import (
     get_external_interfaces_read_only,
     verify_authentication,
 )
-from model_engine_server.common.datadog_utils import add_trace_resource_name
 from model_engine_server.common.dtos.model_bundles import (
     CloneModelBundleV1Request,
     CreateModelBundleV1Request,
@@ -48,7 +47,6 @@ async def create_model_bundle(
     Creates a ModelBundle for the current user.
     """
     logger.info(f"POST /model-bundles with {request} for {auth}")
-    add_trace_resource_name("model_bundles_post")
     try:
         use_case = CreateModelBundleV1UseCase(
             model_bundle_repository=external_interfaces.model_bundle_repository,
@@ -84,7 +82,6 @@ async def clone_model_bundle_with_changes(
     """
     Creates a ModelBundle by cloning an existing one and then applying changes on top.
     """
-    add_trace_resource_name("model_bundles_clone")
     try:
         use_case = CloneModelBundleV1UseCase(
             model_bundle_repository=external_interfaces.model_bundle_repository,
@@ -107,7 +104,6 @@ async def list_model_bundles(
     """
     Lists the ModelBundles owned by the current owner.
     """
-    add_trace_resource_name("model_bundles_get")
     logger.info(f"GET /model-bundles?model_name={model_name}&order_by={order_by} for {auth}")
     use_case = ListModelBundlesV1UseCase(
         model_bundle_repository=external_interfaces.model_bundle_repository
@@ -124,7 +120,6 @@ async def get_latest_model_bundle(
     """
     Gets the latest Model Bundle with the given name owned by the current owner.
     """
-    add_trace_resource_name("model_bundles_latest_get")
     logger.info(f"GET /model-bundles/latest?model_name={model_name} for {auth}")
     try:
         use_case = GetLatestModelBundleByNameV1UseCase(
@@ -149,7 +144,6 @@ async def get_model_bundle(
     """
     Gets the details for a given ModelBundle owned by the current owner.
     """
-    add_trace_resource_name("model_bundles_id_get")
     logger.info(f"GET /model-bundles/{model_bundle_id} for {auth}")
     try:
         use_case = GetModelBundleByIdV1UseCase(

--- a/model-engine/model_engine_server/api/model_bundles_v2.py
+++ b/model-engine/model_engine_server/api/model_bundles_v2.py
@@ -9,7 +9,6 @@ from model_engine_server.api.dependencies import (
     get_external_interfaces_read_only,
     verify_authentication,
 )
-from model_engine_server.common.datadog_utils import add_trace_resource_name
 from model_engine_server.common.dtos.model_bundles import (
     CloneModelBundleV2Request,
     CreateModelBundleV2Request,
@@ -48,7 +47,6 @@ async def create_model_bundle(
     Creates a ModelBundle for the current user.
     """
     logger.info(f"POST /model-bundles with {request} for {auth}")
-    add_trace_resource_name("model_bundles_post")
     try:
         use_case = CreateModelBundleV2UseCase(
             model_bundle_repository=external_interfaces.model_bundle_repository,
@@ -84,7 +82,6 @@ async def clone_model_bundle_with_changes(
     """
     Creates a ModelBundle by cloning an existing one and then applying changes on top.
     """
-    add_trace_resource_name("model_bundles_clone")
     try:
         use_case = CloneModelBundleV2UseCase(
             model_bundle_repository=external_interfaces.model_bundle_repository,
@@ -107,7 +104,6 @@ async def list_model_bundles(
     """
     Lists the ModelBundles owned by the current owner.
     """
-    add_trace_resource_name("model_bundles_get")
     logger.info(f"GET /model-bundles?model_name={model_name}&order_by={order_by} for {auth}")
     use_case = ListModelBundlesV2UseCase(
         model_bundle_repository=external_interfaces.model_bundle_repository
@@ -124,7 +120,6 @@ async def get_latest_model_bundle(
     """
     Gets the latest Model Bundle with the given name owned by the current owner.
     """
-    add_trace_resource_name("model_bundles_latest_get")
     logger.info(f"GET /model-bundles/latest?model_name={model_name} for {auth}")
     try:
         use_case = GetLatestModelBundleByNameV2UseCase(
@@ -149,7 +144,6 @@ async def get_model_bundle(
     """
     Gets the details for a given ModelBundle owned by the current owner.
     """
-    add_trace_resource_name("model_bundles_id_get")
     logger.info(f"GET /model-bundles/{model_bundle_id} for {auth}")
     try:
         use_case = GetModelBundleByIdV2UseCase(

--- a/model-engine/model_engine_server/api/model_endpoints_v1.py
+++ b/model-engine/model_engine_server/api/model_endpoints_v1.py
@@ -12,7 +12,6 @@ from model_engine_server.api.dependencies import (
     get_external_interfaces_read_only,
     verify_authentication,
 )
-from model_engine_server.common.datadog_utils import add_trace_resource_name
 from model_engine_server.common.dtos.model_endpoints import (
     CreateModelEndpointV1Request,
     CreateModelEndpointV1Response,
@@ -57,7 +56,6 @@ async def create_model_endpoint(
     """
     Creates a Model for the current user.
     """
-    add_trace_resource_name("model_endpoints_post")
     logger.info(f"POST /model-endpoints with {request} for {auth}")
     try:
         use_case = CreateModelEndpointV1UseCase(
@@ -104,7 +102,6 @@ async def list_model_endpoints(
     """
     Lists the Models owned by the current owner.
     """
-    add_trace_resource_name("model_endpoints_get")
     logger.info(f"GET /model-endpoints?name={name}&order_by={order_by} for {auth}")
     use_case = ListModelEndpointsV1UseCase(
         model_endpoint_service=external_interfaces.model_endpoint_service,
@@ -123,7 +120,6 @@ async def get_model_endpoint(
     """
     Describe the Model endpoint with given ID.
     """
-    add_trace_resource_name("model_endpoints_id_get")
     logger.info(f"GET /model-endpoints/{model_endpoint_id} for {auth}")
     try:
         use_case = GetModelEndpointByIdV1UseCase(
@@ -149,7 +145,6 @@ async def update_model_endpoint(
     """
     Lists the Models owned by the current owner.
     """
-    add_trace_resource_name("model_endpoints_id_put")
     logger.info(f"PUT /model-endpoints/{model_endpoint_id} with {request} for {auth}")
     try:
         use_case = UpdateModelEndpointByIdV1UseCase(
@@ -192,7 +187,6 @@ async def delete_model_endpoint(
     """
     Lists the Models owned by the current owner.
     """
-    add_trace_resource_name("model_endpoints_id_delete")
     logger.info(f"DELETE /model-endpoints/{model_endpoint_id} for {auth}")
     try:
         use_case = DeleteModelEndpointByIdV1UseCase(

--- a/model-engine/model_engine_server/api/tasks_v1.py
+++ b/model-engine/model_engine_server/api/tasks_v1.py
@@ -6,7 +6,6 @@ from model_engine_server.api.dependencies import (
     get_external_interfaces_read_only,
     verify_authentication,
 )
-from model_engine_server.common.datadog_utils import add_trace_resource_name
 from model_engine_server.common.dtos.tasks import (
     CreateAsyncTaskV1Response,
     EndpointPredictV1Request,
@@ -49,7 +48,6 @@ async def create_async_inference_task(
     """
     Runs an async inference prediction.
     """
-    add_trace_resource_name("task_async_post")
     logger.info(f"POST /async-tasks {request} to endpoint {model_endpoint_id} for {auth}")
     try:
         use_case = CreateAsyncInferenceTaskV1UseCase(
@@ -79,7 +77,6 @@ def get_async_inference_task(
     """
     Gets the status of an async inference task.
     """
-    add_trace_resource_name("task_async_id_get")
     logger.info(f"GET /async-tasks/{task_id} for {auth}")
     try:
         use_case = GetAsyncInferenceTaskV1UseCase(
@@ -103,7 +100,6 @@ async def create_sync_inference_task(
     """
     Runs a sync inference prediction.
     """
-    add_trace_resource_name("task_sync_post")
     logger.info(f"POST /sync-tasks with {request} to endpoint {model_endpoint_id} for {auth}")
     try:
         use_case = CreateSyncInferenceTaskV1UseCase(
@@ -143,7 +139,6 @@ async def create_streaming_inference_task(
     """
     Runs a streaming inference prediction.
     """
-    add_trace_resource_name("task_streaming_post")
     logger.info(f"POST /streaming-tasks with {request} to endpoint {model_endpoint_id} for {auth}")
     try:
         use_case = CreateStreamingInferenceTaskV1UseCase(

--- a/model-engine/model_engine_server/api/triggers_v1.py
+++ b/model-engine/model_engine_server/api/triggers_v1.py
@@ -4,7 +4,6 @@ from model_engine_server.api.dependencies import (
     get_external_interfaces,
     verify_authentication,
 )
-from model_engine_server.common.datadog_utils import add_trace_resource_name
 from model_engine_server.common.dtos.triggers import (
     CreateTriggerV1Request,
     CreateTriggerV1Response,
@@ -48,7 +47,6 @@ async def create_trigger(
     """
     Creates and runs a trigger
     """
-    add_trace_resource_name("triggers_post")
     logger.info(f"POST /triggers with {request} for {auth}")
     try:
         use_case = CreateTriggerUseCase(
@@ -102,7 +100,6 @@ async def list_triggers(
     """
     Lists descriptions of all triggers
     """
-    add_trace_resource_name("triggers_get")
     logger.info(f"GET /triggers for {auth}")
     use_case = ListTriggersUseCase(trigger_repository=external_interfaces.trigger_repository)
     return await use_case.execute(user=auth)
@@ -117,7 +114,6 @@ async def get_trigger(
     """
     Describes the trigger with the given ID
     """
-    add_trace_resource_name("triggers_id_get")
     logger.info(f"GET /triggers/{trigger_id} for {auth}")
     try:
         use_case = GetTriggerUseCase(trigger_repository=external_interfaces.trigger_repository)
@@ -136,7 +132,6 @@ async def update_trigger(
     """
     Updates the trigger with the given ID
     """
-    add_trace_resource_name("triggers_id_put")
     logger.info(f"PUT /triggers/{trigger_id} with {request} for {auth}")
     try:
         use_case = UpdateTriggerUseCase(
@@ -162,7 +157,6 @@ async def delete_trigger(
     """
     Deletes the trigger with the given ID
     """
-    add_trace_resource_name("trigger_id_delete")
     logger.info(f"DELETE /triggers/{trigger_id} for {auth}")
     try:
         use_case = DeleteTriggerUseCase(

--- a/model-engine/model_engine_server/common/datadog_utils.py
+++ b/model-engine/model_engine_server/common/datadog_utils.py
@@ -1,15 +1,6 @@
 from ddtrace import tracer
 
 
-def add_trace_resource_name(tag: str):
-    """Adds a custom tag to a given dd trace corresponding to the route
-    (e.g. get_model_bundles for GET /model-bundles, etc.) so that we can filter in Datadog easier
-    """
-    current_span = tracer.current_span()
-    if current_span:
-        current_span.set_tag("launch.resource_name", tag)
-
-
 def add_trace_request_id(request_id: str):
     """Adds a custom tag to a given dd trace corresponding to the request id
     so that we can filter in Datadog easier


### PR DESCRIPTION
https://docs.datadoghq.com/tracing/metrics/metrics_namespace/
> Trace metrics tags, possible tags are: env, service, version, resource, sublayer_type, sublayer_service, http.status_code, http.status_class, Datadog Agent tags (including the host and second primary tag). Note: Tags set on spans do not count and will not be available as tags for your traces metrics.

There already is a resource trace metric tag. `launch.resource_name` is also a facet that's unused, so it can be removed