### PR TITLE
Allow pydantic 2 in python client requested requirements

### DIFF
--- a/clients/python/llmengine/__init__.py
+++ b/clients/python/llmengine/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.0.0b23"
+__version__ = "0.0.0b24"
 
 import os
 from typing import Sequence

--- a/clients/python/llmengine/data_types.py
+++ b/clients/python/llmengine/data_types.py
@@ -10,7 +10,7 @@ import pydantic
 if int(pydantic.__version__.split(".")[0]) > 1:
     from pydantic.v1 import BaseModel, Field, HttpUrl
 else:
-    from pydantic import BaseModel, Field, HttpUrl
+    from pydantic import BaseModel, Field, HttpUrl  # type: ignore
 
 CpuSpecificationType = Union[str, int, float]
 StorageSpecificationType = Union[str, int, float]  # TODO(phil): we can make this more specific.

--- a/clients/python/llmengine/data_types.py
+++ b/clients/python/llmengine/data_types.py
@@ -163,17 +163,17 @@ class CreateLLMEndpointRequest(BaseModel):
     cpus: CpuSpecificationType
     gpus: int
     memory: StorageSpecificationType
-    gpu_type: GpuType
+    gpu_type: Optional[GpuType]
     storage: Optional[StorageSpecificationType]
-    optimize_costs: Optional[bool]
+    optimize_costs: Optional[bool] = None
     min_workers: int
     max_workers: int
     per_worker: int
     labels: Dict[str, str]
-    prewarm: Optional[bool]
+    prewarm: Optional[bool] = None
     high_priority: Optional[bool]
-    default_callback_url: Optional[HttpUrl]
-    default_callback_auth: Optional[CallbackAuth]
+    default_callback_url: Optional[HttpUrl] = None
+    default_callback_auth: Optional[CallbackAuth] = None
     public_inference: Optional[bool] = True
     """
     Whether the endpoint can be used for inference for all users. LLM endpoints are public by default.

--- a/clients/python/llmengine/model.py
+++ b/clients/python/llmengine/model.py
@@ -1,5 +1,12 @@
 from typing import Dict, List, Optional
 
+import pydantic
+
+if int(pydantic.__version__.split(".")[0]) > 1:
+    from pydantic.v1 import HttpUrl
+else:
+    from pydantic import HttpUrl  # type: ignore
+
 from llmengine.api_engine import DEFAULT_TIMEOUT, APIEngine, assert_self_hosted
 from llmengine.data_types import (
     CreateLLMEndpointRequest,
@@ -277,7 +284,7 @@ class Model(APIEngine):
             per_worker=per_worker,
             high_priority=high_priority,
             post_inference_hooks=post_inference_hooks_strs,
-            default_callback_url=default_callback_url,
+            default_callback_url=HttpUrl(default_callback_url),
             storage=storage,
             public_inference=public_inference,
         )

--- a/clients/python/llmengine/model.py
+++ b/clients/python/llmengine/model.py
@@ -1,12 +1,5 @@
 from typing import Dict, List, Optional
 
-import pydantic
-
-if int(pydantic.__version__.split(".")[0]) > 1:
-    from pydantic.v1 import HttpUrl
-else:
-    from pydantic import HttpUrl  # type: ignore
-
 from llmengine.api_engine import DEFAULT_TIMEOUT, APIEngine, assert_self_hosted
 from llmengine.data_types import (
     CreateLLMEndpointRequest,
@@ -284,7 +277,8 @@ class Model(APIEngine):
             per_worker=per_worker,
             high_priority=high_priority,
             post_inference_hooks=post_inference_hooks_strs,
-            default_callback_url=HttpUrl(default_callback_url),
+            # Pydantic automatically validates the url
+            default_callback_url=default_callback_url,  # type: ignore
             storage=storage,
             public_inference=public_inference,
         )

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scale-llm-engine"
-version = "0.0.0.beta23"
+version = "0.0.0.beta24"
 description = "Scale LLM Engine Python client"
 license = "Apache-2.0"
 authors = ["Phil Chen <phil.chen@scale.com>"]

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -13,7 +13,7 @@ packages = [{include = "llmengine"}]
 
 [tool.poetry.dependencies]
 python = "^3.7"
-pydantic = "^1.10"
+pydantic = ">=1.10"
 aiohttp = "^3.8"
 requests = "^2.31.0"
 

--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -3,6 +3,6 @@ from setuptools import find_packages, setup
 setup(
     name="scale-llm-engine",
     python_requires=">=3.7",
-    version="0.0.0.beta23",
+    version="0.0.0.beta24",
     packages=find_packages(),
 )


### PR DESCRIPTION
# Pull Request Summary

Previous pr allowed pydantic 2 to be compatible with the client, however we didn't update the requirements to note this.

## Test Plan and Usage Guide

Pip install -e and check which version of pydantic it asks for. It asks for `pydantic >= 1.10` which is correct.
