### PR TITLE
Add product label validation

### DIFF
--- a/model-engine/model_engine_server/domain/use_cases/model_endpoint_use_cases.py
+++ b/model-engine/model_engine_server/domain/use_cases/model_endpoint_use_cases.py
@@ -47,6 +47,8 @@ from model_engine_server.domain.services import ModelEndpointService
 CONVERTED_FROM_ARTIFACT_LIKE_KEY = "_CONVERTED_FROM_ARTIFACT_LIKE"
 MODEL_BUNDLE_CHANGED_KEY = "_MODEL_BUNDLE_CHANGED"
 
+DEFAULT_DISALLOWED_TEAMS = ["_INVALID_TEAM"]
+
 logger = make_logger(logger_name())
 
 
@@ -127,7 +129,7 @@ class ValidationResult:
 
 # Placeholder team and product label validator that only checks for a single invalid team
 def simple_team_product_validator(team: str, product: str) -> ValidationResult:
-    if team == "INVALID_TEAM":
+    if team in DEFAULT_DISALLOWED_TEAMS:
         return ValidationResult(False, "Invalid team")
     else:
         return ValidationResult(True, "Valid team")

--- a/model-engine/model_engine_server/domain/use_cases/model_endpoint_use_cases.py
+++ b/model-engine/model_engine_server/domain/use_cases/model_endpoint_use_cases.py
@@ -134,9 +134,7 @@ def validate_labels(labels: Dict[str, str]) -> None:
             validate_team_product_label,
         )
 
-        validation_result = validate_team_product_label(
-            labels["team"], labels["product"]
-        )
+        validation_result = validate_team_product_label(labels["team"], labels["product"])
         if not validation_result.passed:
             raise EndpointLabelsException(validation_result.message)
     except ModuleNotFoundError:

--- a/model-engine/model_engine_server/domain/use_cases/model_endpoint_use_cases.py
+++ b/model-engine/model_engine_server/domain/use_cases/model_endpoint_use_cases.py
@@ -130,11 +130,15 @@ def validate_labels(labels: Dict[str, str]) -> None:
             raise EndpointLabelsException(f"Cannot specify '{restricted_label}' in labels")
 
     try:
-        from plugins.known_users import ALLOWED_TEAMS
+        from shared_plugins.team_product_label_validation import (
+            validate_team_product_label,
+        )
 
-        # Make sure that the team is one of the values from a canonical set.
-        if labels["team"] not in ALLOWED_TEAMS:
-            raise EndpointLabelsException(f"Invalid team label, must be one of: {ALLOWED_TEAMS}")
+        validation_result = validate_team_product_label(
+            labels["team"], labels["product"]
+        )
+        if not validation_result.passed:
+            raise EndpointLabelsException(validation_result.message)
     except ModuleNotFoundError:
         pass
 

