### PR TITLE
Make cooldown period configurable

### DIFF
--- a/charts/model-engine/Chart.yaml
+++ b/charts/model-engine/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/model-engine/templates/service_template_config_map.yaml
+++ b/charts/model-engine/templates/service_template_config_map.yaml
@@ -444,7 +444,7 @@ data:
       scaleTargetRef:
         name: ${RESOURCE_NAME}
       pollingInterval:  5
-      cooldownPeriod:   300
+      cooldownPeriod:   {{ .Values.keda.cooldownPeriod }}
       minReplicaCount:  ${MIN_WORKERS}
       maxReplicaCount:  ${MAX_WORKERS}
       fallback:

--- a/charts/model-engine/values.yaml
+++ b/charts/model-engine/values.yaml
@@ -16,3 +16,5 @@ balloonNodeSelector:
   node-lifecycle: normal
 nodeSelector:
   node-lifecycle: normal
+keda:
+  cooldownPeriod: 300


### PR DESCRIPTION
# Pull Request Summary

Allow the `cooldownPeriod` used in keda for autoscaling to be set as a helm value.

## Test Plan and Usage Guide

Ran `helm template model-engine model-engine/ -f model-engine/values_circleci.yaml` to validate it gets populated as intended