### PR TITLE
Unmount aws config from root

### DIFF
--- a/charts/model-engine/templates/service_template_config_map.yaml
+++ b/charts/model-engine/templates/service_template_config_map.yaml
@@ -321,10 +321,6 @@ data:
                 - name: infra-service-config-volume
                   mountPath: ${INFRA_SERVICE_CONFIG_VOLUME_MOUNT_PATH}
                 {{- end }}
-                # LIRA: For compatibility with runnable image converted from artifactlike bundle
-                - name: config-volume
-                  mountPath: /home/modelengine/.aws/config
-                  subPath: config
                 - name: user-config
                   mountPath: /app/user_config
                   subPath: raw_data

--- a/charts/model-engine/templates/service_template_config_map.yaml
+++ b/charts/model-engine/templates/service_template_config_map.yaml
@@ -243,6 +243,8 @@ data:
               env:
                 - name: AWS_PROFILE
                   value: "${AWS_ROLE}"
+                - name: AWS_CONFIG_FILE
+                  value: "/opt/.aws/config"
               ports:
                 - containerPort: 8000
                   name: http
@@ -271,7 +273,7 @@ data:
                   ${TRITON_STORAGE_DICT}
               volumeMounts:
                 - name: config-volume
-                  mountPath: /root/.aws/config
+                  mountPath: /opt/.aws/config
                   subPath: config
                 - mountPath: /dev/shm
                   name: dshm
@@ -285,6 +287,8 @@ data:
               imagePullPolicy: IfNotPresent
               command: ${COMMAND}
               env: ${MAIN_ENV}
+                - name: AWS_CONFIG_FILE
+                  value: "/opt/.aws/config"
               readinessProbe:
                 httpGet:
                   path: ${HEALTHCHECK_ROUTE}
@@ -309,7 +313,7 @@ data:
                   ${STORAGE_DICT}
               volumeMounts:
                 - name: config-volume
-                  mountPath: /root/.aws/config
+                  mountPath: /opt/.aws/config
                   subPath: config
                 - mountPath: /dev/shm
                   name: dshm
@@ -565,6 +569,8 @@ data:
               env:
                 - name: DD_SERVICE
                   value: ${RESOURCE_NAME}
+                - name: AWS_CONFIG_FILE
+                  value: "/opt/.aws/config"
                 {{- $env_vars := $service_env | fromYaml }}
                 {{- range $env_var := index $env_vars "env" }}
                 {{- $env_var_name := index $env_var "name" }}
@@ -601,7 +607,7 @@ data:
                   memory: 32Gi
               volumeMounts:
                 - name: config-volume
-                  mountPath: /root/.aws/config
+                  mountPath: /opt/.aws/config
                   subPath: config
   {{- range $device := tuple "cpu" "gpu" }}
   docker-image-batch-job-{{- $device }}.yaml: |-
@@ -657,6 +663,8 @@ data:
               env:
                 - name: DD_SERVICE
                   value: ${RESOURCE_NAME}
+                - name: AWS_CONFIG_FILE
+                  value: "/opt/.aws/config"
                 {{- $env_vars := $service_env | fromYaml }}
                 {{- range $env_var := index $env_vars "env" }}
                 {{- $env_var_name := index $env_var "name" }}
@@ -684,7 +692,7 @@ data:
                   ${STORAGE_DICT}
               volumeMounts:
                 - name: config-volume
-                  mountPath: /root/.aws/config
+                  mountPath: /opt/.aws/config
                   subPath: config
                 - name: workdir
                   mountPath: ${MOUNT_PATH}
@@ -693,6 +701,9 @@ data:
           initContainers:
             - name: input-downloader
               image: {{ $gateway_repository }}:${GIT_TAG}
+              env:
+                - name: AWS_CONFIG_FILE
+                  value: "/opt/.aws/config"
               command:
                 - python
                 - -m
@@ -713,7 +724,7 @@ data:
                   memory: 1Gi
               volumeMounts:
                 - name: config-volume
-                  mountPath: /root/.aws/config
+                  mountPath: /opt/.aws/config
                   subPath: config
                 - name: workdir
                   mountPath: ${MOUNT_PATH}

--- a/charts/model-engine/templates/service_template_config_map.yaml
+++ b/charts/model-engine/templates/service_template_config_map.yaml
@@ -287,8 +287,6 @@ data:
               imagePullPolicy: IfNotPresent
               command: ${COMMAND}
               env: ${MAIN_ENV}
-                - name: AWS_CONFIG_FILE
-                  value: "/opt/.aws/config"
               readinessProbe:
                 httpGet:
                   path: ${HEALTHCHECK_ROUTE}

--- a/model-engine/model_engine_server/infra/gateways/resources/k8s_resource_types.py
+++ b/model-engine/model_engine_server/infra/gateways/resources/k8s_resource_types.py
@@ -518,6 +518,8 @@ def get_endpoint_resource_arguments_from_request(
     if isinstance(flavor, RunnableImageLike) and flavor.env:
         main_env = [{"name": key, "value": value} for key, value in flavor.env.items()]
     main_env.append({"name": "AWS_PROFILE", "value": build_endpoint_request.aws_role})
+    # NOTE: /opt/.aws/config is where service_template_config_map.yaml mounts the AWS config file, point to the mount for boto clients
+    main_env.append({"name": "AWS_CONFIG_FILE", "value": "/opt/.aws/config"})
 
     infra_service_config_volume_mount_path = "/infra-config"
     forwarder_config_file_name = "service--forwarder.yaml"


### PR DESCRIPTION
Mount aws configs to non-root directory. 

Tested by deploying runnable bundle (echo_server) and hitting with a sync task. 