### PR TITLE
Change cache update time for async endpoint integration test

### DIFF
--- a/integration_tests/test_endpoints.py
+++ b/integration_tests/test_endpoints.py
@@ -94,7 +94,7 @@ def test_async_model_endpoint(
                 user,
             )
             # Let the cache update
-            time.sleep(30)
+            time.sleep(60)
             # Endpoint builds should be cached now.
             ensure_n_ready_endpoints_short(1, user)
 


### PR DESCRIPTION
# Pull Request Summary

I run into this almost every time I deploy to prod where the cache requires more time to update the resource state of the endpoint for the `test_async_model_endpoint` integration test.

## Test Plan and Usage Guide

_How did you validate that your PR works correctly? How do you run or demo the code? Provide enough detail so a reviewer can reasonably reproduce the testing procedure. Paste example command line invocations if applicable._
