### PR TITLE
Increase max gpu utilization for 70b models

### DIFF
--- a/model-engine/model_engine_server/common/dtos/llms.py
+++ b/model-engine/model_engine_server/common/dtos/llms.py
@@ -528,15 +528,35 @@ class CreateBatchCompletionsRequest(BaseModel):
     """
     Maximum runtime of the batch inference in seconds. Default to one day.
     """
-    max_gpu_memory_utilization: Optional[float] = Field(default=0.9, le=1.0)
-    """
-    Maximum GPU memory utilization for the batch inference. Default to 90%.
-    """
     tool_config: Optional[ToolConfig] = None
     """
     Configuration for tool use.
     NOTE: this config is highly experimental and signature will change significantly in future iterations.
     """
+
+
+class CreateBatchCompletionsEngineRequest(CreateBatchCompletionsRequest):
+    """
+    Internal model for representing request to the llm engine. This contains additional fields that we want
+    hidden from the DTO exposed to the client.
+    """
+
+    max_gpu_memory_utilization: Optional[float] = Field(default=0.9, le=1.0)
+    """
+    Maximum GPU memory utilization for the batch inference. Default to 90%.
+    """
+
+    @staticmethod
+    def from_api(request: CreateBatchCompletionsRequest) -> "CreateBatchCompletionsEngineRequest":
+        return CreateBatchCompletionsEngineRequest(
+            input_data_path=request.input_data_path,
+            output_data_path=request.output_data_path,
+            content=request.content,
+            model_config=request.model_config,
+            data_parallelism=request.data_parallelism,
+            max_runtime_sec=request.max_runtime_sec,
+            tool_config=request.tool_config,
+        )
 
 
 class CreateBatchCompletionsResponse(BaseModel):

--- a/model-engine/model_engine_server/common/dtos/llms.py
+++ b/model-engine/model_engine_server/common/dtos/llms.py
@@ -528,6 +528,10 @@ class CreateBatchCompletionsRequest(BaseModel):
     """
     Maximum runtime of the batch inference in seconds. Default to one day.
     """
