### PR TITLE
[Client] Add Auth headers to the python async routes

### DIFF
--- a/clients/python/llmengine/__init__.py
+++ b/clients/python/llmengine/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.0.0b24"
+__version__ = "0.0.0b25"
 
 import os
 from typing import Sequence

--- a/clients/python/llmengine/api_engine.py
+++ b/clients/python/llmengine/api_engine.py
@@ -8,7 +8,7 @@ from typing import Any, AsyncIterable, Dict, Iterator, Optional
 from urllib.parse import urljoin
 
 import requests
-from aiohttp import ClientSession, ClientTimeout
+from aiohttp import BasicAuth, ClientSession, ClientTimeout
 from llmengine.errors import parse_error
 
 SPELLBOOK_API_URL = "https://api.spellbook.scale.com/llm-engine/"
@@ -163,7 +163,9 @@ class APIEngine:
     ) -> Dict[str, Any]:
         api_key = get_api_key()
         async with ClientSession(
-            timeout=ClientTimeout(timeout), headers={"x-api-key": api_key}
+            timeout=ClientTimeout(timeout),
+            headers={"x-api-key": api_key},
+            auth=BasicAuth(api_key, ""),
         ) as session:
             async with session.post(
                 urljoin(LLM_ENGINE_BASE_PATH, resource_name), json=data
@@ -179,7 +181,9 @@ class APIEngine:
     ) -> AsyncIterable[Dict[str, Any]]:
         api_key = get_api_key()
         async with ClientSession(
-            timeout=ClientTimeout(timeout), headers={"x-api-key": api_key}
+            timeout=ClientTimeout(timeout),
+            headers={"x-api-key": api_key},
+            auth=BasicAuth(api_key, ""),
         ) as session:
             async with session.post(
                 urljoin(LLM_ENGINE_BASE_PATH, resource_name), json=data

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scale-llm-engine"
-version = "0.0.0.beta24"
+version = "0.0.0.beta25"
 description = "Scale LLM Engine Python client"
 license = "Apache-2.0"
 authors = ["Phil Chen <phil.chen@scale.com>"]

--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -3,6 +3,6 @@ from setuptools import find_packages, setup
 setup(
     name="scale-llm-engine",
     python_requires=">=3.7",
-    version="0.0.0.beta24",
+    version="0.0.0.beta25",
     packages=find_packages(),
 )


### PR DESCRIPTION
# Pull Request Summary

Add Basic Auth headers when people use the client's python async routes

## Test Plan and Usage Guide

Setting `LLM_ENGINE_BASE_PATH` to a self-hosted LLM Engine:

```
import asyncio
from llmengine import Completion
asyncio.run(Completion.acreate(model='llama-2-7b-chat', prompt='prompt'))
```

works. Without the change, we get 

```
<stack trace>
llmengine.errors.UnauthorizedError: No authentication was passed in
```
