### PR TITLE
Increase default concurrency to 100 for http forwarder

### DIFF
--- a/model-engine/model_engine_server/inference/forwarding/http_forwarder.py
+++ b/model-engine/model_engine_server/inference/forwarding/http_forwarder.py
@@ -51,7 +51,7 @@ def get_streaming_forwarder_loader():
 @lru_cache()
 def get_concurrency_limiter():
     config = get_config()
-    concurrency = int(config.get("max_concurrency", 5))
+    concurrency = int(config.get("max_concurrency", 50))
     return MultiprocessingConcurrencyLimiter(
         concurrency=concurrency, fail_on_concurrency_limit=True
     )

--- a/model-engine/model_engine_server/inference/forwarding/http_forwarder.py
+++ b/model-engine/model_engine_server/inference/forwarding/http_forwarder.py
@@ -51,7 +51,7 @@ def get_streaming_forwarder_loader():
 @lru_cache()
 def get_concurrency_limiter():
     config = get_config()
-    concurrency = int(config.get("max_concurrency", 50))
+    concurrency = int(config.get("max_concurrency", 100))
     return MultiprocessingConcurrencyLimiter(
         concurrency=concurrency, fail_on_concurrency_limit=True
     )


### PR DESCRIPTION
# Pull Request Summary

Quick change to increase the allowed concurrency to http endpoints

## Test Plan and Usage Guide

todo integration tests
