### PR TITLE
Fix custom framework Dockerfile

### DIFF
--- a/model-engine/model_engine_server/inference/base.Dockerfile
+++ b/model-engine/model_engine_server/inference/base.Dockerfile
@@ -3,6 +3,8 @@ FROM ${BASE_IMAGE}
 
 WORKDIR /app
 
+RUN rm -rf /var/lib/apt/lists/*
+
 # Install basic packages.
 RUN apt-get update && apt-get install -y \
       apt-utils \


### PR DESCRIPTION
# Pull Request Summary

Fix
```
Repository 'http://security.debian.org/debian-security buster/updates InRelease' changed its 'Suite' value from 'oldstable' to 'oldoldstable'
```
error occurring for a user-provided base image

## Test Plan and Usage Guide

`docker build` for the erroring base image succeeds after this change
