### PR TITLE
Add special token param to completions + batch completions apis

### DIFF
--- a/clients/python/llmengine/data_types.py
+++ b/clients/python/llmengine/data_types.py
@@ -332,6 +332,7 @@ class CompletionSyncV1Request(BaseModel):
     guided_regex: Optional[str] = Field(default=None)
     guided_choice: Optional[List[str]] = Field(default=None)
     guided_grammar: Optional[str] = Field(default=None)
+    skip_special_tokens: Optional[bool] = Field(default=True)
 
 
 class TokenOutput(BaseModel):
@@ -407,6 +408,7 @@ class CompletionStreamV1Request(BaseModel):
     guided_regex: Optional[str] = Field(default=None)
     guided_choice: Optional[List[str]] = Field(default=None)
     guided_grammar: Optional[str] = Field(default=None)
+    skip_special_tokens: Optional[bool] = Field(default=True)
 
 
 class CompletionStreamOutput(BaseModel):
@@ -698,6 +700,10 @@ class CreateBatchCompletionsRequestContent(BaseModel):
     top_p: Optional[float] = Field(default=None, gt=0.0, le=1.0)
     """
     Controls the cumulative probability of the top tokens to consider. 1.0 means consider all tokens.
+    """
+    skip_special_tokens: Optional[bool] = True
+    """
+    Whether to skip special tokens in the output.
     """
 
 

--- a/model-engine/model_engine_server/common/dtos/llms.py
+++ b/model-engine/model_engine_server/common/dtos/llms.py
@@ -200,6 +200,10 @@ class CompletionSyncV1Request(BaseModel):
     """
     Context-free grammar for guided decoding. Only supported in vllm.
     """
+    skip_special_tokens: Optional[bool] = True
+    """
+    Whether to skip special tokens in the output. Only supported in vllm.
+    """
 
 
 class TokenOutput(BaseModel):
@@ -279,6 +283,10 @@ class CompletionStreamV1Request(BaseModel):
     guided_grammar: Optional[str] = None
     """
     Context-free grammar for guided decoding. Only supported in vllm.
+    """
+    skip_special_tokens: Optional[bool] = True
+    """
+    Whether to skip special tokens in the output. Only supported in vllm.
     """
 
 
@@ -449,6 +457,10 @@ class CreateBatchCompletionsRequestContent(BaseModel):
     top_p: Optional[float] = Field(default=None, gt=0.0, le=1.0)
     """
     Controls the cumulative probability of the top tokens to consider. 1.0 means consider all tokens.
+    """
+    skip_special_tokens: Optional[bool] = True
+    """
+    Whether to skip special tokens in the output.
     """
 
 

--- a/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
+++ b/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
@@ -1687,6 +1687,8 @@ class CompletionSyncV1UseCase:
                 vllm_args["guided_json"] = request.guided_json
             if request.guided_grammar is not None:
                 vllm_args["guided_grammar"] = request.guided_grammar
