### PR TITLE
Non-interactive installation during docker build

### DIFF
--- a/model-engine/model_engine_server/inference/pytorch_or_tf.base.Dockerfile
+++ b/model-engine/model_engine_server/inference/pytorch_or_tf.base.Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 # TODO: ffmpeg, libsm6, and lixext6 are essentially hardcoded from lidar.
 # It's probably more correct to add support for arbitrary user-specified base images,
 # otherwise this base image gets bloated over time.
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
       apt-utils \
       dumb-init \
       git \


### PR DESCRIPTION
# Pull Request Summary

seeing tzdata installation hanging due to region selection: https://app.datadoghq.com/logs?query=kube_job%3Akaniko-4079a805%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1717453458877&to_ts=1717457058877&live=true

add non-interactive installation as referred in https://askubuntu.com/questions/909277/avoiding-user-interaction-with-tzdata-when-installing-certbot-in-a-docker-contai

this appears to happen building images using newer pytorch base images like `2.1.0-cuda12.1-cudnn8-runtime`

## Test Plan and Usage Guide

_How did you validate that your PR works correctly? How do you run or demo the code? Provide enough detail so a reviewer can reasonably reproduce the testing procedure. Paste example command line invocations if applicable._
