### PR TITLE
include stop string in completions output

### DIFF
--- a/model-engine/model_engine_server/common/dtos/llms.py
+++ b/model-engine/model_engine_server/common/dtos/llms.py
@@ -180,6 +180,10 @@ class CompletionSyncV1Request(BaseModel):
     """
     Controls the cumulative probability of the top tokens to consider. 1.0 means consider all tokens.
     """
+    include_stop_str_in_output: Optional[bool] = None
+    """
+    Whether to include the stop strings in output text.
+    """
 
 
 class TokenOutput(BaseModel):
@@ -239,6 +243,10 @@ class CompletionStreamV1Request(BaseModel):
     top_p: Optional[float] = Field(default=None, gt=0.0, le=1.0)
     """
     Controls the cumulative probability of the top tokens to consider. 1.0 means consider all tokens.
+    """
+    include_stop_str_in_output: Optional[bool] = None
+    """
+    Whether to include the stop strings in output text.
     """
 
 

--- a/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
+++ b/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
@@ -1349,6 +1349,15 @@ def validate_and_update_completion_params(
                 "return_token_log_probs is only supported in deepspeed, text-generation-inference, vllm, lightllm."
             )
 
+    # include_stop_str_in_output
+    if inference_framework == LLMInferenceFramework.VLLM:
+        pass
+    else:
+        if request.include_stop_str_in_output is not None:
+            raise ObjectHasInvalidValueException(
+                "include_stop_str_in_output is only supported in vllm."
+            )
+
     return request
 
 
@@ -1634,6 +1643,8 @@ class CompletionSyncV1UseCase:
                 vllm_args["top_p"] = request.top_p
             if request.return_token_log_probs:
                 vllm_args["logprobs"] = 1
+            if request.include_stop_str_in_output is not None:
+                vllm_args["include_stop_str_in_output"] = request.include_stop_str_in_output
 
             inference_request = SyncEndpointPredictV1Request(
                 args=vllm_args,
@@ -1888,6 +1899,8 @@ class CompletionStreamV1UseCase:
                 args["top_p"] = request.top_p
             if request.return_token_log_probs:
                 args["logprobs"] = 1
+            if request.include_stop_str_in_output is not None:
+                args["include_stop_str_in_output"] = request.include_stop_str_in_output
             args["stream"] = True
         elif model_content.inference_framework == LLMInferenceFramework.LIGHTLLM:
             args = {


### PR DESCRIPTION
# Pull Request Summary

Bring over flag added in https://github.com/vllm-project/vllm/pull/1976 to llm engine

## Test Plan and Usage Guide

test locally
without the flag:
```
> curl -H "Content-Type: application/json" -H "Authorization: Basic <AUTH>" -d '{ "prompt": "Whats 2+2? ", "stop_sequences": ["\n"], "max_new_tokens": 10, "temperature": 0.1 }' http://localhost:5000/v1/llm/completions-sync?model_endpoint_name=llama-7b-vllm-test-temp
{"request_id":"907c759f-e704-4d32-98a5-4dbe388ec04a","output":{"text":"4.","num_prompt_tokens":9,"num_completion_tokens":3,"tokens":null}}
```
note: `"4."` above

with the flag:
```
> curl -H "Content-Type: application/json" -H "Authorization: Basic <AUTH>" -d '{ "prompt": "Whats 2+2? ", "stop_sequences": ["\n"], "max_new_tokens": 10, "temperature": 0.1, "include_stop_str_in_output": true }' http://localhost:5000/v1/llm/completions-sync?model_endpoint_name=llama-7b-vllm-test-temp
{"request_id":"7f465cd7-8d42-4470-96ab-6b8cdfb2b5b0","output":{"text":"4.\n","num_prompt_tokens":9,"num_completion_tokens":3,"tokens":null}}
```
note: `"4.\n"` above