### PR TITLE
Mitigation for AsyncEngineDeadError

### DIFF
--- a/model-engine/model_engine_server/inference/vllm/vllm_server.py
+++ b/model-engine/model_engine_server/inference/vllm/vllm_server.py
@@ -1,6 +1,7 @@
 import argparse
 import code
 import json
+import os
 import signal
 import subprocess
 import traceback
@@ -44,7 +45,7 @@ async def generate(request: Request) -> Response:
         await engine.check_health()
     except Exception as e:
         print(f"The vllm engine is dead, exiting the pod: {e}")
-        exit(1)
+        os.kill(os.getpid(), signal.SIGINT)
 
     request_dict = await request.json()
     prompt = request_dict.pop("prompt")

--- a/model-engine/model_engine_server/inference/vllm/vllm_server.py
+++ b/model-engine/model_engine_server/inference/vllm/vllm_server.py
@@ -10,7 +10,7 @@ import uvicorn
 from fastapi import BackgroundTasks, FastAPI, HTTPException, Request
 from fastapi.responses import Response, StreamingResponse
 from vllm.engine.arg_utils import AsyncEngineArgs
-from vllm.engine.async_llm_engine import AsyncEngineDeadError, AsyncLLMEngine
+from vllm.engine.async_llm_engine import AsyncLLMEngine
 from vllm.entrypoints.openai.protocol import CompletionRequest as OpenAICompletionRequest
 from vllm.model_executor.guided_decoding import get_guided_decoding_logits_processor
 from vllm.outputs import CompletionOutput
@@ -39,6 +39,13 @@ async def generate(request: Request) -> Response:
     - stream: whether to stream the results or not.
     - other fields: the sampling parameters (See `SamplingParams` for details).
     """
+    # check health before accepting request and fail fast if engine isn't healthy
+    try:
+        await engine.check_health()
+    except Exception as e:
+        print(f"The vllm engine is dead, exiting the pod: {e}")
+        exit(1)
+
     request_dict = await request.json()
     prompt = request_dict.pop("prompt")
     stream = request_dict.pop("stream", False)
@@ -75,34 +82,32 @@ async def generate(request: Request) -> Response:
         sampling_params.logits_processors.append(guided_decode_logit_processor)
 
     request_id = random_uuid()
-    try:
-        results_generator = engine.generate(prompt, sampling_params, request_id)
-    except AsyncEngineDeadError as e:
-        print(f"The vllm engine is dead, exiting the pod: {e}")
-        exit(1)
 
-    # Streaming case
-    async def stream_results() -> AsyncGenerator[str, None]:
-        last_output_text = ""
-        async for request_output in results_generator:
-            log_probs = format_logprobs(request_output)
-            ret = {
-                "text": request_output.outputs[-1].text[len(last_output_text) :],
-                "count_prompt_tokens": len(request_output.prompt_token_ids),
-                "count_output_tokens": len(request_output.outputs[0].token_ids),
-                "log_probs": log_probs[-1] if log_probs and sampling_params.logprobs else None,
-                "finished": request_output.finished,
-            }
-            last_output_text = request_output.outputs[-1].text
-            yield f"data:{json.dumps(ret)}\n\n"
+    results_generator = engine.generate(prompt, sampling_params, request_id)
 
     async def abort_request() -> None:
         await engine.abort(request_id)
 
     if stream:
+        # Streaming case
+        async def stream_results() -> AsyncGenerator[str, None]:
+            last_output_text = ""
+            async for request_output in results_generator:
+                log_probs = format_logprobs(request_output)
+                ret = {
+                    "text": request_output.outputs[-1].text[len(last_output_text) :],
+                    "count_prompt_tokens": len(request_output.prompt_token_ids),
+                    "count_output_tokens": len(request_output.outputs[0].token_ids),
+                    "log_probs": log_probs[-1] if log_probs and sampling_params.logprobs else None,
+                    "finished": request_output.finished,
+                }
+                last_output_text = request_output.outputs[-1].text
+                yield f"data:{json.dumps(ret)}\n\n"
+
         background_tasks = BackgroundTasks()
         # Abort the request if the client disconnects.
         background_tasks.add_task(abort_request)
+
         return StreamingResponse(stream_results(), background=background_tasks)
 
     # Non-streaming case


### PR DESCRIPTION
# Pull Request Summary

_What is this PR changing? Why is this change being made? Any caveats you'd like to highlight? Link any relevant documents, links, or screenshots here if applicable._

There is a known error where vLLM's AsyncEngine will fail silently on OOM, but the webserver will continue running. There was a previous attempt at fixing this, but it didn't fully capture the line the error was happening. 

Stack trace:
```
File "/usr/local/lib/python3.10/dist-packages/fastapi/routing.py", line 191, in run_endpoint_function
  return await dependant.call(**values)
File "/workspace/vllm_server.py", line 112, in generate
  async for request_output in results_generator:
File "/usr/local/lib/python3.10/dist-packages/vllm/engine/async_llm_engine.py", line 666, in generate
  raise e
File "/usr/local/lib/python3.10/dist-packages/vllm/engine/async_llm_engine.py", line 650, in generate
  stream = await self.add_request(
File "/usr/local/lib/python3.10/dist-packages/vllm/engine/async_llm_engine.py", line 537, in add_request
  self.start_background_loop()
File "/usr/local/lib/python3.10/dist-packages/vllm/engine/async_llm_engine.py", line 411, in start_background_loop
raise AsyncEngineDeadError(
  vllm.engine.async_llm_engine.AsyncEngineDeadError: Background loop has errored already.
```

To mitigate this, we want to run the engine healthcheck on every request.
To kill the server, we have to manually kill the process via os since raising sigterm is caught by some middleware.

## Test Plan and Usage Guide

_How did you validate that your PR works correctly? How do you run or demo the code? Provide enough detail so a reviewer can reasonably reproduce the testing procedure. Paste example command line invocations if applicable._

Tested with sample uvicorn + fastapi server throwing deadengine errors

```
from typing import Any
import uvicorn
import signal
import os

from fastapi import BackgroundTasks, FastAPI, HTTPException, Request
from fastapi.responses import Response

app = FastAPI()

class AsyncEngineDeadError(Exception):
    pass

async def throw_error():
    raise AsyncEngineDeadError()

@app.get("/predict")
async def generate(request: Request) -> Response:
    try:
        await throw_error()
    except Exception as e:
        print(f"Engine not healthy: {e}")
        os.kill(os.getpid(), signal.SIGINT)

if __name__ == "__main__":
    uvicorn.run(app, port=8080, log_level="debug")

```
