### PR TITLE
fix dumb mistake in cacher, also bump the ttl

### DIFF
--- a/model-engine/model_engine_server/infra/gateways/resources/k8s_endpoint_resource_delegate.py
+++ b/model-engine/model_engine_server/infra/gateways/resources/k8s_endpoint_resource_delegate.py
@@ -1897,8 +1897,9 @@ class K8SEndpointResourceDelegate:
         else:
             command = forwarder_container.command
             # look for the thing that comes after --num-workers
-            num_workers_index = command.index("--num-workers")
-            if num_workers_index == -1:
+            try:
+                num_workers_index = command.index("--num-workers")
+            except ValueError:
                 concurrent_requests_per_worker = 1
             else:
                 concurrent_requests_per_worker = int(command[num_workers_index + 1])

--- a/model-engine/model_engine_server/infra/services/live_endpoint_builder_service.py
+++ b/model-engine/model_engine_server/infra/services/live_endpoint_builder_service.py
@@ -80,7 +80,7 @@ GIT_TAG: str = os.getenv("GIT_TAG")  # type: ignore
 ENV: str = os.getenv("DD_ENV")  # type: ignore
 WORKSPACE_PATH = os.getenv("WORKSPACE", ".")
 
-INITIAL_K8S_CACHE_TTL_SECONDS: int = 60
+INITIAL_K8S_CACHE_TTL_SECONDS: int = 180
 MAX_IMAGE_TAG_LEN = 128
 
 RESTRICTED_ENV_VARS_KEYS = {

--- a/model-engine/model_engine_server/infra/services/live_model_endpoint_service.py
+++ b/model-engine/model_engine_server/infra/services/live_model_endpoint_service.py
@@ -129,7 +129,7 @@ class LiveModelEndpointService(ModelEndpointService):
             )
             if state is not None:
                 await self.model_endpoint_cache_repository.write_endpoint_info(
-                    endpoint_id=record.id, endpoint_info=state, ttl_seconds=60
+                    endpoint_id=record.id, endpoint_info=state, ttl_seconds=180
                 )
         return state
 

--- a/model-engine/tests/unit/infra/gateways/resources/test_k8s_endpoint_resource_delegate.py
+++ b/model-engine/tests/unit/infra/gateways/resources/test_k8s_endpoint_resource_delegate.py
@@ -937,3 +937,15 @@ async def test_get_async_autoscaling_params(k8s_endpoint_resource_delegate):
         per_worker=5,
         concurrent_requests_per_worker=24,
     )
+
+    # test old format for backwards compatibility
+    celery_forwarder.command = ["a", "b", "c", "d"]
+    autoscaling_params = K8SEndpointResourceDelegate._get_async_autoscaling_params(
+        deployment_config
+    )
+    assert autoscaling_params == dict(
+        min_workers=1,
+        max_workers=2,
+        per_worker=5,
+        concurrent_requests_per_worker=1,
+    )


### PR DESCRIPTION
# Pull Request Summary

Found a silly mistake in the code that runs in the cacher, which led to cacher errors on some old deployments
Also bump ttl

## Test Plan and Usage Guide

Will deploy to cluster and see if the error messages are still there, which they aren't
