### PR TITLE
Fix package name mapping in setup.py

### DIFF
--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -5,5 +5,5 @@ setup(
     python_requires=">=3.7",
     version="0.0.0.beta32",
     packages=find_packages(),
-    package_data={"scale_llm_engine": ["py.typed"]},
+    package_data={"llmengine": ["py.typed"]},
 )


### PR DESCRIPTION
# Pull Request Summary

_What is this PR changing? Why is this change being made? Any caveats you'd like to highlight? Link any relevant documents, links, or screenshots here if applicable._

https://github.com/scaleapi/llm-engine/pull/513 has the wrong name for the python module in setup.py

## Test Plan and Usage Guide

_How did you validate that your PR works correctly? How do you run or demo the code? Provide enough detail so a reviewer can reasonably reproduce the testing procedure. Paste example command line invocations if applicable._
