### PR TITLE
Allow using pydantic v2

### DIFF
--- a/clients/python/llmengine/__init__.py
+++ b/clients/python/llmengine/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.0.0b22"
+__version__ = "0.0.0b23"
 
 import os
 from typing import Sequence

--- a/clients/python/llmengine/data_types.py
+++ b/clients/python/llmengine/data_types.py
@@ -5,7 +5,12 @@ import datetime
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel, Field, HttpUrl
+import pydantic
+
+if int(pydantic.__version__.split(".")[0]) > 1:
+    from pydantic.v1 import BaseModel, Field, HttpUrl
+else:
+    from pydantic import BaseModel, Field, HttpUrl
 
 CpuSpecificationType = Union[str, int, float]
 StorageSpecificationType = Union[str, int, float]  # TODO(phil): we can make this more specific.

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scale-llm-engine"
-version = "0.0.0.beta22"
+version = "0.0.0.beta23"
 description = "Scale LLM Engine Python client"
 license = "Apache-2.0"
 authors = ["Phil Chen <phil.chen@scale.com>"]

--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -3,6 +3,6 @@ from setuptools import find_packages, setup
 setup(
     name="scale-llm-engine",
     python_requires=">=3.7",
-    version="0.0.0.beta22",
+    version="0.0.0.beta23",
     packages=find_packages(),
 )


### PR DESCRIPTION
# Pull Request Summary

Fixes a bug where importing the python client with pydantic 2 installed raises an error. Will publish to pypi after merging the PR.

## Test Plan and Usage Guide

Imported client with pydantic 1.10 or pydantic 2 installed, imports succeed.
