### PR TITLE
Downgrade sse-starlette version

### DIFF
--- a/model-engine/requirements.in
+++ b/model-engine/requirements.in
@@ -47,7 +47,7 @@ sentencepiece==0.1.99
 sh~=1.13
 smart-open~=5.2
 sqlalchemy[asyncio]~=2.0.4
-sse-starlette==1.8.2
+sse-starlette==1.6.1
 sseclient-py==1.7.2
 starlette[full]>=0.36.2 # not used directly, but needs to be pinned for Microsoft security scan
 stringcase==1.2.0

--- a/model-engine/requirements.txt
+++ b/model-engine/requirements.txt
@@ -22,7 +22,6 @@ anyio==3.7.1
     # via
     #   azure-core
     #   httpx
-    #   sse-starlette
     #   starlette
 asgiref==3.7.2
     # via uvicorn
@@ -161,9 +160,7 @@ exceptiongroup==1.2.0
     #   anyio
     #   cattrs
 fastapi==0.110.0
-    # via
-    #   -r model-engine/requirements.in
-    #   sse-starlette
+    # via -r model-engine/requirements.in
 filelock==3.13.1
     # via
     #   huggingface-hub
@@ -475,7 +472,7 @@ sqlalchemy[asyncio]==2.0.4
     # via
     #   -r model-engine/requirements.in
     #   alembic
-sse-starlette==1.8.2
+sse-starlette==1.6.1
     # via -r model-engine/requirements.in
 sseclient-py==1.7.2
     # via -r model-engine/requirements.in
@@ -567,9 +564,7 @@ urllib3==1.26.16
     #   kubernetes-asyncio
     #   requests
 uvicorn==0.17.6
-    # via
-    #   -r model-engine/requirements.in
-    #   sse-starlette
+    # via -r model-engine/requirements.in
 uvloop==0.17.0
     # via -r model-engine/requirements.in
 vine==5.1.0


### PR DESCRIPTION
# Pull Request Summary

The updated version has weird behavior with streaming in the http-forwarder (tokens getting streamed back were batched so time to first token was very long; we expect to get tokens back at a steady rate instead)

I tried sse-starlette version 1.8.2 to see if it was the major version bump (1.8.2 -> 2.0.0) that broke things, but 1.8.2 still had the weird behavior, so downgrading to the original version of 1.6.1 from before the security scan updates

Should still be fine with security scan

## Test Plan and Usage Guide

Tested that using this image for the HTTP forwarder of a Llama 2 endpoint in the training cluster fixes the oncall issue of streaming time to first token being long (via curling localhost:5000 from the HTTP forwarder)
