### PR TITLE
Multinode bundle db migration + orm class + entity

### DIFF
--- a/model-engine/model_engine_server/db/migrations/alembic/versions/2024_09_24_1456-f55525c81eb5_multinode_bundle.py
+++ b/model-engine/model_engine_server/db/migrations/alembic/versions/2024_09_24_1456-f55525c81eb5_multinode_bundle.py
@@ -1,0 +1,25 @@
+"""multinode_bundle
+
+Revision ID: f55525c81eb5
+Revises: b574e9711e35
+Create Date: 2024-09-24 14:56:36.287001
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f55525c81eb5"
+down_revision = "b574e9711e35"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # TODO
+    pass
+
+
+def downgrade() -> None:
+    # TODO
+    pass

--- a/model-engine/model_engine_server/db/migrations/alembic/versions/2024_09_24_1456-f55525c81eb5_multinode_bundle.py
+++ b/model-engine/model_engine_server/db/migrations/alembic/versions/2024_09_24_1456-f55525c81eb5_multinode_bundle.py
@@ -7,6 +7,7 @@ Create Date: 2024-09-24 14:56:36.287001
 """
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects.postgresql import ARRAY
 
 # revision identifiers, used by Alembic.
 revision = "f55525c81eb5"
@@ -16,10 +17,26 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # TODO
-    pass
+    op.add_column(
+        "bundles",
+        sa.Column("runnable_image_worker_command", ARRAY(sa.Text), nullable=True),
+        schema="hosted_model_inference",
+    )
+    op.add_column(
+        "bundles",
+        sa.Column("runnable_image_worker_args", sa.JSON, nullable=True),
+        schema="hosted_model_inference",
+    )
 
 
 def downgrade() -> None:
-    # TODO
-    pass
+    op.drop_column(
+        "bundles",
+        "runnable_image_worker_command",
+        schema="hosted_model_inference",
+    )
+    op.drop_column(
+        "bundles",
+        "runnable_image_worker_args",
+        schema="hosted_model_inference",
+    )

--- a/model-engine/model_engine_server/db/migrations/alembic/versions/2024_09_24_1456-f55525c81eb5_multinode_bundle.py
+++ b/model-engine/model_engine_server/db/migrations/alembic/versions/2024_09_24_1456-f55525c81eb5_multinode_bundle.py
@@ -24,7 +24,7 @@ def upgrade() -> None:
     )
     op.add_column(
         "bundles",
-        sa.Column("runnable_image_worker_args", sa.JSON, nullable=True),
+        sa.Column("runnable_image_worker_env", sa.JSON, nullable=True),
         schema="hosted_model_inference",
     )
 
@@ -37,6 +37,6 @@ def downgrade() -> None:
     )
     op.drop_column(
         "bundles",
-        "runnable_image_worker_args",
+        "runnable_image_worker_env",
         schema="hosted_model_inference",
     )

--- a/model-engine/model_engine_server/db/models/hosted_model_inference.py
+++ b/model-engine/model_engine_server/db/models/hosted_model_inference.py
@@ -209,6 +209,8 @@ class Bundle(Base):
         runnable_image_protocol: Optional[str] = None,
         runnable_image_readiness_initial_delay_seconds: Optional[int] = None,
         runnable_image_extra_routes: Optional[List[str]] = None,
+        runnable_image_worker_command: Optional[List[str]] = None,
+        runnable_image_worker_env: Optional[Dict[str, Any]] = None,
         # Streaming Enhanced Runnable Image fields
         streaming_enhanced_runnable_image_streaming_command: Optional[List[str]] = None,
         streaming_enhanced_runnable_image_streaming_predict_route: Optional[str] = None,
@@ -265,6 +267,8 @@ class Bundle(Base):
         self.runnable_image_env = runnable_image_env
         self.runnable_image_protocol = runnable_image_protocol
         self.runnable_image_extra_routes = runnable_image_extra_routes
+        self.runnable_image_worker_command = runnable_image_worker_command
+        self.runnable_image_worker_env = runnable_image_worker_env
         self.runnable_image_readiness_initial_delay_seconds = (
             runnable_image_readiness_initial_delay_seconds
         )

--- a/model-engine/model_engine_server/db/models/hosted_model_inference.py
+++ b/model-engine/model_engine_server/db/models/hosted_model_inference.py
@@ -147,6 +147,8 @@ class Bundle(Base):
     runnable_image_protocol = Column(Text, nullable=True)
     runnable_image_readiness_initial_delay_seconds = Column(Integer, nullable=True)
     runnable_image_extra_routes = Column(ARRAY(Text), nullable=True)
+    runnable_image_worker_command = Column(ARRAY(Text), nullable=True)
+    runnable_image_worker_env = Column(JSON, nullable=True)
 
     # Streaming Enhanced Runnable Image fields
     streaming_enhanced_runnable_image_streaming_command = Column(ARRAY(Text), nullable=True)

--- a/model-engine/model_engine_server/domain/entities/model_bundle_entity.py
+++ b/model-engine/model_engine_server/domain/entities/model_bundle_entity.py
@@ -158,6 +158,8 @@ class RunnableImageLike(BaseModel, ABC):
     protocol: Literal["http"]  # TODO: add support for other protocols (e.g. grpc)
     readiness_initial_delay_seconds: int = 120
     extra_routes: List[str] = Field(default_factory=list)
+    worker_command: Optional[List[str]] = None
+    worker_env: Optional[Dict[str, str]] = None
 
 
 class RunnableImageFlavor(RunnableImageLike):

--- a/model-engine/model_engine_server/infra/repositories/db_model_bundle_repository.py
+++ b/model-engine/model_engine_server/infra/repositories/db_model_bundle_repository.py
@@ -147,6 +147,8 @@ def translate_model_bundle_orm_to_model_bundle(
             protocol=model_bundle_orm.runnable_image_protocol,
             readiness_initial_delay_seconds=model_bundle_orm.runnable_image_readiness_initial_delay_seconds,
             extra_routes=model_bundle_orm.runnable_image_extra_routes,
+            worker_command=model_bundle_orm.runnable_image_worker_command,
+            worker_env=model_bundle_orm.runnable_image_worker_env,
             streaming_command=model_bundle_orm.streaming_enhanced_runnable_image_streaming_command,
             streaming_predict_route=model_bundle_orm.streaming_enhanced_runnable_image_streaming_predict_route,
             triton_model_repository=model_bundle_orm.triton_enhanced_runnable_image_model_repository,
@@ -216,6 +218,8 @@ def translate_kwargs_to_model_bundle_orm(
             "readiness_initial_delay_seconds"
         ),
         runnable_image_extra_routes=flavor_dict.get("extra_routes"),
+        runnable_image_worker_command=flavor_dict.get("worker_command"),
+        runnable_image_worker_env=flavor_dict.get("worker_env"),
         streaming_enhanced_runnable_image_streaming_command=flavor_dict.get("streaming_command"),
         streaming_enhanced_runnable_image_streaming_predict_route=flavor_dict.get(
             "streaming_predict_route"


### PR DESCRIPTION
# Pull Request Summary

Add two columns for worker command + worker env to the bundle table + orm class + entity class

## Test Plan and Usage Guide

the integration tests do seem to exercise the db migration which is pretty cool, and it caught a typo where I named the column in the migration script wrong
will run db migration after merge
