### PR TITLE
Upgrade vLLM version for batch completion

### DIFF
--- a/model-engine/model_engine_server/common/dtos/llms.py
+++ b/model-engine/model_engine_server/common/dtos/llms.py
@@ -4,6 +4,7 @@ DTOs for LLM APIs.
 
 from typing import Any, Dict, List, Optional
 
+import pydantic
 from model_engine_server.common.dtos.model_endpoints import (
     CpuSpecificationType,
     GetModelEndpointV1Response,
@@ -21,7 +22,11 @@ from model_engine_server.domain.entities import (
     ModelEndpointStatus,
     Quantization,
 )
-from pydantic import BaseModel, Field, HttpUrl
+
+if int(pydantic.__version__.split(".")[0]) > 1:
+    from pydantic.v1 import BaseModel, Field, HttpUrl
+else:
+    from pydantic import BaseModel, Field, HttpUrl
 
 
 class CreateLLMModelEndpointV1Request(BaseModel):

--- a/model-engine/model_engine_server/common/dtos/llms.py
+++ b/model-engine/model_engine_server/common/dtos/llms.py
@@ -24,7 +24,7 @@ from model_engine_server.domain.entities import (
 )
 
 if int(pydantic.__version__.split(".")[0]) > 1:
-    from pydantic.v1 import BaseModel, Field, HttpUrl
+    from pydantic.v1 import BaseModel, Field, HttpUrl  # pragma: no cover
 else:
     from pydantic import BaseModel, Field, HttpUrl
 

--- a/model-engine/model_engine_server/inference/batch_inference/Dockerfile_vllm
+++ b/model-engine/model_engine_server/inference/batch_inference/Dockerfile_vllm
@@ -1,3 +1,37 @@
+#################### BASE BUILD IMAGE ####################
+FROM nvidia/cuda:12.1.0-devel-ubuntu22.04 AS dev
+RUN apt-get update -y \
+    && apt-get install -y python3-pip git
+# Workaround for https://github.com/openai/triton/issues/2507 and
+# https://github.com/pytorch/pytorch/issues/107960 -- hopefully
+# this won't be needed for future versions of this docker image
+# or future versions of triton.
+RUN ldconfig /usr/local/cuda-12.1/compat/
+WORKDIR /workspace
+
+COPY model-engine/model_engine_server/inference/batch_inference/requirements-build.txt requirements-build.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install -r requirements-build.txt
+#################### BASE BUILD IMAGE ####################
+
+#################### FLASH_ATTENTION Build IMAGE ####################
+FROM dev as flash-attn-builder
+# max jobs used for build
+ARG max_jobs=2
+ENV MAX_JOBS=${max_jobs}
+# flash attention version
+ARG flash_attn_version=v2.5.6
+ENV FLASH_ATTN_VERSION=${flash_attn_version}
+
+WORKDIR /usr/src/flash-attention-v2
+
+# Download the wheel or build it if a pre-compiled release doesn't exist
+RUN pip --verbose wheel flash-attn==${FLASH_ATTN_VERSION} \
+    --no-build-isolation --no-deps --no-cache-dir
+
+#################### FLASH_ATTENTION Build IMAGE ####################
+
+#################### Runtime IMAGE ####################
 FROM nvcr.io/nvidia/pytorch:23.09-py3
 
 RUN apt-get update && \
@@ -5,6 +39,10 @@ RUN apt-get update && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
+
+# Install flash attention (from pre-built wheel)
+RUN --mount=type=bind,from=flash-attn-builder,src=/usr/src/flash-attention-v2,target=/usr/src/flash-attention-v2 \
+    pip install /usr/src/flash-attention-v2/*.whl --no-cache-dir
 
 RUN pip uninstall torch -y
 RUN pip install torch==2.1.1 --index-url https://download.pytorch.org/whl/cu121
@@ -21,3 +59,5 @@ RUN pip install -r requirements.txt
 COPY model-engine /workspace/model-engine
 RUN pip install -e /workspace/model-engine
 COPY model-engine/model_engine_server/inference/batch_inference/vllm_batch.py /workspace/vllm_batch.py
+
+#################### Runtime IMAGE ####################

--- a/model-engine/model_engine_server/inference/batch_inference/requirements-build.txt
+++ b/model-engine/model_engine_server/inference/batch_inference/requirements-build.txt
@@ -1,0 +1,8 @@
+# Copied from https://github.com/vllm-project/vllm/blob/main/requirements-build.txt
+# Needed to build flash-attn into docker image
+cmake>=3.21
+ninja
+packaging
+setuptools>=49.4.0
+torch==2.3.0
+wheel

--- a/model-engine/model_engine_server/inference/batch_inference/requirements-dev.txt
+++ b/model-engine/model_engine_server/inference/batch_inference/requirements-dev.txt
@@ -1,0 +1,1 @@
+-e ../../.. # Need to install model_engine_server as a package

--- a/model-engine/model_engine_server/inference/batch_inference/requirements.txt
+++ b/model-engine/model_engine_server/inference/batch_inference/requirements.txt
@@ -1,6 +1,6 @@
-vllm==0.2.5
+vllm==0.4.2
 pydantic==2.7.1
-boto3==1.34.15
+boto3>=1.34.105
 smart-open==6.4.0
 ddtrace==2.4.0
 docker==7.0.0

--- a/model-engine/model_engine_server/inference/batch_inference/requirements.txt
+++ b/model-engine/model_engine_server/inference/batch_inference/requirements.txt
@@ -1,5 +1,5 @@
 vllm==0.2.5
-pydantic==1.10.13
+pydantic==2.7.1
 boto3==1.34.15
 smart-open==6.4.0
 ddtrace==2.4.0


### PR DESCRIPTION
# Pull Request Summary

_What is this PR changing? Why is this change being made? Any caveats you'd like to highlight? Link any relevant documents, links, or screenshots here if applicable._

Upgrade vLLM from 0.2.5 to 0.4.2 for batch completion job to support AWQ quantization with mixtral 8x7b. 


Caveats about upgrading:
* vLLM 0.4.2 uses pydantic 2, so will need to make the approach changes to the relevant dtos to support this upgrade
* vLLM 0.4.2 requires us to install flash attention 2 manually (e.g. https://github.com/vllm-project/vllm/pull/3396/files)

## Test Plan and Usage Guide

_How did you validate that your PR works correctly? How do you run or demo the code? Provide enough detail so a reviewer can reasonably reproduce the testing procedure. Paste example command line invocations if applicable._

Tested batch job: ft-cp2hij4gfe6g02gh488g