### PR TITLE
Parse wrapped sync endpoint error

### DIFF
--- a/model-engine/model_engine_server/infra/gateways/live_streaming_model_endpoint_inference_gateway.py
+++ b/model-engine/model_engine_server/infra/gateways/live_streaming_model_endpoint_inference_gateway.py
@@ -208,7 +208,7 @@ class LiveStreamingModelEndpointInferenceGateway(StreamingModelEndpointInference
             async for item in response:
                 yield SyncEndpointPredictV1Response(status=TaskStatus.SUCCESS, result=item)
         except UpstreamServiceError as exc:
-            logger.error(f"Service error on sync task: {exc.content!r}")
+            logger.error(f"Service error on streaming task: {exc.content!r}")
             try:
                 error_json = orjson.loads(exc.content.decode("utf-8"))
                 result_traceback = (

--- a/model-engine/model_engine_server/infra/gateways/live_sync_model_endpoint_inference_gateway.py
+++ b/model-engine/model_engine_server/infra/gateways/live_sync_model_endpoint_inference_gateway.py
@@ -187,11 +187,14 @@ class LiveSyncModelEndpointInferenceGateway(SyncModelEndpointInferenceGateway):
             logger.error(f"Service error on sync task: {exc.content!r}")
             try:
                 error_json = orjson.loads(exc.content.decode("utf-8"))
-                result_traceback = (
-                    error_json.get("detail", {}).get("traceback")
-                    if isinstance(error_json, dict)
-                    else None
-                )
+                if not isinstance(error_json, dict):
+                    result_traceback = None
+                else:
+                    if "result" in error_json:
+                        error_json = error_json["result"]
+                    result_traceback = error_json.get("detail", {}).get(
+                        "traceback", "Failed to parse traceback"
+                    )
                 return SyncEndpointPredictV1Response(
                     status=TaskStatus.FAILURE,
                     traceback=result_traceback,

--- a/model-engine/model_engine_server/infra/gateways/live_sync_model_endpoint_inference_gateway.py
+++ b/model-engine/model_engine_server/infra/gateways/live_sync_model_endpoint_inference_gateway.py
@@ -21,7 +21,6 @@ from model_engine_server.domain.gateways.sync_model_endpoint_inference_gateway i
     SyncModelEndpointInferenceGateway,
 )
 from model_engine_server.infra.gateways.k8s_resource_parser import get_node_port
-from orjson import JSONDecodeError
 from tenacity import (
     AsyncRetrying,
     RetryError,
@@ -186,27 +185,27 @@ class LiveSyncModelEndpointInferenceGateway(SyncModelEndpointInferenceGateway):
         except UpstreamServiceError as exc:
             logger.error(f"Service error on sync task: {exc.content!r}")
             try:
-                # Try to parse traceback from the response, fallback to just return all the content if failed
+                # Try to parse traceback from the response, fallback to just return all the content if failed.
+                # Three cases considered:
+                # detail.traceback
+                # result."detail.traceback"
+                # result."detail[]"
                 error_json = orjson.loads(exc.content.decode("utf-8"))
-                if not isinstance(error_json, dict):
-                    result_traceback = None
+                if "result" in error_json:
+                    error_json = orjson.loads(error_json["result"])
+                detail = error_json.get("detail", {})
+                if not isinstance(detail, dict):
+                    result_traceback = orjson.dumps(error_json)
                 else:
-                    if "result" in error_json:
-                        error_json = error_json["result"]
-                        if not isinstance(error_json, dict):
-                            error_json = orjson.loads(error_json)
-                    detail = error_json.get("detail", {})
-                    if not isinstance(detail, dict):
-                        result_traceback = orjson.dumps(error_json)
-                    else:
-                        result_traceback = error_json.get("detail", {}).get(
-                            "traceback", "Failed to parse traceback"
-                        )
+                    result_traceback = error_json.get("detail", {}).get(
+                        "traceback", "Failed to parse traceback"
+                    )
                 return SyncEndpointPredictV1Response(
                     status=TaskStatus.FAILURE,
                     traceback=result_traceback,
                 )
-            except JSONDecodeError:
+            except Exception as e:
+                logger.error(f"Failed to parse error: {e}")
                 return SyncEndpointPredictV1Response(
                     status=TaskStatus.FAILURE, traceback=exc.content.decode()
                 )

--- a/model-engine/tests/unit/infra/gateways/test_live_sync_model_endpoint_inference_gateway.py
+++ b/model-engine/tests/unit/infra/gateways/test_live_sync_model_endpoint_inference_gateway.py
@@ -179,3 +179,27 @@ async def test_predict_raises_traceback_not_json(
             "result": None,
             "traceback": "Test traceback content",
         }
+
+
+@pytest.mark.asyncio
+async def test_predict_raises_traceback_wrapped_traceback(
+    sync_endpoint_predict_request_1: Tuple[SyncEndpointPredictV1Request, Dict[str, Any]]
+):
+    gateway = LiveSyncModelEndpointInferenceGateway(use_asyncio=True)
+
+    content = json.dumps({"response": {"detail": {"traceback": "test_traceback"}}}).encode("utf-8")
+    fake_response = FakeResponse(status=500, content=content)
+    mock_client_session = _get_mock_client_session(fake_response)
+    with patch(
+        "model_engine_server.infra.gateways.live_sync_model_endpoint_inference_gateway.aiohttp.ClientSession",
+        mock_client_session,
+    ):
+        response = await gateway.predict(
+            topic="test_topic", predict_request=sync_endpoint_predict_request_1[0]
+        )
+        assert isinstance(response, SyncEndpointPredictV1Response)
+        assert response.dict() == {
+            "status": "FAILURE",
+            "result": None,
+            "traceback": "test_traceback",
+        }

--- a/model-engine/tests/unit/infra/gateways/test_live_sync_model_endpoint_inference_gateway.py
+++ b/model-engine/tests/unit/infra/gateways/test_live_sync_model_endpoint_inference_gateway.py
@@ -187,7 +187,7 @@ async def test_predict_raises_traceback_wrapped_traceback(
 ):
     gateway = LiveSyncModelEndpointInferenceGateway(use_asyncio=True)
 
-    content = json.dumps({"response": {"detail": {"traceback": "test_traceback"}}}).encode("utf-8")
+    content = json.dumps({"result": {"detail": {"traceback": "test_traceback"}}}).encode("utf-8")
     fake_response = FakeResponse(status=500, content=content)
     mock_client_session = _get_mock_client_session(fake_response)
     with patch(

--- a/model-engine/tests/unit/infra/gateways/test_live_sync_model_endpoint_inference_gateway.py
+++ b/model-engine/tests/unit/infra/gateways/test_live_sync_model_endpoint_inference_gateway.py
@@ -227,5 +227,5 @@ async def test_predict_raises_traceback_wrapped_detail_array(
         assert response.dict() == {
             "status": "FAILURE",
             "result": None,
-            "traceback": """{"detail": [{"error": "error"}]}""",
+            "traceback": """{"detail":[{"error":"error"}]}""",
         }


### PR DESCRIPTION
# Pull Request Summary

sometimes requests are wrapped and so are error details. do one extra step to get the data out

## Test Plan and Usage Guide

with the help of @Tma2333-Scale, tested for exception within the API (verified that we can get traceback),

and for exception from Pydantic before reaching to the API:
![image](https://github.com/user-attachments/assets/4e3fe711-7fed-49bf-8228-0e94313f8f02)

