### PR TITLE
Forward HTTP status code for sync requests

### DIFF
--- a/model-engine/model_engine_server/inference/configs/service--forwarder-runnable-img-converted-from-artifact.yaml
+++ b/model-engine/model_engine_server/inference/configs/service--forwarder-runnable-img-converted-from-artifact.yaml
@@ -9,6 +9,7 @@ forwarder:
     model_engine_unwrap: false
     serialize_results_as_string: false
     wrap_response: false
+    forward_http_status: true
   async:
     user_port: 5005
     user_hostname: "localhost"

--- a/model-engine/model_engine_server/inference/configs/service--forwarder.yaml
+++ b/model-engine/model_engine_server/inference/configs/service--forwarder.yaml
@@ -8,6 +8,7 @@ forwarder:
     batch_route: null
     model_engine_unwrap: true
     serialize_results_as_string: true
+    forward_http_status: true
   async:
     user_port: 5005
     user_hostname: "localhost"

--- a/model-engine/model_engine_server/inference/configs/service--http_forwarder.yaml
+++ b/model-engine/model_engine_server/inference/configs/service--http_forwarder.yaml
@@ -8,6 +8,7 @@ forwarder:
     batch_route: null
     model_engine_unwrap: true
     serialize_results_as_string: true
+    forward_http_status: true
   stream:
     user_port: 5005
     user_hostname: "localhost"

--- a/model-engine/model_engine_server/inference/forwarding/echo_server.py
+++ b/model-engine/model_engine_server/inference/forwarding/echo_server.py
@@ -5,6 +5,7 @@ import argparse
 import subprocess
 
 from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
 from sse_starlette.sse import EventSourceResponse
 
 app = FastAPI()
@@ -19,6 +20,12 @@ def healthcheck():
 @app.post("/predict")
 async def predict(request: Request):
     return await request.json()
+
+
+@app.post("/predict500")
+async def predict500(request: Request):
+    response = JSONResponse(content=await request.json(), status_code=500)
+    return response
 
 
 @app.post("/stream")

--- a/model-engine/model_engine_server/inference/forwarding/forwarding.py
+++ b/model-engine/model_engine_server/inference/forwarding/forwarding.py
@@ -8,6 +8,7 @@ from typing import Any, Iterator, List, Optional, Sequence, Tuple
 import requests
 import sseclient
 import yaml
+from fastapi.responses import JSONResponse
 from model_engine_server.common.dtos.tasks import EndpointPredictV1Request
 from model_engine_server.core.loggers import logger_name, make_logger
 from model_engine_server.inference.common import get_endpoint_config
@@ -131,13 +132,14 @@ class Forwarder(ModelEngineSerializationMixin):
         logger.info(f"Accepted request, forwarding {json_payload_repr=}")
 
         try:
-            response: Any = requests.post(
+            response_raw: Any = requests.post(
                 self.predict_endpoint,
                 json=json_payload,
                 headers={
                     "Content-Type": "application/json",
                 },
-            ).json()
+            )
+            response = response_raw.json()
         except Exception:
             logger.exception(
                 f"Failed to get response for request ({json_payload_repr}) "
@@ -145,18 +147,24 @@ class Forwarder(ModelEngineSerializationMixin):
             )
             raise
         if isinstance(response, dict):
-            logger.info(f"Got response from user-defined service: {response.keys()=}")
+            logger.info(
+                f"Got response from user-defined service: {response.keys()=}, {response_raw.status_code=}"
+            )
         elif isinstance(response, list):
-            logger.info(f"Got response from user-defined service: {len(response)=}")
+            logger.info(
+                f"Got response from user-defined service: {len(response)=}, {response_raw.status_code=}"
+            )
         else:
-            logger.info(f"Got response from user-defined service: {response=}")
+            logger.info(
+                f"Got response from user-defined service: {response=}, {response_raw.status_code=}"
+            )
 
         if self.wrap_response:
             response = self.get_response_payload(using_serialize_results_as_string, response)
 
         # TODO: we actually want to do this after we've returned the response.
         self.post_inference_hooks_handler.handle(request_obj, response)
-        return response
+        return JSONResponse(content=response, status_code=response_raw.status_code)
 
 
 @dataclass(frozen=True)
