### PR TITLE
[Mirror deployments] Allow adding shadow endpoints to endpoint creation/updating API

### DIFF
--- a/model-engine/model_engine_server/api/llms_v1.py
+++ b/model-engine/model_engine_server/api/llms_v1.py
@@ -59,6 +59,7 @@ from model_engine_server.domain.exceptions import (
     ObjectHasInvalidValueException,
     ObjectNotAuthorizedException,
     ObjectNotFoundException,
+    ShadowModelEndpointInvalidException,
     UpstreamServiceError,
 )
 from model_engine_server.domain.gateways.monitoring_metrics_gateway import MetricMetadata
@@ -193,6 +194,11 @@ async def create_model_endpoint(
             status_code=404,
             detail="The specified docker image could not be found.",
         ) from exc
+    except ShadowModelEndpointInvalidException as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=str(exc),
+        ) from exc
 
 
 @llm_router_v1.get("/model-endpoints", response_model=ListLLMModelEndpointsV1Response)
@@ -290,6 +296,11 @@ async def update_model_endpoint(
         raise HTTPException(
             status_code=404,
             detail="The specified docker image could not be found.",
+        ) from exc
+    except ShadowModelEndpointInvalidException as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=str(exc),
         ) from exc
 
 

--- a/model-engine/model_engine_server/api/model_endpoints_v1.py
+++ b/model-engine/model_engine_server/api/model_endpoints_v1.py
@@ -33,6 +33,7 @@ from model_engine_server.domain.exceptions import (
     ObjectHasInvalidValueException,
     ObjectNotAuthorizedException,
     ObjectNotFoundException,
+    ShadowModelEndpointInvalidException,
 )
 from model_engine_server.domain.use_cases.model_endpoint_use_cases import (
     CreateModelEndpointV1UseCase,
@@ -83,6 +84,11 @@ async def create_model_endpoint(
         raise HTTPException(
             status_code=404,
             detail="The specified model bundle could not be found.",
+        ) from exc
+    except ShadowModelEndpointInvalidException as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=str(exc),
         ) from exc
 
 
@@ -162,6 +168,11 @@ async def update_model_endpoint(
         raise HTTPException(
             status_code=409,
             detail="Existing operation on endpoint in progress, try again later.",
+        ) from exc
+    except ShadowModelEndpointInvalidException as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=str(exc),
         ) from exc
 
 

--- a/model-engine/model_engine_server/common/dtos/llms.py
+++ b/model-engine/model_engine_server/common/dtos/llms.py
@@ -20,6 +20,7 @@ from model_engine_server.domain.entities import (
     LLMSource,
     ModelEndpointStatus,
     Quantization,
+    ShadowModelEndpointRecord,
 )
 from pydantic import BaseModel, Field, HttpUrl
 
@@ -67,6 +68,10 @@ class CreateLLMModelEndpointV1Request(BaseModel):
     default_callback_url: Optional[HttpUrl]
     default_callback_auth: Optional[CallbackAuth]
     public_inference: Optional[bool] = True  # LLM endpoints are public by default.
+    shadow_endpoints: Optional[List[ShadowModelEndpointRecord]]
+    """
+    List of shadow endpoints to deploy for this endpoint.
+    """
 
 
 class CreateLLMModelEndpointV1Response(BaseModel):

--- a/model-engine/model_engine_server/common/dtos/llms.py
+++ b/model-engine/model_engine_server/common/dtos/llms.py
@@ -139,6 +139,10 @@ class UpdateLLMModelEndpointV1Request(BaseModel):
     default_callback_url: Optional[HttpUrl]
     default_callback_auth: Optional[CallbackAuth]
     public_inference: Optional[bool]
+    shadow_endpoints: Optional[List[ShadowModelEndpointRecord]]
+    """
+    List of shadow endpoints to deploy for this endpoint.
+    """
 
 
 class UpdateLLMModelEndpointV1Response(BaseModel):

--- a/model-engine/model_engine_server/common/dtos/model_endpoints.py
+++ b/model-engine/model_engine_server/common/dtos/model_endpoints.py
@@ -19,6 +19,7 @@ from model_engine_server.domain.entities import (
     ModelEndpointsSchema,
     ModelEndpointStatus,
     ModelEndpointType,
+    ShadowModelEndpointRecord,
     StorageSpecificationType,
 )
 from pydantic import BaseModel, Field, HttpUrl
@@ -66,6 +67,7 @@ class CreateModelEndpointV1Request(BaseModel):
     default_callback_url: Optional[HttpUrl]
     default_callback_auth: Optional[CallbackAuth]
     public_inference: Optional[bool] = Field(default=False)
+    shadow_endpoints: Optional[List[ShadowModelEndpointRecord]]
 
 
 class CreateModelEndpointV1Response(BaseModel):

--- a/model-engine/model_engine_server/common/dtos/model_endpoints.py
+++ b/model-engine/model_engine_server/common/dtos/model_endpoints.py
@@ -94,6 +94,7 @@ class UpdateModelEndpointV1Request(BaseModel):
     default_callback_url: Optional[HttpUrl]
     default_callback_auth: Optional[CallbackAuth]
     public_inference: Optional[bool]
+    shadow_endpoints: Optional[List[ShadowModelEndpointRecord]]
 
 
 class UpdateModelEndpointV1Response(BaseModel):

--- a/model-engine/model_engine_server/db/models/hosted_model_inference.py
+++ b/model-engine/model_engine_server/db/models/hosted_model_inference.py
@@ -453,6 +453,7 @@ class Endpoint(Base):
     current_bundle = relationship("Bundle")
     owner = Column(String(SHORT_STRING))
     public_inference = Column(Boolean, default=False)
+    shadow_endpoints_ids = Column(ARRAY(Text), default=[])
 
     def __init__(
         self,
@@ -467,6 +468,7 @@ class Endpoint(Base):
         endpoint_status: Optional[str] = "READY",  # EndpointStatus.ready.value
         owner: Optional[str] = None,
         public_inference: Optional[bool] = False,
+        shadow_endpoints_ids: Optional[List[str]] = None,
     ):
         self.id = f"end_{get_xid()}"
         self.name = name
@@ -479,6 +481,7 @@ class Endpoint(Base):
         self.endpoint_status = endpoint_status
         self.owner = owner
         self.public_inference = public_inference
+        self.shadow_endpoints_ids = shadow_endpoints_ids
 
     @classmethod
     async def create(cls, session: AsyncSession, endpoint: "Endpoint") -> None:
@@ -632,7 +635,9 @@ class BatchJob(Base):
     created_by = Column(String(SHORT_STRING), index=True, nullable=False)
     owner = Column(String(SHORT_STRING), index=True, nullable=False)
     model_bundle_id = Column(
-        Text, ForeignKey("hosted_model_inference.bundles.id", ondelete="SET NULL"), nullable=False
+        Text,
+        ForeignKey("hosted_model_inference.bundles.id", ondelete="SET NULL"),
+        nullable=False,
     )
     model_endpoint_id = Column(
         Text, ForeignKey("hosted_model_inference.endpoints.id"), nullable=True

--- a/model-engine/model_engine_server/domain/entities/__init__.py
+++ b/model-engine/model_engine_server/domain/entities/__init__.py
@@ -45,6 +45,7 @@ from .model_endpoint_entity import (
     ModelEndpointStatus,
     ModelEndpointType,
     ModelEndpointUserConfigState,
+    ShadowModelEndpointRecord,
 )
 from .owned_entity import OwnedEntity
 from .trigger_entity import Trigger
@@ -91,6 +92,7 @@ __all__: Sequence[str] = [
     "Quantization",
     "RunnableImageFlavor",
     "RunnableImageLike",
+    "ShadowModelEndpointRecord",
     "StorageSpecificationType",
     "StreamingEnhancedRunnableImageFlavor",
     "TensorflowFramework",

--- a/model-engine/model_engine_server/domain/entities/model_endpoint_entity.py
+++ b/model-engine/model_engine_server/domain/entities/model_endpoint_entity.py
@@ -150,3 +150,11 @@ class ModelEndpoint(BaseModel):
 
     record: ModelEndpointRecord
     infra_state: Optional[ModelEndpointInfraState]
+
+
+class ShadowModelEndpointRecord(BaseModel):
+    """
+    This is the entity-layer class for everything related to a Shadow Endpoint.
+    """
+
+    id: str

--- a/model-engine/model_engine_server/domain/entities/model_endpoint_entity.py
+++ b/model-engine/model_engine_server/domain/entities/model_endpoint_entity.py
@@ -122,6 +122,7 @@ class ModelEndpointRecord(OwnedEntity):
     current_model_bundle: ModelBundle
     owner: str
     public_inference: Optional[bool]
+    shadow_endpoints_ids: Optional[List[str]]
 
 
 class ModelEndpointInfraState(BaseModel):

--- a/model-engine/model_engine_server/domain/exceptions.py
+++ b/model-engine/model_engine_server/domain/exceptions.py
@@ -164,3 +164,9 @@ class TriggerNameAlreadyExistsException(DomainException):
     """
     Thrown if the requested name already exists in the trigger repository
     """
+
+
+class ShadowModelEndpointInvalidException(DomainException):
+    """
+    Thrown if the shadow endpoint model is invalid. Currently, this is thrown if the shadow endpoints don't exist.
+    """

--- a/model-engine/model_engine_server/domain/services/model_endpoint_service.py
+++ b/model-engine/model_engine_server/domain/services/model_endpoint_service.py
@@ -91,7 +91,7 @@ class ModelEndpointService(ABC):
         default_callback_url: Optional[str],
         default_callback_auth: Optional[CallbackAuth],
         public_inference: Optional[bool] = False,
-        shadow_endpoints: Optional[List[ShadowModelEndpointRecord]] = None,
+        shadow_endpoints: Optional[List[ShadowModelEndpointRecord]],
     ) -> ModelEndpointRecord:
         """
         Creates a model endpoint.

--- a/model-engine/model_engine_server/domain/services/model_endpoint_service.py
+++ b/model-engine/model_engine_server/domain/services/model_endpoint_service.py
@@ -222,6 +222,7 @@ class ModelEndpointService(ABC):
         default_callback_url: Optional[str] = None,
         default_callback_auth: Optional[CallbackAuth] = None,
         public_inference: Optional[bool] = None,
+        shadow_endpoints: Optional[List[ShadowModelEndpointRecord]] = None,
     ) -> ModelEndpointRecord:
         """
         Updates a model endpoint.
@@ -250,6 +251,8 @@ class ModelEndpointService(ABC):
             default_callback_url: The default callback URL to use for the model endpoint.
             default_callback_auth: The default callback auth to use for the model endpoint.
             public_inference: Whether to allow public inference.
+            shadow_endpoints: The shadow endpoints to deploy with the model endpoint.
+
         Returns:
             A Model Endpoint Record domain entity object of the updated endpoint.
         Raises:

--- a/model-engine/model_engine_server/domain/services/model_endpoint_service.py
+++ b/model-engine/model_engine_server/domain/services/model_endpoint_service.py
@@ -11,6 +11,7 @@ from model_engine_server.domain.entities import (
     ModelEndpointRecord,
     ModelEndpointsSchema,
     ModelEndpointType,
+    ShadowModelEndpointRecord,
     StorageSpecificationType,
 )
 from model_engine_server.domain.gateways import (
@@ -90,6 +91,7 @@ class ModelEndpointService(ABC):
         default_callback_url: Optional[str],
         default_callback_auth: Optional[CallbackAuth],
         public_inference: Optional[bool] = False,
+        shadow_endpoints: Optional[List[ShadowModelEndpointRecord]] = None,
     ) -> ModelEndpointRecord:
         """
         Creates a model endpoint.
@@ -123,6 +125,7 @@ class ModelEndpointService(ABC):
             default_callback_url: The default callback URL to use for the model endpoint.
             default_callback_auth: The default callback auth to use for the model endpoint.
             public_inference: Whether to allow public inference.
+            shadow_endpoints: The shadow endpoints to deploy with the model endpoint.
         Returns:
             A Model Endpoint Record domain entity object of the created endpoint.
         Raises:

--- a/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
+++ b/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
@@ -961,6 +961,7 @@ class CreateLLMModelEndpointV1UseCase:
             default_callback_url=request.default_callback_url,
             default_callback_auth=request.default_callback_auth,
             public_inference=request.public_inference,
+            shadow_endpoints=request.shadow_endpoints,
         )
         _handle_post_inference_hooks(
             created_by=user.user_id,

--- a/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
+++ b/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
@@ -80,6 +80,7 @@ from .model_endpoint_use_cases import (
     validate_deployment_resources,
     validate_labels,
     validate_post_inference_hooks,
+    validate_shadow_endpoints,
 )
 
 logger = make_logger(logger_name())
@@ -879,6 +880,7 @@ class CreateLLMModelEndpointV1UseCase:
         validate_model_name(request.model_name, request.inference_framework)
         validate_num_shards(request.num_shards, request.inference_framework, request.gpus)
         validate_quantization(request.quantize, request.inference_framework)
+        await validate_shadow_endpoints(self.model_endpoint_service, request.shadow_endpoints)
 
         if request.inference_framework in [
             LLMInferenceFramework.TEXT_GENERATION_INFERENCE,
@@ -1069,6 +1071,7 @@ class UpdateLLMModelEndpointV1UseCase:
             validate_labels(request.labels)
         validate_billing_tags(request.billing_tags)
         validate_post_inference_hooks(user, request.post_inference_hooks)
+        await validate_shadow_endpoints(self.model_endpoint_service, request.shadow_endpoints)
 
         model_endpoint = await self.llm_model_endpoint_service.get_llm_model_endpoint(
             model_endpoint_name
@@ -1190,6 +1193,7 @@ class UpdateLLMModelEndpointV1UseCase:
             default_callback_url=request.default_callback_url,
             default_callback_auth=request.default_callback_auth,
             public_inference=request.public_inference,
+            shadow_endpoints=request.shadow_endpoints,
         )
         _handle_post_inference_hooks(
             created_by=endpoint_record.created_by,

--- a/model-engine/model_engine_server/domain/use_cases/model_endpoint_use_cases.py
+++ b/model-engine/model_engine_server/domain/use_cases/model_endpoint_use_cases.py
@@ -403,6 +403,7 @@ class UpdateModelEndpointByIdV1UseCase:
             default_callback_url=request.default_callback_url,
             default_callback_auth=request.default_callback_auth,
             public_inference=request.public_inference,
+            shadow_endpoints=request.shadow_endpoints,
         )
         _handle_post_inference_hooks(
             created_by=endpoint_record.created_by,

--- a/model-engine/model_engine_server/domain/use_cases/model_endpoint_use_cases.py
+++ b/model-engine/model_engine_server/domain/use_cases/model_endpoint_use_cases.py
@@ -289,6 +289,7 @@ class CreateModelEndpointV1UseCase:
             default_callback_url=request.default_callback_url,
             default_callback_auth=request.default_callback_auth,
             public_inference=request.public_inference,
+            shadow_endpoints=request.shadow_endpoints,
         )
         _handle_post_inference_hooks(
             created_by=user.user_id,

--- a/model-engine/model_engine_server/infra/repositories/db_model_endpoint_record_repository.py
+++ b/model-engine/model_engine_server/infra/repositories/db_model_endpoint_record_repository.py
@@ -307,6 +307,7 @@ class DbModelEndpointRecordRepository(ModelEndpointRecordRepository, DbRepositor
         destination: Optional[str] = None,
         status: Optional[str] = None,
         public_inference: Optional[bool] = None,
+        shadow_endpoints_ids: Optional[List[str]] = None,
     ) -> Optional[ModelEndpointRecord]:
         async with self.session() as session:
             model_endpoint_orm = await OrmModelEndpoint.select_by_id(
@@ -326,6 +327,7 @@ class DbModelEndpointRecordRepository(ModelEndpointRecordRepository, DbRepositor
                 endpoint_status=status,
                 last_updated_at=datetime.utcnow(),
                 public_inference=public_inference,
+                shadow_endpoints_ids=shadow_endpoints_ids,
             )
             await OrmModelEndpoint.update_by_name_owner(
                 session=session,

--- a/model-engine/model_engine_server/infra/repositories/db_model_endpoint_record_repository.py
+++ b/model-engine/model_engine_server/infra/repositories/db_model_endpoint_record_repository.py
@@ -53,6 +53,7 @@ def translate_model_endpoint_orm_to_model_endpoint_record(
         status=model_endpoint_orm.endpoint_status,
         current_model_bundle=current_model_bundle,
         public_inference=model_endpoint_orm.public_inference,
+        shadow_endpoints_ids=model_endpoint_orm.shadow_endpoints_ids,
     )
 
 

--- a/model-engine/model_engine_server/infra/repositories/db_model_endpoint_record_repository.py
+++ b/model-engine/model_engine_server/infra/repositories/db_model_endpoint_record_repository.py
@@ -120,6 +120,7 @@ class DbModelEndpointRecordRepository(ModelEndpointRecordRepository, DbRepositor
         status: str,
         owner: str,
         public_inference: Optional[bool] = False,
+        shadow_endpoints_ids: Optional[List[str]] = None,  # list of ids
     ) -> ModelEndpointRecord:
         model_endpoint_record = OrmModelEndpoint(
             name=name,
@@ -132,6 +133,7 @@ class DbModelEndpointRecordRepository(ModelEndpointRecordRepository, DbRepositor
             endpoint_status=status,
             owner=owner,
             public_inference=public_inference,
+            shadow_endpoints_ids=shadow_endpoints_ids,
         )
         async with self.session() as session:
             await OrmModelEndpoint.create(session, model_endpoint_record)

--- a/model-engine/model_engine_server/infra/repositories/model_endpoint_record_repository.py
+++ b/model-engine/model_engine_server/infra/repositories/model_endpoint_record_repository.py
@@ -50,6 +50,7 @@ class ModelEndpointRecordRepository(ABC):
         status: str,
         owner: str,
         public_inference: Optional[bool] = False,
+        shadow_endpoints_ids: Optional[List[str]] = None,
     ) -> ModelEndpointRecord:
         """
         Creates an entry for endpoint tracking data, but not the actual compute resources.
@@ -66,6 +67,7 @@ class ModelEndpointRecordRepository(ABC):
                 used to coordinate edit operations on the endpoint
             owner: Team who owns endpoint
             public_inference: Whether the endpoint is publicly accessible
+            shadow_endpoints_ids: List of shadow endpoint ids
 
         Returns:
             A Model Endpoint Record domain entity.

--- a/model-engine/model_engine_server/infra/repositories/model_endpoint_record_repository.py
+++ b/model-engine/model_engine_server/infra/repositories/model_endpoint_record_repository.py
@@ -84,6 +84,7 @@ class ModelEndpointRecordRepository(ABC):
         destination: Optional[str] = None,
         status: Optional[str] = None,
         public_inference: Optional[bool] = None,
+        shadow_endpoints_ids: Optional[List[str]] = None,
     ) -> Optional[ModelEndpointRecord]:
         """
         Updates the entry for endpoint tracking data with the given new values. Only these values are editable.
@@ -96,6 +97,7 @@ class ModelEndpointRecordRepository(ABC):
             destination: The destination where async tasks should be sent.
             status: Status field on the endpoint, used to coordinate endpoint edit operations
             public_inference: Whether the endpoint is publicly accessible
+            shadow_endpoints_ids: List of shadow endpoint ids
 
         Returns:
             A Model Endpoint Record domain entity if found, else None.

--- a/model-engine/model_engine_server/infra/services/live_model_endpoint_service.py
+++ b/model-engine/model_engine_server/infra/services/live_model_endpoint_service.py
@@ -161,7 +161,7 @@ class LiveModelEndpointService(ModelEndpointService):
         default_callback_url: Optional[str] = None,
         default_callback_auth: Optional[CallbackAuth],
         public_inference: Optional[bool] = False,
-        shadow_endpoints: Optional[List[ShadowModelEndpointRecord]] = None,
+        shadow_endpoints: Optional[List[ShadowModelEndpointRecord]],
     ) -> ModelEndpointRecord:
         existing_endpoints = (
             await self.model_endpoint_record_repository.list_model_endpoint_records(

--- a/model-engine/model_engine_server/infra/services/live_model_endpoint_service.py
+++ b/model-engine/model_engine_server/infra/services/live_model_endpoint_service.py
@@ -14,6 +14,7 @@ from model_engine_server.domain.entities import (
     ModelEndpointsSchema,
     ModelEndpointStatus,
     ModelEndpointType,
+    ShadowModelEndpointRecord,
     StorageSpecificationType,
 )
 from model_engine_server.domain.exceptions import (
@@ -160,6 +161,7 @@ class LiveModelEndpointService(ModelEndpointService):
         default_callback_url: Optional[str] = None,
         default_callback_auth: Optional[CallbackAuth],
         public_inference: Optional[bool] = False,
+        shadow_endpoints: Optional[List[ShadowModelEndpointRecord]] = None,
     ) -> ModelEndpointRecord:
         existing_endpoints = (
             await self.model_endpoint_record_repository.list_model_endpoint_records(
@@ -181,6 +183,7 @@ class LiveModelEndpointService(ModelEndpointService):
                 status=ModelEndpointStatus.UPDATE_PENDING,
                 owner=owner,
                 public_inference=public_inference,
+                shadow_endpoints_ids=[shadow.id for shadow in shadow_endpoints or []],
             )
         )
         creation_task_id = self.model_endpoint_infra_gateway.create_model_endpoint_infra(

--- a/model-engine/model_engine_server/infra/services/live_model_endpoint_service.py
+++ b/model-engine/model_engine_server/infra/services/live_model_endpoint_service.py
@@ -286,6 +286,7 @@ class LiveModelEndpointService(ModelEndpointService):
         default_callback_url: Optional[str] = None,
         default_callback_auth: Optional[CallbackAuth] = None,
         public_inference: Optional[bool] = None,
+        shadow_endpoints: Optional[List[ShadowModelEndpointRecord]] = None,
     ) -> ModelEndpointRecord:
         record = await self.model_endpoint_record_repository.get_model_endpoint_record(
             model_endpoint_id=model_endpoint_id
@@ -325,6 +326,7 @@ class LiveModelEndpointService(ModelEndpointService):
                 metadata=metadata,
                 status=ModelEndpointStatus.UPDATE_PENDING,
                 public_inference=public_inference,
+                shadow_endpoints_ids=[shadow.id for shadow in shadow_endpoints or []],
             )
             if record is None:  # pragma: no cover
                 raise ObjectNotFoundException

--- a/model-engine/tests/unit/conftest.py
+++ b/model-engine/tests/unit/conftest.py
@@ -172,6 +172,7 @@ def _translate_fake_model_endpoint_orm_to_model_endpoint_record(
         destination="test_destination",
         status=ModelEndpointStatus(model_endpoint_orm.endpoint_status),
         current_model_bundle=current_model_bundle,
+        shadow_endpoints_ids=model_endpoint_orm.shadow_endpoints_ids,
     )
 
 
@@ -439,6 +440,7 @@ class FakeModelEndpointRecordRepository(ModelEndpointRecordRepository):
         status: str,
         owner: str,
         public_inference: Optional[bool] = False,
+        shadow_endpoints_ids: Optional[List[str]] = None,
     ) -> ModelEndpointRecord:
         orm_model_endpoint = OrmModelEndpoint(
             name=name,
@@ -451,6 +453,7 @@ class FakeModelEndpointRecordRepository(ModelEndpointRecordRepository):
             endpoint_status=status,
             owner=owner,
             public_inference=public_inference,
+            shadow_endpoints_ids=shadow_endpoints_ids,
         )
         orm_model_endpoint.created_at = datetime.now()
         orm_model_endpoint.last_updated_at = datetime.now()
@@ -475,6 +478,8 @@ class FakeModelEndpointRecordRepository(ModelEndpointRecordRepository):
             model_endpoint_record.creation_task_id = kwargs["creation_task_id"]
         if kwargs["status"] is not None:
             model_endpoint_record.status = kwargs["status"]
+        if kwargs["shadow_endpoints_ids"] is not None:
+            model_endpoint_record.shadow_endpoints_ids = kwargs["shadow_endpoints_ids"]
 
     async def update_model_endpoint_record(
         self,
@@ -486,6 +491,7 @@ class FakeModelEndpointRecordRepository(ModelEndpointRecordRepository):
         destination: Optional[str] = None,
         status: Optional[str] = None,
         public_inference: Optional[bool] = None,
+        shadow_endpoints_ids: Optional[List[str]] = None,
     ) -> Optional[ModelEndpointRecord]:
         model_endpoint_record = await self.get_model_endpoint_record(
             model_endpoint_id=model_endpoint_id


### PR DESCRIPTION
# Pull Request Summary

Allow adding shadow endpoints to endpoint creation/updating in API.
- Modify db schema
- Update LLM and model create/update endpoints to take in shadows

Follow-up PR:
- db migration

## Test Plan and Usage Guide

Finished unit tests:
- `test_model_endpoint_use_cases.py` for creation and updating
- `test_live_model_endpoint_service.py` for creation and updating

TODO unit tests:
- `test_db_model_endpoint_record_repository.py` for creating record with shadow endpoints
- `test_llm_use_cases.py` for creating and updating 

TODO: create shortcut tickets for shadow deployments