### PR TITLE
fix return_token_log_probs on vLLM > 0.3.3 endpoints

### DIFF
--- a/model-engine/model_engine_server/inference/batch_inference/vllm_batch.py
+++ b/model-engine/model_engine_server/inference/batch_inference/vllm_batch.py
@@ -409,11 +409,6 @@ async def generate_with_vllm(
 ) -> List[CompletionOutput]:  # pragma: no cover
     from vllm import SamplingParams
 
-    try:
-        from vllm.sequence import Logprob
-    except ImportError:
-        Logprob = None
-
     metrics_gateway = DatadogInferenceMonitoringMetricsGateway()
 
     # Add the requests to the engine.
@@ -445,8 +440,6 @@ async def generate_with_vllm(
 
             token_text = request_output.outputs[-1].text[len(last_output_text) :]
             log_probs = request_output.outputs[0].logprobs[-1] if return_token_log_probs else None
-            if log_probs is not None and Logprob is not None:  # post vLLM >= 0.3.4
-                log_probs = log_probs.logprob
 
             if return_token_log_probs:
                 tokens.append(

--- a/model-engine/model_engine_server/inference/batch_inference/vllm_batch.py
+++ b/model-engine/model_engine_server/inference/batch_inference/vllm_batch.py
@@ -440,6 +440,7 @@ async def generate_with_vllm(
 
             token_text = request_output.outputs[-1].text[len(last_output_text) :]
             log_probs = request_output.outputs[0].logprobs[-1] if return_token_log_probs else None
+            last_output_text = request_output.outputs[-1].text
 
             if return_token_log_probs:
                 tokens.append(

--- a/model-engine/model_engine_server/inference/batch_inference/vllm_batch.py
+++ b/model-engine/model_engine_server/inference/batch_inference/vllm_batch.py
@@ -409,6 +409,11 @@ async def generate_with_vllm(
 ) -> List[CompletionOutput]:  # pragma: no cover
     from vllm import SamplingParams
 
+    try:
+        from vllm.sequence import Logprob
+    except ImportError:
+        Logprob = None
+
     metrics_gateway = DatadogInferenceMonitoringMetricsGateway()
 
     # Add the requests to the engine.
@@ -440,7 +445,8 @@ async def generate_with_vllm(
 
             token_text = request_output.outputs[-1].text[len(last_output_text) :]
             log_probs = request_output.outputs[0].logprobs[-1] if return_token_log_probs else None
-            last_output_text = request_output.outputs[-1].text
+            if log_probs is not None and Logprob is not None:  # post vLLM >= 0.3.4
+                log_probs = log_probs.logprob
 
             if return_token_log_probs:
                 tokens.append(

--- a/model-engine/model_engine_server/inference/vllm/requirements.txt
+++ b/model-engine/model_engine_server/inference/vllm/requirements.txt
@@ -1,2 +1,2 @@
-vllm==0.3.3
+vllm==0.4.0.post1
 pydantic>=2.0

--- a/model-engine/model_engine_server/inference/vllm/vllm_server.py
+++ b/model-engine/model_engine_server/inference/vllm/vllm_server.py
@@ -4,7 +4,7 @@ import json
 import signal
 import subprocess
 import traceback
-from typing import AsyncGenerator
+from typing import AsyncGenerator, Dict, List, Optional
 
 import uvicorn
 from fastapi import BackgroundTasks, FastAPI, HTTPException, Request
@@ -13,14 +13,10 @@ from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.async_llm_engine import AsyncLLMEngine
 from vllm.entrypoints.openai.protocol import CompletionRequest as OpenAICompletionRequest
 from vllm.model_executor.guided_decoding import get_guided_decoding_logits_processor
+from vllm.outputs import CompletionOutput
 from vllm.sampling_params import SamplingParams
+from vllm.sequence import Logprob
 from vllm.utils import random_uuid
-
-try:
-    from vllm.sequence import Logprob
-except ImportError:
-    Logprob = None
-
 
 TIMEOUT_KEEP_ALIVE = 5  # seconds.
 TIMEOUT_TO_PREVENT_DEADLOCK = 1  # seconds
@@ -82,17 +78,14 @@ async def generate(request: Request) -> Response:
     async def stream_results() -> AsyncGenerator[str, None]:
         last_output_text = ""
         async for request_output in results_generator:
+            log_probs = format_logprobs(request_output)
             ret = {
                 "text": request_output.outputs[-1].text[len(last_output_text) :],
                 "count_prompt_tokens": len(request_output.prompt_token_ids),
                 "count_output_tokens": len(request_output.outputs[0].token_ids),
-                "log_probs": (
-                    request_output.outputs[0].logprobs[-1] if sampling_params.logprobs else None
-                ),
+                "log_probs": log_probs[-1] if log_probs and sampling_params.logprobs else None,
                 "finished": request_output.finished,
             }
-            if ret["log_probs"] is not None and Logprob is not None:  # post vLLM >= 0.3.4
-                ret["log_probs"] = [log_probs.logprob for log_probs in ret["log_probs"]]
             last_output_text = request_output.outputs[-1].text
             yield f"data:{json.dumps(ret)}\n\n"
 
@@ -124,11 +117,9 @@ async def generate(request: Request) -> Response:
         "text": final_output.outputs[0].text,
         "count_prompt_tokens": len(final_output.prompt_token_ids),
         "count_output_tokens": len(final_output.outputs[0].token_ids),
-        "log_probs": final_output.outputs[0].logprobs,
+        "log_probs": format_logprobs(final_output),
         "tokens": tokens,
     }
-    if ret["log_probs"] is not None and Logprob is not None:  # post vLLM >= 0.3.4
-        ret["log_probs"] = [log_probs.logprob for log_probs in ret["log_probs"]]
     return Response(content=json.dumps(ret))
 
 
@@ -174,6 +165,18 @@ def debug(sig, frame):
     message = "Signal received : entering python shell.\nTraceback:\n"
     message += "".join(traceback.format_stack(frame))
     i.interact(message)
+
+
+def format_logprobs(request_output: CompletionOutput) -> Optional[List[Dict[int, float]]]:
+    """Given a request output, format the logprobs if they exist."""
+    output_logprobs = request_output.outputs[0].logprobs
+    if output_logprobs is None:
+        return None
+
+    def extract_logprobs(logprobs: Dict[int, Logprob]) -> Dict[int, float]:
+        return {k: v.logprob for k, v in logprobs.items()}
+
+    return [extract_logprobs(logprobs) for logprobs in output_logprobs]
 
 
 if __name__ == "__main__":

--- a/model-engine/tests/unit/inference/conftest.py
+++ b/model-engine/tests/unit/inference/conftest.py
@@ -58,13 +58,19 @@ def create_batch_completions_request_content():
 
 @pytest.fixture
 def create_vllm_request_outputs():
+    class Logprob:
+        """mock, from https://github.com/vllm-project/vllm/blob/v0.4.1/vllm/sequence.py#L18"""
+
+        def __init__(self, logprob: float):
+            self.logprob = logprob
+
     mock_vllm_request_output1 = MagicMock()
     mock_vllm_request_output1.outputs = [
         MagicMock(text="text1"),
     ]
     mock_vllm_request_output1.prompt_token_ids = [1, 2, 3]
     mock_vllm_request_output1.outputs[0].token_ids = [4]
-    mock_vllm_request_output1.outputs[0].logprobs = [{4: 0.1}]
+    mock_vllm_request_output1.outputs[0].logprobs = [{4: Logprob(0.1)}]
 
     mock_vllm_request_output2 = MagicMock()
     mock_vllm_request_output2.outputs = [
@@ -72,7 +78,7 @@ def create_vllm_request_outputs():
     ]
     mock_vllm_request_output2.prompt_token_ids = [1, 2, 3]
     mock_vllm_request_output2.outputs[0].token_ids = [4, 5]
-    mock_vllm_request_output2.outputs[0].logprobs = [{4: 0.1, 5: 0.2}]
+    mock_vllm_request_output2.outputs[0].logprobs = [{4: Logprob(0.1), 5: Logprob(0.2)}]
 
     mock_vllm_request_output3 = MagicMock()
     mock_vllm_request_output3.outputs = [
@@ -80,7 +86,9 @@ def create_vllm_request_outputs():
     ]
     mock_vllm_request_output3.prompt_token_ids = [1, 2, 3]
     mock_vllm_request_output3.outputs[0].token_ids = [4, 5, 6]
-    mock_vllm_request_output3.outputs[0].logprobs = [{4: 0.1, 5: 0.2, 6: 0.3}]
+    mock_vllm_request_output3.outputs[0].logprobs = [
+        {4: Logprob(0.1), 5: Logprob(0.2), 6: Logprob(0.3)}
+    ]
     return [mock_vllm_request_output1, mock_vllm_request_output2, mock_vllm_request_output3]
 
 


### PR DESCRIPTION
# Pull Request Summary

since vLLM > 0.3.3, `logprobs` are returned as as type `Logprob` instead as direct float's. it's an API-breaking change (see https://github.com/vllm-project/vllm/pull/3065#issuecomment-1984761326)

change `vllm_server` to return output in the same previous format

## Test Plan and Usage Guide

create new `llama-2-7b` with vLLM==0.4.0.post1

```python
Completion.create(
    model="llama-2-7b",
    prompt="Hello ",
    max_new_tokens=10,
    temperature=0.0,
    return_token_log_probs=True,
)
```