### PR TITLE
Make configs backwards-compatible

### DIFF
--- a/model-engine/model_engine_server/common/config.py
+++ b/model-engine/model_engine_server/common/config.py
@@ -1,6 +1,7 @@
 # Keep in line with service_config_{*}.yaml
 # This file loads sensitive data that shouldn't make it to inference docker images
 # Do not include this file in our inference/endpoint code
+import inspect
 import os
 from dataclasses import dataclass
 from pathlib import Path
@@ -77,15 +78,14 @@ class HostedModelInferenceServiceConfig:
     ] = None  # Not an env var because the redis cache info is already here
 
     @classmethod
+    def from_json(cls, json):
+        return cls(**{k: v for k, v in json.items() if k in inspect.signature(cls).parameters})
+
+    @classmethod
     def from_yaml(cls, yaml_path):
         with open(yaml_path, "r") as f:
             raw_data = yaml.safe_load(f)
-        raw_data = {
-            key: value
-            for key, value in raw_data.items()
-            if key in HostedModelInferenceServiceConfig.__annotations__
-        }
-        return HostedModelInferenceServiceConfig(**raw_data)
+        return HostedModelInferenceServiceConfig.from_json(raw_data)
 
     @property
     def cache_redis_url(self) -> str:

--- a/model-engine/model_engine_server/core/config.py
+++ b/model-engine/model_engine_server/core/config.py
@@ -4,6 +4,7 @@ The configuration file is loaded from the ML_INFRA_SERVICES_CONFIG_PATH environm
 If this is not set, the default configuration file is used from
 model_engine_server.core/configs/default.yaml.
 """
+import inspect
 import os
 from contextlib import contextmanager
 from copy import deepcopy
@@ -48,13 +49,14 @@ class InfraConfig:
     firehose_stream_name: Optional[str] = None
 
     @classmethod
+    def from_json(cls, json):
+        return cls(**{k: v for k, v in json.items() if k in inspect.signature(cls).parameters})
+
+    @classmethod
     def from_yaml(cls, yaml_path) -> "InfraConfig":
         with open(yaml_path, "r") as f:
             raw_data = yaml.safe_load(f)
-        raw_data = {
-            key: value for key, value in raw_data.items() if key in InfraConfig.__annotations__
-        }
-        return InfraConfig(**raw_data)
+        return InfraConfig.from_json(raw_data)
 
 
 def read_default_config():


### PR DESCRIPTION
# Pull Request Summary

Filter out extra config fields to fix `TypeError: __init__() got an unexpected keyword argument 'cache_redis_url'` error in customer VPC occurring from `cache_redis_url` being an old parameter that some versions of the model engine instantiation code still pass in

## Test Plan and Usage Guide

_How did you validate that your PR works correctly? How do you run or demo the code? Provide enough detail so a reviewer can reasonably reproduce the testing procedure. Paste example command line invocations if applicable._
