### PR TITLE
[Client] Add num_prompt_tokens to the client's CompletionOutputs

### DIFF
--- a/clients/python/llmengine/__init__.py
+++ b/clients/python/llmengine/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.0.0b26"
+__version__ = "0.0.0b27"
 
 import os
 from typing import Sequence

--- a/clients/python/llmengine/data_types.py
+++ b/clients/python/llmengine/data_types.py
@@ -306,7 +306,10 @@ class CompletionOutput(BaseModel):
     text: str
     """The text of the completion."""
 
+    # We're not guaranteed to have `num_prompt_tokens` in the response in all cases, so to be safe, set a default.
+    # If we send request to api.spellbook.scale.com, we don't get this back.
     num_prompt_tokens: Optional[int] = None
+    """Number of tokens in the prompt."""
 
     num_completion_tokens: int
     """Number of tokens in the completion."""
@@ -357,7 +360,9 @@ class CompletionStreamOutput(BaseModel):
     finished: bool
     """Whether the completion is finished."""
 
+    # We're not guaranteed to have `num_prompt_tokens` in the response in all cases, so to be safe, set a default.
     num_prompt_tokens: Optional[int] = None
+    """Number of tokens in the prompt."""
 
     num_completion_tokens: Optional[int] = None
     """Number of tokens in the completion."""

--- a/clients/python/llmengine/data_types.py
+++ b/clients/python/llmengine/data_types.py
@@ -279,6 +279,7 @@ class CompletionSyncV1Request(BaseModel):
     frequency_penalty: Optional[float] = Field(default=None, ge=0.0, le=2.0)
     top_k: Optional[int] = Field(default=None, ge=-1)
     top_p: Optional[float] = Field(default=None, gt=0.0, le=1.0)
+    # include_stop_str_in_output: Optional[bool] = Field(default=None)  # TODO
 
 
 class TokenOutput(BaseModel):
@@ -304,6 +305,8 @@ class CompletionOutput(BaseModel):
 
     text: str
     """The text of the completion."""
+
+    num_prompt_tokens: Optional[int] = None
 
     num_completion_tokens: int
     """Number of tokens in the completion."""
@@ -344,6 +347,7 @@ class CompletionStreamV1Request(BaseModel):
     frequency_penalty: Optional[float] = Field(default=None, ge=0.0, le=2.0)
     top_k: Optional[int] = Field(default=None, ge=-1)
     top_p: Optional[float] = Field(default=None, gt=0.0, le=1.0)
+    # include_stop_str_in_output: Optional[bool] = Field(default=None)  # TODO
 
 
 class CompletionStreamOutput(BaseModel):
@@ -352,6 +356,8 @@ class CompletionStreamOutput(BaseModel):
 
     finished: bool
     """Whether the completion is finished."""
+
+    num_prompt_tokens: Optional[int] = None
 
     num_completion_tokens: Optional[int] = None
     """Number of tokens in the completion."""

--- a/clients/python/llmengine/data_types.py
+++ b/clients/python/llmengine/data_types.py
@@ -279,7 +279,6 @@ class CompletionSyncV1Request(BaseModel):
     frequency_penalty: Optional[float] = Field(default=None, ge=0.0, le=2.0)
     top_k: Optional[int] = Field(default=None, ge=-1)
     top_p: Optional[float] = Field(default=None, gt=0.0, le=1.0)
-    # include_stop_str_in_output: Optional[bool] = Field(default=None)  # TODO
 
 
 class TokenOutput(BaseModel):
@@ -350,7 +349,6 @@ class CompletionStreamV1Request(BaseModel):
     frequency_penalty: Optional[float] = Field(default=None, ge=0.0, le=2.0)
     top_k: Optional[int] = Field(default=None, ge=-1)
     top_p: Optional[float] = Field(default=None, gt=0.0, le=1.0)
-    # include_stop_str_in_output: Optional[bool] = Field(default=None)  # TODO
 
 
 class CompletionStreamOutput(BaseModel):

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scale-llm-engine"
-version = "0.0.0.beta26"
+version = "0.0.0.beta27"
 description = "Scale LLM Engine Python client"
 license = "Apache-2.0"
 authors = ["Phil Chen <phil.chen@scale.com>"]

--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -3,6 +3,6 @@ from setuptools import find_packages, setup
 setup(
     name="scale-llm-engine",
     python_requires=">=3.7",
-    version="0.0.0.beta26",
+    version="0.0.0.beta27",
     packages=find_packages(),
 )


### PR DESCRIPTION
# Pull Request Summary

Add a quick `num_prompt_tokens` field to the client's CompletionOutput/CompletionStreamOutput.

Originally wanted to add `include_stop_str_in_output`, but that requires various server changes to get functional, so I didn't include it here.

## Test Plan and Usage Guide

Ran against Scale public APIs plus a hosted version. `num_prompt_tokens` exists if it's in the http response.