@@ -492,7 +500,7 @@ def _set_value(config: dict, key_path: List[str], value: Any) -> None:
     """
     key = key_path[0]
     if len(key_path) == 1:
-        config[key] = value
+        config[key] = value if not value.isdigit() else int(value)
     else:
         if key not in config:
             config[key] = dict()

--- a/model-engine/tests/unit/inference/test_forwarding.py
+++ b/model-engine/tests/unit/inference/test_forwarding.py
@@ -4,6 +4,7 @@ from typing import Mapping
 from unittest import mock
 
 import pytest
+from fastapi.responses import JSONResponse
 from model_engine_server.core.utils.env import environment
 from model_engine_server.domain.entities import ModelEndpointConfig
 from model_engine_server.inference.forwarding.forwarding import (
@@ -98,17 +99,27 @@ def test_forwarders(post_inference_hooks_handler):
         serialize_results_as_string=False,
         post_inference_hooks_handler=post_inference_hooks_handler,
         wrap_response=True,
+        forward_http_status=True,
     )
     json_response = fwd({"ignore": "me"})
     _check(json_response)
 
 
 def _check(json_response) -> None:
-    assert json.loads(json_response.body.decode("utf-8")) == {"result": PAYLOAD}
+    json_response = (
+        json.loads(json_response.body.decode("utf-8"))
+        if isinstance(json_response, JSONResponse)
+        else json_response
+    )
+    assert json_response == {"result": PAYLOAD}
 
 
 def _check_responses_not_wrapped(json_response) -> None:
-    json_response = json.loads(json_response.body.decode("utf-8"))
+    json_response = (
+        json.loads(json_response.body.decode("utf-8"))
+        if isinstance(json_response, JSONResponse)
+        else json_response
+    )
     assert json_response == PAYLOAD
 
 
@@ -135,13 +146,18 @@ def test_forwarders_serialize_results_as_string(post_inference_hooks_handler):
         serialize_results_as_string=True,
         post_inference_hooks_handler=post_inference_hooks_handler,
         wrap_response=True,
+        forward_http_status=True,
     )
     json_response = fwd({"ignore": "me"})
     _check_serialized(json_response)
 
 
 def _check_serialized(json_response) -> None:
-    json_response = json.loads(json_response.body.decode("utf-8"))
+    json_response = (
+        json.loads(json_response.body.decode("utf-8"))
+        if isinstance(json_response, JSONResponse)
+        else json_response
+    )
     assert isinstance(json_response["result"], str)
     assert len(json_response) == 1, f"expecting only 'result' key, but got {json_response=}"
     assert json.loads(json_response["result"]) == PAYLOAD
@@ -156,6 +172,7 @@ def test_forwarders_override_serialize_results(post_inference_hooks_handler):
         serialize_results_as_string=True,
         post_inference_hooks_handler=post_inference_hooks_handler,
         wrap_response=True,
+        forward_http_status=True,
     )
     json_response = fwd({"ignore": "me", KEY_SERIALIZE_RESULTS_AS_STRING: False})
     _check(json_response)
@@ -166,6 +183,7 @@ def test_forwarders_override_serialize_results(post_inference_hooks_handler):
         serialize_results_as_string=False,
         post_inference_hooks_handler=post_inference_hooks_handler,
         wrap_response=True,
+        forward_http_status=True,
     )
     json_response = fwd({"ignore": "me", KEY_SERIALIZE_RESULTS_AS_STRING: True})
     _check_serialized(json_response)
@@ -180,6 +198,7 @@ def test_forwarder_does_not_wrap_response(post_inference_hooks_handler):
         serialize_results_as_string=False,
         post_inference_hooks_handler=post_inference_hooks_handler,
         wrap_response=False,
+        forward_http_status=True,
     )
     json_response = fwd({"ignore": "me"})
     _check_responses_not_wrapped(json_response)
@@ -194,10 +213,26 @@ def test_forwarder_return_status_code(post_inference_hooks_handler):
         serialize_results_as_string=True,
         post_inference_hooks_handler=post_inference_hooks_handler,
         wrap_response=False,
+        forward_http_status=True,
     )
     json_response = fwd({"ignore": "me"})
     _check_responses_not_wrapped(json_response)
     assert json_response.status_code == 500
+
+
+@mock.patch("requests.post", mocked_post_500)
+@mock.patch("requests.get", mocked_get)
+def test_forwarder_dont_return_status_code(post_inference_hooks_handler):
+    fwd = Forwarder(
+        "ignored",
+        model_engine_unwrap=True,
+        serialize_results_as_string=True,
+        post_inference_hooks_handler=post_inference_hooks_handler,
+        wrap_response=False,
+        forward_http_status=False,
+    )
+    json_response = fwd({"ignore": "me"})
+    assert json_response == PAYLOAD
 
 
 @mock.patch("requests.post", mocked_post)
@@ -248,6 +283,7 @@ def test_forwarder_serialize_within_args(post_inference_hooks_handler):
         serialize_results_as_string=True,
         post_inference_hooks_handler=post_inference_hooks_handler,
         wrap_response=True,
+        forward_http_status=True,
     )
     # expected: no `serialize_results_as_string` at top-level nor in 'args'
     json_response = fwd({"something": "to ignore", "args": {"my": "payload", "is": "here"}})
@@ -266,6 +302,7 @@ def test_forwarder_serialize_within_args(post_inference_hooks_handler):
         serialize_results_as_string=True,
         post_inference_hooks_handler=post_inference_hooks_handler,
         wrap_response=True,
+        forward_http_status=True,
     )
     json_response = fwd(payload)
     _check_serialized(json_response)


### PR DESCRIPTION
# Pull Request Summary

We used to always forward with 200s ignoring downstream HTTP codes, now forwarding the code as well

## Test Plan and Usage Guide

unit tests and tested with echo server to make sure 500 status was forwarded

```
curl -X POST localhost:5000/predict -d '{"args":{}}' -H "content-type:application/json" -vv
Note: Unnecessary use of -X or --request, POST is already inferred.
* processing: localhost:5000/predict
*   Trying [::1]:5000...
* Connected to localhost (::1) port 5000
> POST /predict HTTP/1.1
> Host: localhost:5000
> User-Agent: curl/7.68.0
> Accept: */*
> content-type:application/json
> Content-Length: 11
> 
< HTTP/1.1 500 Internal Server Error
< date: Tue, 14 Nov 2023 21:23:58 GMT
< server: uvicorn
< content-length: 15
< content-type: application/json
< 
* Connection #0 to host localhost left intact
{"result":"{}"}
```
