### PR TITLE
Allow hardware infer from client

### DIFF
--- a/clients/python/llmengine/data_types.py
+++ b/clients/python/llmengine/data_types.py
@@ -164,9 +164,9 @@ class CreateLLMEndpointRequest(BaseModel):
     metadata: Dict[str, Any]  # TODO: JSON type
     post_inference_hooks: Optional[List[str]]
     endpoint_type: ModelEndpointType = ModelEndpointType.STREAMING
-    cpus: CpuSpecificationType
-    gpus: int
-    memory: StorageSpecificationType
+    cpus: Optional[CpuSpecificationType]
+    gpus: Optional[int]
+    memory: Optional[StorageSpecificationType]
     gpu_type: Optional[GpuType]
     storage: Optional[StorageSpecificationType]
     optimize_costs: Optional[bool] = None


### PR DESCRIPTION
# Pull Request Summary

infer hardware when users don't specify cpu/gpu/memory/storage/gpu_type, also some docs

## Test Plan and Usage Guide

tested with
```
from llmengine import Model, api_engine

api_engine.set_api_key(<key>)
api_engine.set_base_path(<base_path>)
response = Model.create(
    name="llama-2-70b-test",
    model="llama-2-70b",
    inference_framework_image_tag="0.5.0",
    inference_framework="vllm",
    num_shards=4,
    # checkpoint_path="s3://path/to/checkpoint",
    min_workers=0,
    max_workers=1,
    per_worker=10,
    endpoint_type="streaming",
    public_inference=False,
    labels={"team": "infra", "product": "test"},
)

```
