### PR TITLE
Increase Kaniko Memory

### DIFF
--- a/model-engine/model_engine_server/core/docker/kaniko_template.yaml
+++ b/model-engine/model_engine_server/core/docker/kaniko_template.yaml
@@ -39,6 +39,7 @@ spec:
             - "--use-new-run"
             - "--image-fs-extract-retry=5"
             - "--log-format=json"
+            - "--push-retry=2"
           # The --use-new-run flag should fix docker builds eating up a lot of memory and consequently oom/failing
           env:
             - name: AWS_REGION

--- a/model-engine/model_engine_server/core/docker/kaniko_template.yaml
+++ b/model-engine/model_engine_server/core/docker/kaniko_template.yaml
@@ -51,11 +51,11 @@ spec:
           resources:
             requests:
               cpu: 3.5
-              memory: 30Gi
+              memory: 90Gi
               ephemeral-storage: 80G
             limits:
               cpu: 3.5
-              memory: 30Gi
+              memory: 90Gi
               ephemeral-storage: 80G
       volumes:
         - name: pipconf


### PR DESCRIPTION
# Pull Request Summary

- increase kaniko job memory to 90Gi
- also add push retries in case that step fails

## Test Plan and Usage Guide

tested on job