### PR TITLE
Pin boto3 and urllib3 versions to fix error in inference image

### DIFF
--- a/model-engine/model_engine_server/inference/requirements_base.txt
+++ b/model-engine/model_engine_server/inference/requirements_base.txt
@@ -1,5 +1,6 @@
 aioredis~=2.0
-boto3>=1.28.38
+urllib3~=1.26.13
+boto3~=1.34.33
 celery[redis,sqs,tblib]==5.3.1
 datadog-api-client==2.11.0
 datadog~=0.47.0


### PR DESCRIPTION
# Pull Request Summary

The model_engine_integration_tests are broken as is endpoint creation for endpoints where the user does not provide their own docker image. This is because our inference image does not pin some dependencies leading to this known issue with boto3 [here](https://github.com/boto/botocore/issues/3111). Thus we should pin to a safe version of urllib3 and boto3.

Notably, in the inference image generated right now, the following code crashes. We use the boto3 client when users request `return_picked=True`
```py
import boto3
s3_client = boto3.client("s3", region_name="us-west-2")
with open("/tmp/file.txt", 'rb') as f:
  s3_client.upload_fileobj(f, "temp-edwardgan-test", "tmp/file")
```

## Test Plan and Usage Guide
I manually confirmed that these changes to the requirements.txt allow the above code to work in the docker image used by our inference endpoint.

Also ran model integration tests in this PR in the models repo: https://github.com/scaleapi/models/pull/8786