### PR TITLE
Return 400 for botocore client errors

### DIFF
--- a/model-engine/model_engine_server/api/tasks_v1.py
+++ b/model-engine/model_engine_server/api/tasks_v1.py
@@ -18,6 +18,7 @@ from model_engine_server.core.auth.authentication_repository import User
 from model_engine_server.core.loggers import logger_name, make_logger
 from model_engine_server.domain.exceptions import (
     EndpointUnsupportedInferenceTypeException,
+    InvalidRequestException,
     ObjectNotAuthorizedException,
     ObjectNotFoundException,
     UpstreamServiceError,
@@ -65,6 +66,11 @@ async def create_async_inference_task(
         raise HTTPException(
             status_code=400,
             detail=f"Unsupported inference type: {str(exc)}",
+        ) from exc
+    except InvalidRequestException as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid request: {str(exc)}",
         ) from exc
 
 


### PR DESCRIPTION
# Pull Request Summary

Return 400 for some client errors

## Test Plan and Usage Guide

tested calling an endpoint with long message and received:
`<Response [400]>`
```
{"detail":"Invalid request: Error sending celery task: An error occurred (InvalidParameterValue) when calling the SendMessage operation: One or more parameters are invalid. Reason: Message must be shorter than 262144 bytes."}
```