### PR TITLE
update tensor-rt llm in enum

### DIFF
--- a/clients/python/llmengine/data_types.py
+++ b/clients/python/llmengine/data_types.py
@@ -16,6 +16,7 @@ class LLMInferenceFramework(str, Enum):
     TEXT_GENERATION_INFERENCE = "text_generation_inference"
     VLLM = "vllm"
     LIGHTLLM = "lightllm"
+    TENSORRTLLM = "tensorrt-llm"
 
 
 class LLMSource(str, Enum):

--- a/clients/python/llmengine/data_types.py
+++ b/clients/python/llmengine/data_types.py
@@ -16,7 +16,7 @@ class LLMInferenceFramework(str, Enum):
     TEXT_GENERATION_INFERENCE = "text_generation_inference"
     VLLM = "vllm"
     LIGHTLLM = "lightllm"
-    TENSORRTLLM = "tensorrt-llm"
+    TENSORRT_LLM = "tensorrt-llm"
 
 
 class LLMSource(str, Enum):


### PR DESCRIPTION
# Pull Request Summary

_What is this PR changing? Why is this change being made? Any caveats you'd like to highlight? Link any relevant documents, links, or screenshots here if applicable._
adds tensorrt-llm to enum for valid inference frameworks. currently `Model.list()` is broken due to the addition of endpoints that use tensorrt-llm as an inference framework when this framework isn't an option in the client. 

Ex: 

```
ValidationError: 1 validation error for ListLLMEndpointsResponse
model_endpoints -> 13 -> inference_framework
  value is not a valid enumeration member; permitted: 'deepspeed', 'text_generation_inference', 'vllm', 'lightllm' (type=type_error.enum; enum_values=[<LLMInferenceFramework.DEEPSPEED: 'deepspeed'>, <LLMInferenceFramework.TEXT_GENERATION_INFERENCE: 'text_generation_inference'>, <LLMInferenceFramework.VLLM: 'vllm'>, <LLMInferenceFramework.LIGHTLLM: 'lightllm'>])
```

## Test Plan and Usage Guide

_How did you validate that your PR works correctly? How do you run or demo the code? Provide enough detail so a reviewer can reasonably reproduce the testing procedure. Paste example command line invocations if applicable._
