### PR TITLE
More rigorous endpoint update handling

### DIFF
--- a/model-engine/tests/unit/domain/conftest.py
+++ b/model-engine/tests/unit/domain/conftest.py
@@ -31,6 +31,9 @@ from model_engine_server.domain.entities import (
     Quantization,
     StreamingEnhancedRunnableImageFlavor,
 )
+from model_engine_server.domain.use_cases.model_endpoint_use_cases import (
+    CONVERTED_FROM_ARTIFACT_LIKE_KEY,
+)
 
 
 @pytest.fixture
@@ -263,6 +266,19 @@ def update_llm_model_endpoint_request() -> UpdateLLMModelEndpointV1Request:
         min_workers=0,
         max_workers=1,
     )
+
+
+@pytest.fixture
+def update_llm_model_endpoint_request_only_workers() -> UpdateLLMModelEndpointV1Request:
+    return UpdateLLMModelEndpointV1Request(
+        min_workers=5,
+        max_workers=10,
+    )
+
+
+@pytest.fixture
+def update_llm_model_endpoint_request_bad_metadata() -> UpdateLLMModelEndpointV1Request:
+    return UpdateLLMModelEndpointV1Request(metadata={CONVERTED_FROM_ARTIFACT_LIKE_KEY: {}})
 
 
 @pytest.fixture


### PR DESCRIPTION
# Pull Request Summary

_What is this PR changing? Why is this change being made? Any caveats you'd like to highlight? Link any relevant documents, links, or screenshots here if applicable._

request.metadata is only set when certain fields are updated. This causes issues where endpoint metadata is reset when other fields are updates (e.g. min_workers).

This change updates the behavior to retain existing endpoint metadata if they exist

## Test Plan and Usage Guide

_How did you validate that your PR works correctly? How do you run or demo the code? Provide enough detail so a reviewer can reasonably reproduce the testing procedure. Paste example command line invocations if applicable._
