### PR TITLE
Revert "Upgrade vLLM version for batch completion"

### DIFF
--- a/model-engine/model_engine_server/common/dtos/llms.py
+++ b/model-engine/model_engine_server/common/dtos/llms.py
@@ -4,7 +4,6 @@ DTOs for LLM APIs.
 
 from typing import Any, Dict, List, Optional
 
-import pydantic
 from model_engine_server.common.dtos.model_endpoints import (
     CpuSpecificationType,
     GetModelEndpointV1Response,
@@ -22,11 +21,7 @@ from model_engine_server.domain.entities import (
     ModelEndpointStatus,
     Quantization,
 )
-
-if int(pydantic.__version__.split(".")[0]) > 1:
-    from pydantic.v1 import BaseModel, Field, HttpUrl  # pragma: no cover
-else:
-    from pydantic import BaseModel, Field, HttpUrl
+from pydantic import BaseModel, Field, HttpUrl
 
 
 class CreateLLMModelEndpointV1Request(BaseModel):

--- a/model-engine/model_engine_server/inference/batch_inference/Dockerfile_vllm
+++ b/model-engine/model_engine_server/inference/batch_inference/Dockerfile_vllm
@@ -1,37 +1,3 @@
-#################### BASE BUILD IMAGE ####################
-FROM nvidia/cuda:12.1.0-devel-ubuntu22.04 AS dev
-RUN apt-get update -y \
-    && apt-get install -y python3-pip git
-# Workaround for https://github.com/openai/triton/issues/2507 and
-# https://github.com/pytorch/pytorch/issues/107960 -- hopefully
-# this won't be needed for future versions of this docker image
-# or future versions of triton.
-RUN ldconfig /usr/local/cuda-12.1/compat/
-WORKDIR /workspace
-
-COPY model-engine/model_engine_server/inference/batch_inference/requirements-build.txt requirements-build.txt
-RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install -r requirements-build.txt
-#################### BASE BUILD IMAGE ####################
-
-#################### FLASH_ATTENTION Build IMAGE ####################
-FROM dev as flash-attn-builder
-# max jobs used for build
-ARG max_jobs=2
-ENV MAX_JOBS=${max_jobs}
-# flash attention version
-ARG flash_attn_version=v2.5.6
-ENV FLASH_ATTN_VERSION=${flash_attn_version}
-
-WORKDIR /usr/src/flash-attention-v2
-
-# Download the wheel or build it if a pre-compiled release doesn't exist
-RUN pip --verbose wheel flash-attn==${FLASH_ATTN_VERSION} \
-    --no-build-isolation --no-deps --no-cache-dir
-
-#################### FLASH_ATTENTION Build IMAGE ####################
-
-#################### Runtime IMAGE ####################
 FROM nvcr.io/nvidia/pytorch:23.09-py3
 
 RUN apt-get update && \
@@ -39,10 +5,6 @@ RUN apt-get update && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
-
-# Install flash attention (from pre-built wheel)
-RUN --mount=type=bind,from=flash-attn-builder,src=/usr/src/flash-attention-v2,target=/usr/src/flash-attention-v2 \
-    pip install /usr/src/flash-attention-v2/*.whl --no-cache-dir
 
 RUN pip uninstall torch -y
 RUN pip install torch==2.1.1 --index-url https://download.pytorch.org/whl/cu121
@@ -59,5 +21,3 @@ RUN pip install -r requirements.txt
 COPY model-engine /workspace/model-engine
 RUN pip install -e /workspace/model-engine
 COPY model-engine/model_engine_server/inference/batch_inference/vllm_batch.py /workspace/vllm_batch.py
-
-#################### Runtime IMAGE ####################

--- a/model-engine/model_engine_server/inference/batch_inference/requirements-build.txt
+++ b/model-engine/model_engine_server/inference/batch_inference/requirements-build.txt
@@ -1,8 +1,0 @@
-# Copied from https://github.com/vllm-project/vllm/blob/main/requirements-build.txt
-# Needed to build flash-attn into docker image
-cmake>=3.21
-ninja
-packaging
-setuptools>=49.4.0
-torch==2.3.0
-wheel

--- a/model-engine/model_engine_server/inference/batch_inference/requirements-dev.txt
+++ b/model-engine/model_engine_server/inference/batch_inference/requirements-dev.txt
@@ -1,1 +1,0 @@
--e ../../.. # Need to install model_engine_server as a package

--- a/model-engine/model_engine_server/inference/batch_inference/requirements.txt
+++ b/model-engine/model_engine_server/inference/batch_inference/requirements.txt
@@ -1,6 +1,6 @@
-vllm==0.4.2
-pydantic==2.7.1
-boto3>=1.34.105
+vllm==0.2.5
+pydantic==1.10.13
+boto3==1.34.15
 smart-open==6.4.0
 ddtrace==2.4.0
 docker==7.0.0


### PR DESCRIPTION
Reverts scaleapi/llm-engine#518

This was not correctly done. Misses various other recursive imports and worst of all, [the import of openai's model](https://github.com/scaleapi/llm-engine/blob/4d0cd26087c3436b6bde2c722018d5b486e78fa9/model-engine/model_engine_server/common/dtos/model_endpoints.py#L146) makes this approach not feasible.

```
/usr/local/lib/python3.10/dist-packages/pydantic/_internal/_config.py:334: UserWarning: Valid config keys have changed in V2:                                                          │
* 'orm_mode' has been renamed to 'from_attributes'                                                                                                                                     │
  warnings.warn(message, UserWarning)                                                                                                                                                  │
Traceback (most recent call last):                                                                                                                                                     │
  File "/workspace/vllm_batch.py", line 16, in <module>                                                                                                                                │
    from model_engine_server.common.dtos.llms import (                                                                                                                                 │
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load                                                                                                                   │
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked                                                                                                          │
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked                                                                                                                    │
  File "/usr/local/lib/python3.10/dist-packages/ddtrace/internal/module.py", line 225, in _exec_module                                                                                 │
    self.loader.exec_module(module)                                                                                                                                                    │
  File "/workspace/model-engine/model_engine_server/common/dtos/llms.py", line 8, in <module>                                                                                          │
    from model_engine_server.common.dtos.model_endpoints import (                                                                                                                      │
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load                                                                                                                   │
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked                                                                                                          │
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked                                                                                                                    │
  File "/usr/local/lib/python3.10/dist-packages/ddtrace/internal/module.py", line 225, in _exec_module                                                                                 │
    self.loader.exec_module(module)                                                                                                                                                    │
  File "/workspace/model-engine/model_engine_server/common/dtos/model_endpoints.py", line 150, in <module>                                                                             │
    class GetModelEndpointsSchemaV1Response(BaseModel):                                                                                                                                │
  File "/usr/local/lib/python3.10/dist-packages/pydantic/v1/main.py", line 197, in __new__                                                                                             │
    fields[ann_name] = ModelField.infer(                                                                                                                                               │
  File "/usr/local/lib/python3.10/dist-packages/pydantic/v1/fields.py", line 504, in infer                                                                                             │
    return cls(                                                                                                                                                                        │
  File "/usr/local/lib/python3.10/dist-packages/pydantic/v1/fields.py", line 434, in __init__                                                                                          │
    self.prepare()                                                                                                                                                                     │
  File "/usr/local/lib/python3.10/dist-packages/pydantic/v1/fields.py", line 555, in prepare                                                                                           │
    self.populate_validators()                                                                                                                                                         │
  File "/usr/local/lib/python3.10/dist-packages/pydantic/v1/fields.py", line 829, in populate_validators                                                                               │
    *(get_validators() if get_validators else list(find_validators(self.type_, self.model_config))),                                                                                   │
  File "/usr/local/lib/python3.10/dist-packages/pydantic/v1/validators.py", line 765, in find_validators                                                                               │
    raise RuntimeError(f'no validator found for {type_}, see `arbitrary_types_allowed` in Config')                                                                                     │
RuntimeError: no validator found for <class 'fastapi.openapi.models.OpenAPI'>, see `arbitrary_types_allowed` in Config
```

We'll need to a do a proper upgrade to pydantic2 to unblock the vllm upgrade.