### PR TITLE
[SGP] Add cooldown period customizability for celery through annotations

### DIFF
--- a/charts/model-engine/Chart.yaml
+++ b/charts/model-engine/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.6
+version: 0.1.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/model-engine/Chart.yaml
+++ b/charts/model-engine/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.7
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/model-engine/model_engine_server/core/celery/celery_autoscaler.py
+++ b/model-engine/model_engine_server/core/celery/celery_autoscaler.py
@@ -65,6 +65,7 @@ class CeleryAutoscalerParams:
     per_worker: int = 1
     min_workers: int = 0
     max_workers: int = 1
+    cooldown_period_seconds: int = 600
 
 
 def _hash_any_to_int(data: Any):
@@ -153,9 +154,9 @@ class Instance:
         time_now = time.monotonic()
         self.history.append((workers_wanted, time_now))
 
-        # Take last 10 minutes
+        # Use cooldown_period in seconds
         times = [t for _, t in self.history]
-        evict = bisect(times, time_now - 600)
+        evict = bisect(times, time_now - self.params.cooldown_period_seconds)
         self.history = self.history[evict:]
 
         workers_wanted = max(self.history)[0]  # type: ignore

--- a/model-engine/model_engine_server/core/celery/celery_autoscaler.py
+++ b/model-engine/model_engine_server/core/celery/celery_autoscaler.py
@@ -154,7 +154,7 @@ class Instance:
         time_now = time.monotonic()
         self.history.append((workers_wanted, time_now))
 
-        # Use cooldown_period in seconds
+        # Use cooldown_period_seconds
         times = [t for _, t in self.history]
         evict = bisect(times, time_now - self.params.cooldown_period_seconds)
         self.history = self.history[evict:]


### PR DESCRIPTION
# Pull Request Summary

Use the `celery.scaleml.autoscaler/cooldownPeriodSeconds` annotation to customize the cooldown period (how long the deployment stays up for after it has been autoscaled up).

For the initial version, will just rely on editing the deployment to add this annotation.

## Test Plan and Usage Guide

_How did you validate that your PR works correctly? How do you run or demo the code? Provide enough detail so a reviewer can reasonably reproduce the testing procedure. Paste example command line invocations if applicable._