+            if request.skip_special_tokens is not None:
+                vllm_args["skip_special_tokens"] = request.skip_special_tokens
 
             inference_request = SyncEndpointPredictV1Request(
                 args=vllm_args,
@@ -1957,6 +1959,8 @@ class CompletionStreamV1UseCase:
                 args["guided_json"] = request.guided_json
             if request.guided_grammar is not None:
                 args["guided_grammar"] = request.guided_grammar
+            if request.skip_special_tokens is not None:
+                args["skip_special_tokens"] = request.skip_special_tokens
             args["stream"] = True
         elif model_content.inference_framework == LLMInferenceFramework.LIGHTLLM:
             args = {

--- a/model-engine/model_engine_server/inference/batch_inference/build_and_upload_image.sh
+++ b/model-engine/model_engine_server/inference/batch_inference/build_and_upload_image.sh
@@ -17,5 +17,5 @@ fi
 IMAGE_TAG=$2
 ACCOUNT=$1
 aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin $ACCOUNT.dkr.ecr.us-west-2.amazonaws.com
-DOCKER_BUILDKIT=1 docker build -t $ACCOUNT.dkr.ecr.us-west-2.amazonaws.com/llm-engine/batch-infer-vllm:$IMAGE_TAG -f Dockerfile_vllm ../../../../
+DOCKER_BUILDKIT=1 docker build -t $ACCOUNT.dkr.ecr.us-west-2.amazonaws.com/llm-engine/batch-infer-vllm-test:$IMAGE_TAG -f Dockerfile_vllm ../../../../
 docker push $ACCOUNT.dkr.ecr.us-west-2.amazonaws.com/llm-engine/batch-infer-vllm-test:$IMAGE_TAG

--- a/model-engine/model_engine_server/inference/batch_inference/build_and_upload_image.sh
+++ b/model-engine/model_engine_server/inference/batch_inference/build_and_upload_image.sh
@@ -18,4 +18,4 @@ IMAGE_TAG=$2
 ACCOUNT=$1
 aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin $ACCOUNT.dkr.ecr.us-west-2.amazonaws.com
 DOCKER_BUILDKIT=1 docker build -t $ACCOUNT.dkr.ecr.us-west-2.amazonaws.com/llm-engine/batch-infer-vllm:$IMAGE_TAG -f Dockerfile_vllm ../../../../
-docker push $ACCOUNT.dkr.ecr.us-west-2.amazonaws.com/llm-engine/batch-infer-vllm:$IMAGE_TAG
+docker push $ACCOUNT.dkr.ecr.us-west-2.amazonaws.com/llm-engine/batch-infer-vllm-test:$IMAGE_TAG

--- a/model-engine/model_engine_server/inference/batch_inference/build_and_upload_image.sh
+++ b/model-engine/model_engine_server/inference/batch_inference/build_and_upload_image.sh
@@ -17,5 +17,5 @@ fi
 IMAGE_TAG=$2
 ACCOUNT=$1
 aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin $ACCOUNT.dkr.ecr.us-west-2.amazonaws.com
-DOCKER_BUILDKIT=1 docker build -t $ACCOUNT.dkr.ecr.us-west-2.amazonaws.com/llm-engine/batch-infer-vllm-test:$IMAGE_TAG -f Dockerfile_vllm ../../../../
-docker push $ACCOUNT.dkr.ecr.us-west-2.amazonaws.com/llm-engine/batch-infer-vllm-test:$IMAGE_TAG
+DOCKER_BUILDKIT=1 docker build -t $ACCOUNT.dkr.ecr.us-west-2.amazonaws.com/llm-engine/batch-infer-vllm:$IMAGE_TAG -f Dockerfile_vllm ../../../../
+docker push $ACCOUNT.dkr.ecr.us-west-2.amazonaws.com/llm-engine/batch-infer-vllm:$IMAGE_TAG

--- a/model-engine/model_engine_server/inference/batch_inference/vllm_batch.py
+++ b/model-engine/model_engine_server/inference/batch_inference/vllm_batch.py
@@ -217,6 +217,7 @@ async def generate_with_tool(
             content.frequency_penalty,
             content.top_k,
             content.top_p,
+            content.skip_special_tokens,
             [iter[0] for iter in iter_prompts],
             bar,
             use_tool=True,
@@ -366,6 +367,7 @@ async def batch_inference():
             content.frequency_penalty,
             content.top_k,
             content.top_p,
+            content.skip_special_tokens,
             prompts,
             bar,
             use_tool=False,
@@ -401,6 +403,7 @@ async def generate_with_vllm(
     frequency_penalty,
     top_k,
     top_p,
+    skip_special_tokens,
     prompts,
     bar,
     use_tool,
@@ -424,6 +427,7 @@ async def generate_with_vllm(
             frequency_penalty=frequency_penalty or 0.0,
             top_k=top_k or -1,
             top_p=top_p or 1.0,
+            skip_special_tokens=skip_special_tokens if skip_special_tokens is not None else True,
         )
         results_generator = await engine.add_request(
             request_id, prompt, sampling_params, None, time.monotonic()

--- a/model-engine/tests/unit/domain/test_llm_use_cases.py
+++ b/model-engine/tests/unit/domain/test_llm_use_cases.py
@@ -709,6 +709,7 @@ async def test_completion_sync_use_case_success(
 ):
     completion_sync_request.include_stop_str_in_output = True
     completion_sync_request.guided_json = {}
+    completion_sync_request.skip_special_tokens = False
     fake_llm_model_endpoint_service.add_model_endpoint(llm_model_endpoint_sync[0])
     fake_model_endpoint_service.sync_model_endpoint_inference_gateway.response = (
         SyncEndpointPredictV1Response(


### PR DESCRIPTION
# Pull Request Summary

Adds an option to show the special tokens in completions/stream completions/batch completions output

## Test Plan and Usage Guide


Completions/Stream completions
- Deploy a model (or grab one from somewhere) that has the special tokens
- Make request to model to see if special tokens are respected (with skip = False). Also try skip = True to sanity check

Made request with body ```{
"prompt": "Give me a list of all numbers. Sure! 1, 2",
"max_new_tokens": 10,
"temperature": 0.0,
"skip_special_tokens": false,
"guided_regex": "4"
}```, this gives output "4</s>", making same request with skip=true, output is just "4". Works for sync and stream.

Batch completions
- Make batch completions call using model with special tokens
- See whether output has the special tokens

Made batch completions calls with both skip special token=true and false, true had empty spaces where tokens should have been, false had the special tokens.
