### PR TITLE
Disable data parallelism for batch completions

### DIFF
--- a/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
+++ b/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
@@ -2460,6 +2460,11 @@ class CreateBatchCompletionsUseCase:
     async def execute(
         self, user: User, request: CreateBatchCompletionsRequest
     ) -> CreateBatchCompletionsResponse:
+        if request.data_parallelism is not None and request.data_parallelism > 1:
+            raise ObjectHasInvalidValueException(
+                "Data parallelism is disabled for batch completions."
+            )
+
         request.model_cfg.checkpoint_path = get_checkpoint_path(
             request.model_cfg.model, request.model_cfg.checkpoint_path
         )

--- a/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
+++ b/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
@@ -2460,7 +2460,9 @@ class CreateBatchCompletionsUseCase:
     async def execute(
         self, user: User, request: CreateBatchCompletionsRequest
     ) -> CreateBatchCompletionsResponse:
-        if request.data_parallelism is not None and request.data_parallelism > 1: # pragma: no cover
+        if (
+            request.data_parallelism is not None and request.data_parallelism > 1
+        ):  # pragma: no cover
             raise ObjectHasInvalidValueException(
                 "Data parallelism is disabled for batch completions."
             )

--- a/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
+++ b/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
@@ -2460,7 +2460,7 @@ class CreateBatchCompletionsUseCase:
     async def execute(
         self, user: User, request: CreateBatchCompletionsRequest
     ) -> CreateBatchCompletionsResponse:
-        if request.data_parallelism is not None and request.data_parallelism > 1:
+        if request.data_parallelism is not None and request.data_parallelism > 1: # pragma: no cover
             raise ObjectHasInvalidValueException(
                 "Data parallelism is disabled for batch completions."
             )

--- a/model-engine/tests/unit/domain/conftest.py
+++ b/model-engine/tests/unit/domain/conftest.py
@@ -534,7 +534,7 @@ def create_batch_completions_request() -> CreateBatchCompletionsRequest:
             model="mpt-7b",
             checkpoint_path="s3://test_checkpoint_path",
             labels={},
-            num_shards=2,
+            num_shards=1,
         ),
-        data_parallelism=2,
+        data_parallelism=1,
     )


### PR DESCRIPTION
# Pull Request Summary

_What is this PR changing? Why is this change being made? Any caveats you'd like to highlight? Link any relevant documents, links, or screenshots here if applicable._

The current implementation for data parallelism has a race condition where gpus can be fully utilized by 1 worker across many jobs and cause a deadlock while they wait for the other workers to spin up. Disabling this feature until we fix this bug

## Test Plan and Usage Guide

_How did you validate that your PR works correctly? How do you run or demo the code? Provide enough detail so a reviewer can reasonably reproduce the testing procedure. Paste example command line invocations if applicable._
