### PR TITLE
Add missing pydantic v2 handling

### DIFF
--- a/model-engine/model_engine_server/common/dtos/batch_jobs.py
+++ b/model-engine/model_engine_server/common/dtos/batch_jobs.py
@@ -4,6 +4,7 @@ DTOs for the batch job abstraction.
 from datetime import datetime, timedelta
 from typing import Any, Collection, Dict, List, Optional
 
+import pydantic
 from model_engine_server.common import dict_not_none
 from model_engine_server.domain.entities import (
     BatchJobSerializationFormat,
@@ -13,7 +14,11 @@ from model_engine_server.domain.entities import (
     GpuType,
     StorageSpecificationType,
 )
-from pydantic import BaseModel, root_validator
+
+if int(pydantic.__version__.split(".")[0]) > 1:
+    from pydantic.v1 import BaseModel, root_validator  # pragma: no cover
+else:
+    from pydantic import BaseModel, root_validator
 
 
 class CreateBatchJobResourceRequests(BaseModel):

--- a/model-engine/model_engine_server/common/dtos/model_endpoints.py
+++ b/model-engine/model_engine_server/common/dtos/model_endpoints.py
@@ -10,6 +10,7 @@ import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
+import pydantic
 from model_engine_server.domain.entities import (
     CallbackAuth,
     CpuSpecificationType,
@@ -21,7 +22,11 @@ from model_engine_server.domain.entities import (
     ModelEndpointType,
     StorageSpecificationType,
 )
-from pydantic import BaseModel, Field, HttpUrl
+
+if int(pydantic.__version__.split(".")[0]) > 1:
+    from pydantic.v1 import BaseModel, Field, HttpUrl  # pragma: no cover
+else:
+    from pydantic import BaseModel, Field, HttpUrl
 
 
 class BrokerType(str, Enum):

--- a/model-engine/model_engine_server/domain/entities/batch_job_entity.py
+++ b/model-engine/model_engine_server/domain/entities/batch_job_entity.py
@@ -2,10 +2,15 @@ from datetime import datetime
 from enum import Enum
 from typing import Dict, Optional
 
+import pydantic
 from model_engine_server.domain.entities.model_bundle_entity import ModelBundle
 from model_engine_server.domain.entities.model_endpoint_entity import ModelEndpoint
 from model_engine_server.domain.entities.owned_entity import OwnedEntity
-from pydantic import BaseModel
+
+if int(pydantic.__version__.split(".")[0]) > 1:
+    from pydantic.v1 import BaseModel  # pragma: no cover
+else:
+    from pydantic import BaseModel
 
 
 class BatchJobStatus(str, Enum):

--- a/model-engine/model_engine_server/domain/entities/model_bundle_entity.py
+++ b/model-engine/model_engine_server/domain/entities/model_bundle_entity.py
@@ -3,9 +3,15 @@ from abc import ABC
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
+import pydantic
 from model_engine_server.common.constants import DEFAULT_CELERY_TASK_NAME, LIRA_CELERY_TASK_NAME
 from model_engine_server.domain.entities.owned_entity import OwnedEntity
-from pydantic import BaseModel, Field, root_validator
+
+if int(pydantic.__version__.split(".")[0]) > 1:
+    from pydantic.v1 import BaseModel, Field, root_validator  # pragma: no cover
+else:
+    from pydantic import BaseModel, Field, root_validator
+
 from typing_extensions import Literal
 
 

--- a/model-engine/model_engine_server/domain/entities/model_endpoint_entity.py
+++ b/model-engine/model_engine_server/domain/entities/model_endpoint_entity.py
@@ -2,6 +2,7 @@ import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
+import pydantic
 from fastapi.openapi.models import OpenAPI
 from model_engine_server.common import dict_not_none
 from model_engine_server.common.serialization_utils import b64_to_python_json, python_json_to_b64
@@ -12,7 +13,12 @@ from model_engine_server.domain.entities.common_types import (
 from model_engine_server.domain.entities.gpu_type import GpuType
 from model_engine_server.domain.entities.model_bundle_entity import ModelBundle
 from model_engine_server.domain.entities.owned_entity import OwnedEntity
-from pydantic import BaseModel, Field
+
+if int(pydantic.__version__.split(".")[0]) > 1:
+    from pydantic.v1 import BaseModel, Field  # pragma: no cover
+else:
+    from pydantic import BaseModel, Field
+
 from typing_extensions import Literal
 
 ModelEndpointsSchema = OpenAPI

--- a/model-engine/model_engine_server/domain/entities/owned_entity.py
+++ b/model-engine/model_engine_server/domain/entities/owned_entity.py
@@ -1,4 +1,9 @@
-from pydantic import BaseModel
+import pydantic
+
+if int(pydantic.__version__.split(".")[0]) > 1:
+    from pydantic.v1 import BaseModel  # pragma: no cover
+else:
+    from pydantic import BaseModel
 
 
 class OwnedEntity(BaseModel):


### PR DESCRIPTION
# Pull Request Summary

_What is this PR changing? Why is this change being made? Any caveats you'd like to highlight? Link any relevant documents, links, or screenshots here if applicable._
Getting pydantic import errors on batch vllm inference
```
pydantic.errors.PydanticUserError: If you use `@root_validator` with pre=False (the default) you MUST specify `skip_on_failure=True`. Note that `@root_validator` is deprecated and should be replaced with `@model_validator`.
```

Missed a few spots [here](https://github.com/scaleapi/llm-engine/pull/518) where i needed to override pydantic imports.

## Test Plan and Usage Guide

_How did you validate that your PR works correctly? How do you run or demo the code? Provide enough detail so a reviewer can reasonably reproduce the testing procedure. Paste example command line invocations if applicable._