--- a/model-engine/model_engine_server/domain/use_cases/model_endpoint_use_cases.py
+++ b/model-engine/model_engine_server/domain/use_cases/model_endpoint_use_cases.py
@@ -4,8 +4,8 @@ List model endpoint history: GET model-endpoints/<endpoint id>/history
 Read model endpoint creation logs: GET model-endpoints/<endpoint id>/creation-logs
 """
 
-from dataclasses import dataclass
 import re
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 from model_engine_server.common.constants import SUPPORTED_POST_INFERENCE_HOOKS
@@ -124,12 +124,14 @@ class ValidationResult:
     passed: bool
     message: str
 
+
 # Placeholder team and product label validator that only checks for a single invalid team
 def simple_team_product_validator(team: str, product: str) -> ValidationResult:
     if team == "INVALID_TEAM":
         return ValidationResult(False, "Invalid team")
     else:
         return ValidationResult(True, "Valid team")
+
 
 def validate_labels(labels: Dict[str, str]) -> None:
     for required_label in REQUIRED_ENDPOINT_LABELS:

--- a/model-engine/model_engine_server/domain/use_cases/model_endpoint_use_cases.py
+++ b/model-engine/model_engine_server/domain/use_cases/model_endpoint_use_cases.py
@@ -144,6 +144,16 @@ def validate_labels(labels: Dict[str, str]) -> None:
         if restricted_label in labels:
             raise EndpointLabelsException(f"Cannot specify '{restricted_label}' in labels")
 
+    # TODO: remove after we fully migrate to the new team + product validator
+    try:
+        from plugins.known_users import ALLOWED_TEAMS
+
+        # Make sure that the team is one of the values from a canonical set.
+        if labels["team"] not in ALLOWED_TEAMS:
+            raise EndpointLabelsException(f"Invalid team label, must be one of: {ALLOWED_TEAMS}")
+    except ModuleNotFoundError:
+        pass
+
     try:
         from shared_plugins.team_product_label_validation import validate_team_product_label
     except ModuleNotFoundError:

--- a/model-engine/model_engine_server/domain/use_cases/model_endpoint_use_cases.py
+++ b/model-engine/model_engine_server/domain/use_cases/model_endpoint_use_cases.py
@@ -124,6 +124,7 @@ class ValidationResult:
     passed: bool
     message: str
 
+# Placeholder team and product label validator that only checks for a single invalid team
 def simple_team_product_validator(team: str, product: str) -> ValidationResult:
     if team == "INVALID_TEAM":
         return ValidationResult(False, "Invalid team")

--- a/model-engine/tests/unit/api/test_model_endpoints.py
+++ b/model-engine/tests/unit/api/test_model_endpoints.py
@@ -394,7 +394,6 @@ def test_update_model_endpoint_by_id_success(
     assert response.json()["endpoint_creation_task_id"]
 
 
-@pytest.mark.skip(reason="TODO: team validation is currently disabled")
 def test_update_model_endpoint_by_id_invalid_team_returns_400(
     model_bundle_1_v1: Tuple[ModelBundle, Any],
     model_endpoint_1: Tuple[ModelEndpoint, Any],
@@ -418,8 +417,9 @@ def test_update_model_endpoint_by_id_invalid_team_returns_400(
         fake_batch_job_progress_gateway_contents={},
         fake_docker_image_batch_job_bundle_repository_contents={},
     )
+    invalid_team_name = "INVALID_TEAM"
     update_model_endpoint_request["labels"] = {
-        "team": "some_invalid_team",
+        "team": invalid_team_name,
         "product": "my_product",
     }
     response = client.put(

--- a/model-engine/tests/unit/api/test_model_endpoints.py
+++ b/model-engine/tests/unit/api/test_model_endpoints.py
@@ -40,7 +40,6 @@ def test_create_model_endpoint_success(
     assert response_2.status_code == 200
 
 
-@pytest.mark.skip(reason="TODO: team validation is currently disabled")
 def test_create_model_endpoint_invalid_team_returns_400(
     model_bundle_1_v1: Tuple[ModelBundle, Any],
     create_model_endpoint_request_sync: Dict[str, Any],
@@ -59,7 +58,8 @@ def test_create_model_endpoint_invalid_team_returns_400(
         fake_batch_job_progress_gateway_contents={},
         fake_docker_image_batch_job_bundle_repository_contents={},
     )
-    create_model_endpoint_request_sync["labels"]["team"] = "some_invalid_team"
+    invalid_team_name = "INVALID_TEAM"
+    create_model_endpoint_request_sync["labels"]["team"] = invalid_team_name
     response_1 = client.post(
         "/v1/model-endpoints",
         auth=(test_api_key, ""),
@@ -67,7 +67,7 @@ def test_create_model_endpoint_invalid_team_returns_400(
     )
     assert response_1.status_code == 400
 
-    create_model_endpoint_request_async["labels"]["team"] = "some_invalid_team"
+    create_model_endpoint_request_async["labels"]["team"] = invalid_team_name
     response_2 = client.post(
         "/v1/model-endpoints",
         auth=(test_api_key, ""),

--- a/model-engine/tests/unit/api/test_model_endpoints.py
+++ b/model-engine/tests/unit/api/test_model_endpoints.py
@@ -5,6 +5,7 @@ import pytest
 from fastapi.testclient import TestClient
 from model_engine_server.common.dtos.model_endpoints import GetModelEndpointV1Response
 from model_engine_server.domain.entities import ModelBundle, ModelEndpoint, ModelEndpointStatus
+from model_engine_server.domain.use_cases.model_endpoint_use_cases import DEFAULT_DISALLOWED_TEAMS
 
 
 def test_create_model_endpoint_success(
@@ -58,7 +59,7 @@ def test_create_model_endpoint_invalid_team_returns_400(
         fake_batch_job_progress_gateway_contents={},
         fake_docker_image_batch_job_bundle_repository_contents={},
     )
-    invalid_team_name = "INVALID_TEAM"
+    invalid_team_name = DEFAULT_DISALLOWED_TEAMS[0]
     create_model_endpoint_request_sync["labels"]["team"] = invalid_team_name
     response_1 = client.post(
         "/v1/model-endpoints",
@@ -417,7 +418,7 @@ def test_update_model_endpoint_by_id_invalid_team_returns_400(
         fake_batch_job_progress_gateway_contents={},
         fake_docker_image_batch_job_bundle_repository_contents={},
     )
-    invalid_team_name = "INVALID_TEAM"
+    invalid_team_name = DEFAULT_DISALLOWED_TEAMS[0]
     update_model_endpoint_request["labels"] = {
         "team": invalid_team_name,
         "product": "my_product",


### PR DESCRIPTION
# Pull Request Summary

This generalizes the logic in llm engine to look for a plugin that can validate both team and product. The goal is to be able to support conventions where the set of products allowed depends on the team label, like the one here [doc](https://docs.google.com/document/d/1CXDMeEWkdSvK32HuUn1-rdm_jnNFuvCpeRCEzKVCvbQ/edit) using a shared plugin between launch and train. 

We keep the old code for just checking the team using a plugin around even though it will no longer be necessary so that llm-engine code is backwards compatible with deployments that are not yet using the new extended plugin.

## Test Plan and Usage Guide

CI. Manual testing with internal code in https://github.com/scaleapi/models/pull/8924 .
Also note that this PR re-enables some API tests that attempt to create endpoints with invalid team labels.

[SC-812003]