### PR TITLE
bump datadog module to 0.47.0

### DIFF
--- a/model-engine/model_engine_server/inference/requirements_base.txt
+++ b/model-engine/model_engine_server/inference/requirements_base.txt
@@ -2,7 +2,7 @@ aioredis~=2.0
 boto3>=1.28.38
 celery[redis,sqs,tblib]==5.3.1
 datadog-api-client==2.11.0
-datadog~=0.46.0
+datadog~=0.47.0
 fastapi==0.78.0
 # Incompatibility between celery 5 and python 3.7 because of importlib-metadata 5, so we pin it
 importlib-metadata<5.0;python_version<"3.8"

--- a/model-engine/requirements.in
+++ b/model-engine/requirements.in
@@ -14,7 +14,7 @@ cloudpickle==2.1.0
 croniter==1.4.1
 dataclasses-json>=0.5.7
 datadog-api-client==2.11.0
-datadog~=0.46.0
+datadog~=0.47.0
 ddtrace==1.8.3
 deprecation~=2.1
 docker~=5.0

--- a/model-engine/requirements.txt
+++ b/model-engine/requirements.txt
@@ -111,7 +111,7 @@ cryptography==41.0.3
     # via secretstorage
 dataclasses-json==0.5.9
     # via -r model-engine/requirements.in
-datadog==0.46.0
+datadog==0.47.0
     # via -r model-engine/requirements.in
 datadog-api-client==2.11.0
     # via -r model-engine/requirements.in


### PR DESCRIPTION
# Pull Request Summary

datadog v0.47.0 added support for ipv6 support of dogstatsd

## Test Plan and Usage Guide

local