+    max_gpu_memory_utilization: Optional[float] = Field(default=0.9, le=1.0)
+    """
+    Maximum GPU memory utilization for the batch inference. Default to 90%.
+    """
     tool_config: Optional[ToolConfig] = None
     """
     Configuration for tool use.

--- a/model-engine/model_engine_server/inference/batch_inference/vllm_batch.py
+++ b/model-engine/model_engine_server/inference/batch_inference/vllm_batch.py
@@ -15,7 +15,7 @@ import smart_open
 from func_timeout import FunctionTimedOut, func_set_timeout
 from model_engine_server.common.dtos.llms import (
     CompletionOutput,
-    CreateBatchCompletionsRequest,
+    CreateBatchCompletionsEngineRequest,
     CreateBatchCompletionsRequestContent,
     TokenOutput,
     ToolConfig,
@@ -145,7 +145,7 @@ def random_uuid() -> str:
     return str(uuid.uuid4().hex)
 
 
-def get_vllm_engine(model, request: CreateBatchCompletionsRequest):
+def get_vllm_engine(model: str, request: CreateBatchCompletionsEngineRequest):
     from vllm import AsyncEngineArgs, AsyncLLMEngine
 
     engine_args = AsyncEngineArgs(
@@ -313,7 +313,7 @@ async def generate_with_tool(
 async def batch_inference():
     job_index = int(os.getenv("JOB_COMPLETION_INDEX", 0))
 
-    request = CreateBatchCompletionsRequest.parse_file(CONFIG_FILE)
+    request = CreateBatchCompletionsEngineRequest.parse_file(CONFIG_FILE)
 
     if request.model_config.checkpoint_path is not None:
         download_model(request.model_config.checkpoint_path, MODEL_WEIGHTS_FOLDER)

--- a/model-engine/model_engine_server/inference/batch_inference/vllm_batch.py
+++ b/model-engine/model_engine_server/inference/batch_inference/vllm_batch.py
@@ -145,7 +145,7 @@ def random_uuid() -> str:
     return str(uuid.uuid4().hex)
 
 
-def get_vllm_engine(model, request):
+def get_vllm_engine(model, request: CreateBatchCompletionsRequest):
     from vllm import AsyncEngineArgs, AsyncLLMEngine
 
     engine_args = AsyncEngineArgs(
@@ -154,7 +154,7 @@ def get_vllm_engine(model, request):
         tensor_parallel_size=request.model_config.num_shards,
         seed=request.model_config.seed or 0,
         disable_log_requests=True,
-        gpu_memory_utilization=0.9,
+        gpu_memory_utilization=request.max_gpu_memory_utilization or 0.9,
     )
 
     llm = AsyncLLMEngine.from_engine_args(engine_args)

--- a/model-engine/tests/unit/inference/conftest.py
+++ b/model-engine/tests/unit/inference/conftest.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 from model_engine_server.common.dtos.llms import (
     CompletionOutput,
+    CreateBatchCompletionsEngineRequest,
     CreateBatchCompletionsModelConfig,
     CreateBatchCompletionsRequest,
     CreateBatchCompletionsRequestContent,
@@ -12,14 +13,20 @@ from model_engine_server.common.dtos.llms import (
 
 
 @pytest.fixture
-def create_batch_completions_request():
-    return CreateBatchCompletionsRequest(
-        model_config=CreateBatchCompletionsModelConfig(
-            checkpoint_path="checkpoint_path", model="model", num_shards=4, seed=123, labels={}
-        ),
-        data_parallelism=1,
+def create_batch_completions_engine_request() -> CreateBatchCompletionsEngineRequest:
+    return CreateBatchCompletionsEngineRequest(
         input_data_path="input_data_path",
         output_data_path="output_data_path",
+        model_config=CreateBatchCompletionsModelConfig(
+            model="model",
+            checkpoint_path="checkpoint_path",
+            labels={},
+            seed=123,
+            num_shards=4,
+        ),
+        data_parallelism=1,
+        max_runtime_sec=86400,
+        max_gpu_memory_utilization=0.95,
     )
 
 

--- a/model-engine/tests/unit/inference/test_vllm_batch.py
+++ b/model-engine/tests/unit/inference/test_vllm_batch.py
@@ -7,7 +7,9 @@ from model_engine_server.inference.batch_inference.vllm_batch import batch_infer
 
 @pytest.mark.asyncio
 @patch("model_engine_server.inference.batch_inference.vllm_batch.get_vllm_engine")
-@patch("model_engine_server.inference.batch_inference.vllm_batch.CreateBatchCompletionsRequest")
+@patch(
+    "model_engine_server.inference.batch_inference.vllm_batch.CreateBatchCompletionsEngineRequest"
+)
 @patch(
     "model_engine_server.inference.batch_inference.vllm_batch.CreateBatchCompletionsRequestContent"
 )
@@ -25,9 +27,9 @@ async def test_batch_inference(
     mock_get_s3_client,
     mock_generate_with_vllm,
     mock_create_batch_completions_request_content,
-    mock_create_batch_completions_request,
+    mock_create_batch_completions_engine_request,
     mock_vllm,
-    create_batch_completions_request,
+    create_batch_completions_engine_request,
     create_batch_completions_request_content,
     mock_s3_client,
     mock_process,
@@ -36,7 +38,9 @@ async def test_batch_inference(
     # Mock the necessary objects and data
     mock_popen.return_value = mock_process
     mock_get_s3_client.return_value = mock_s3_client
-    mock_create_batch_completions_request.parse_file.return_value = create_batch_completions_request
+    mock_create_batch_completions_engine_request.parse_file.return_value = (
+        create_batch_completions_engine_request
+    )
     mock_create_batch_completions_request_content.parse_raw.return_value = (
         create_batch_completions_request_content
     )
@@ -48,7 +52,7 @@ async def test_batch_inference(
     await batch_inference()
 
     # Assertions
-    mock_create_batch_completions_request.parse_file.assert_called_once()
+    mock_create_batch_completions_engine_request.parse_file.assert_called_once()
     mock_open_func.assert_has_calls(
         [
             call("input_data_path", "r"),
@@ -61,7 +65,9 @@ async def test_batch_inference(
 
 @pytest.mark.asyncio
 @patch("model_engine_server.inference.batch_inference.vllm_batch.get_vllm_engine")
-@patch("model_engine_server.inference.batch_inference.vllm_batch.CreateBatchCompletionsRequest")
+@patch(
+    "model_engine_server.inference.batch_inference.vllm_batch.CreateBatchCompletionsEngineRequest"
+)
 @patch(
     "model_engine_server.inference.batch_inference.vllm_batch.CreateBatchCompletionsRequestContent"
 )
@@ -79,9 +85,9 @@ async def test_batch_inference_failed_to_download_model_but_proceed(
     mock_get_s3_client,
     mock_generate_with_vllm,
     mock_create_batch_completions_request_content,
-    mock_create_batch_completions_request,
+    mock_create_batch_completions_engine_request,
     mock_vllm,
-    create_batch_completions_request,
+    create_batch_completions_engine_request,
     create_batch_completions_request_content,
     mock_s3_client,
     mock_process,
@@ -91,7 +97,9 @@ async def test_batch_inference_failed_to_download_model_but_proceed(
     mock_process.returncode = 1  # Failed to download model
     mock_popen.return_value = mock_process
     mock_get_s3_client.return_value = mock_s3_client
-    mock_create_batch_completions_request.parse_file.return_value = create_batch_completions_request
+    mock_create_batch_completions_engine_request.parse_file.return_value = (
+        create_batch_completions_engine_request
+    )
     mock_create_batch_completions_request_content.parse_raw.return_value = (
         create_batch_completions_request_content
     )
@@ -103,7 +111,7 @@ async def test_batch_inference_failed_to_download_model_but_proceed(
     await batch_inference()
 
     # Assertions
-    mock_create_batch_completions_request.parse_file.assert_called_once()
+    mock_create_batch_completions_engine_request.parse_file.assert_called_once()
     mock_open_func.assert_has_calls(
         [
             call("input_data_path", "r"),
@@ -116,7 +124,9 @@ async def test_batch_inference_failed_to_download_model_but_proceed(
 
 @pytest.mark.asyncio
 @patch("model_engine_server.inference.batch_inference.vllm_batch.get_vllm_engine")
-@patch("model_engine_server.inference.batch_inference.vllm_batch.CreateBatchCompletionsRequest")
+@patch(
+    "model_engine_server.inference.batch_inference.vllm_batch.CreateBatchCompletionsEngineRequest"
+)
 @patch(
     "model_engine_server.inference.batch_inference.vllm_batch.CreateBatchCompletionsRequestContent"
 )
@@ -136,9 +146,9 @@ async def test_batch_inference_two_workers(
     mock_get_s3_client,
     mock_generate_with_vllm,
     mock_create_batch_completions_request_content,
-    mock_create_batch_completions_request,
+    mock_create_batch_completions_engine_request,
     mock_vllm,
-    create_batch_completions_request,
+    create_batch_completions_engine_request,
     create_batch_completions_request_content,
     mock_s3_client,
     mock_process,
@@ -147,8 +157,10 @@ async def test_batch_inference_two_workers(
     # Mock the necessary objects and data
     mock_popen.return_value = mock_process
     mock_get_s3_client.return_value = mock_s3_client
-    create_batch_completions_request.data_parallelism = 2
-    mock_create_batch_completions_request.parse_file.return_value = create_batch_completions_request
+    create_batch_completions_engine_request.data_parallelism = 2
+    mock_create_batch_completions_engine_request.parse_file.return_value = (
+        create_batch_completions_engine_request
+    )
     mock_create_batch_completions_request_content.parse_raw.return_value = (
         create_batch_completions_request_content
     )
@@ -168,7 +180,7 @@ async def test_batch_inference_two_workers(
     await batch_inference()
 
     # Assertions
-    mock_create_batch_completions_request.parse_file.assert_called_once()
+    mock_create_batch_completions_engine_request.parse_file.assert_called_once()
     mock_open_func.assert_has_calls(
         [
             call("input_data_path", "r"),
@@ -198,7 +210,9 @@ async def test_batch_inference_two_workers(
 
 @pytest.mark.asyncio
 @patch("model_engine_server.inference.batch_inference.vllm_batch.get_vllm_engine")
-@patch("model_engine_server.inference.batch_inference.vllm_batch.CreateBatchCompletionsRequest")
+@patch(
+    "model_engine_server.inference.batch_inference.vllm_batch.CreateBatchCompletionsEngineRequest"
+)
 @patch(
     "model_engine_server.inference.batch_inference.vllm_batch.CreateBatchCompletionsRequestContent"
 )
@@ -218,9 +232,9 @@ async def test_batch_inference_delete_chunks(
     mock_get_s3_client,
     mock_generate_with_vllm,
     mock_create_batch_completions_request_content,
-    mock_create_batch_completions_request,
+    mock_create_batch_completions_engine_request,
     mock_vllm,
-    create_batch_completions_request,
+    create_batch_completions_engine_request,
     create_batch_completions_request_content,
     mock_s3_client,
     mock_process,
@@ -229,9 +243,11 @@ async def test_batch_inference_delete_chunks(
     # Mock the necessary objects and data
     mock_popen.return_value = mock_process
     mock_get_s3_client.return_value = mock_s3_client
-    create_batch_completions_request.data_parallelism = 2
-    create_batch_completions_request.output_data_path = "s3://bucket/key"
-    mock_create_batch_completions_request.parse_file.return_value = create_batch_completions_request
+    create_batch_completions_engine_request.data_parallelism = 2
+    create_batch_completions_engine_request.output_data_path = "s3://bucket/key"
+    mock_create_batch_completions_engine_request.parse_file.return_value = (
+        create_batch_completions_engine_request
+    )
     mock_create_batch_completions_request_content.parse_raw.return_value = (
         create_batch_completions_request_content
     )
@@ -251,7 +267,7 @@ async def test_batch_inference_delete_chunks(
     await batch_inference()
 
     # Assertions
-    mock_create_batch_completions_request.parse_file.assert_called_once()
+    mock_create_batch_completions_engine_request.parse_file.assert_called_once()
     mock_open_func.assert_has_calls(
         [
             call("input_data_path", "r"),
@@ -310,7 +326,9 @@ def test_file_exists_no_such_key():
 
 @pytest.mark.asyncio
 @patch("model_engine_server.inference.batch_inference.vllm_batch.get_vllm_engine")
-@patch("model_engine_server.inference.batch_inference.vllm_batch.CreateBatchCompletionsRequest")
+@patch(
+    "model_engine_server.inference.batch_inference.vllm_batch.CreateBatchCompletionsEngineRequest"
+)
 @patch(
     "model_engine_server.inference.batch_inference.vllm_batch.CreateBatchCompletionsRequestContent"
 )
@@ -330,7 +348,7 @@ async def test_batch_inference_tool_completion(
     mock_get_s3_client,
     mock_generate_with_vllm,
     mock_create_batch_completions_request_content,
-    mock_create_batch_completions_request,
+    mock_create_batch_completions_engine_request,
     mock_vllm,
     create_batch_completions_tool_completion_request,
     create_batch_completions_tool_completion_request_content,
@@ -344,7 +362,7 @@ async def test_batch_inference_tool_completion(
     mock_run.return_value = mock_run_output
     mock_popen.return_value = mock_process
     mock_get_s3_client.return_value = mock_s3_client
-    mock_create_batch_completions_request.parse_file.return_value = (
+    mock_create_batch_completions_engine_request.parse_file.return_value = (
         create_batch_completions_tool_completion_request
     )
     mock_create_batch_completions_request_content.parse_raw.return_value = (
@@ -361,7 +379,7 @@ async def test_batch_inference_tool_completion(
     await batch_inference()
 
     # Assertions
-    mock_create_batch_completions_request.parse_file.assert_called_once()
+    mock_create_batch_completions_engine_request.parse_file.assert_called_once()
     mock_open_func.assert_has_calls(
         [
             call("input_data_path", "r"),


### PR DESCRIPTION
# Pull Request Summary

_What is this PR changing? Why is this change being made? Any caveats you'd like to highlight? Link any relevant documents, links, or screenshots here if applicable._

Up max gpu memory utilization to 0.95 for 70b models in attempt to address OOM issues

https://linear.app/scale-epd/issue/MLI-2309/use-095-gpu-memory-utilization-for-70b-models

## Test Plan and Usage Guide

_How did you validate that your PR works correctly? How do you run or demo the code? Provide enough detail so a reviewer can reasonably reproduce the testing procedure. Paste example command line invocations if applicable._

Published test docker image for batch_inference. Tested with API request using local gateway: job `ft-cp21h54gfe6g02mlqikg`
