### PR TITLE
Fix small nodes_per_worker bug in batch completions v2

### DIFF
--- a/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
+++ b/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
@@ -3603,6 +3603,7 @@ class CreateBatchCompletionsV2UseCase:
                 memory=request.memory,
                 storage=request.storage,
                 gpu_type=request.gpu_type,
+                nodes_per_worker=request.nodes_per_worker or 1,
             )
         else:
             if (

--- a/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
+++ b/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
@@ -298,6 +298,8 @@ _SUPPORTED_QUANTIZATIONS: Dict[LLMInferenceFramework, List[Quantization]] = {
 NUM_DOWNSTREAM_REQUEST_RETRIES = 80  # has to be high enough so that the retries take the 5 minutes
 DOWNSTREAM_REQUEST_TIMEOUT_SECONDS = 5 * 60  # 5 minutes
 
+DEFAULT_BATCH_COMPLETIONS_NODES_PER_WORKER = 1
+
 SERVICE_NAME = "model-engine"
 SERVICE_IDENTIFIER = os.getenv("SERVICE_IDENTIFIER")
 if SERVICE_IDENTIFIER:
@@ -3603,7 +3605,8 @@ class CreateBatchCompletionsV2UseCase:
                 memory=request.memory,
                 storage=request.storage,
                 gpu_type=request.gpu_type,
-                nodes_per_worker=request.nodes_per_worker or 1,
+                nodes_per_worker=request.nodes_per_worker
+                or DEFAULT_BATCH_COMPLETIONS_NODES_PER_WORKER,
             )
         else:
             if (

--- a/model-engine/tests/unit/domain/test_llm_use_cases.py
+++ b/model-engine/tests/unit/domain/test_llm_use_cases.py
@@ -2964,6 +2964,39 @@ async def test_create_batch_completions_v2(
         num_workers=create_batch_completions_v2_request.data_parallelism,
     )
 
+    create_batch_completions_v2_request_with_hardware.nodes_per_worker = 2
+
+    await use_case.execute(create_batch_completions_v2_request_with_hardware, user)
+
+    expected_engine_request = CreateBatchCompletionsEngineRequest(
+        model_cfg=create_batch_completions_v2_request_with_hardware.model_cfg,
+        max_runtime_sec=create_batch_completions_v2_request_with_hardware.max_runtime_sec,
+        data_parallelism=create_batch_completions_v2_request_with_hardware.data_parallelism,
+        labels=create_batch_completions_v2_request_with_hardware.labels,
+        content=create_batch_completions_v2_request_with_hardware.content,
+        output_data_path=create_batch_completions_v2_request_with_hardware.output_data_path,
+    )
+
+    expected_hardware = CreateDockerImageBatchJobResourceRequests(
+        cpus=create_batch_completions_v2_request_with_hardware.cpus,
+        gpus=create_batch_completions_v2_request_with_hardware.gpus,
+        memory=create_batch_completions_v2_request_with_hardware.memory,
+        storage=create_batch_completions_v2_request_with_hardware.storage,
+        gpu_type=create_batch_completions_v2_request_with_hardware.gpu_type,
+        nodes_per_worker=2,
+    )
+    # assert fake_llm_batch_completions_service was called with the correct arguments
+    fake_llm_batch_completions_service.create_batch_job.assert_called_with(
+        user=user,
+        job_request=expected_engine_request,
+        image_repo="llm-engine/batch-infer-vllm",
+        image_tag="fake_docker_repository_latest_image_tag",
+        resource_requests=expected_hardware,
+        labels=create_batch_completions_v2_request.labels,
+        max_runtime_sec=create_batch_completions_v2_request.max_runtime_sec,
+        num_workers=create_batch_completions_v2_request.data_parallelism,
+    )
+
 
 def test_merge_metadata():
     request_metadata = {

--- a/model-engine/tests/unit/domain/test_llm_use_cases.py
+++ b/model-engine/tests/unit/domain/test_llm_use_cases.py
@@ -45,6 +45,7 @@ from model_engine_server.domain.use_cases.llm_fine_tuning_use_cases import (
 )
 from model_engine_server.domain.use_cases.llm_model_endpoint_use_cases import (
     CHAT_TEMPLATE_MAX_LENGTH,
+    DEFAULT_BATCH_COMPLETIONS_NODES_PER_WORKER,
     CompletionStreamV1UseCase,
     CompletionSyncV1UseCase,
     CreateBatchCompletionsUseCase,
@@ -2949,7 +2950,7 @@ async def test_create_batch_completions_v2(
         memory=create_batch_completions_v2_request_with_hardware.memory,
         storage=create_batch_completions_v2_request_with_hardware.storage,
         gpu_type=create_batch_completions_v2_request_with_hardware.gpu_type,
-        nodes_per_worker=create_batch_completions_v2_request_with_hardware.nodes_per_worker,
+        nodes_per_worker=DEFAULT_BATCH_COMPLETIONS_NODES_PER_WORKER,
     )
     # assert fake_llm_batch_completions_service was called with the correct arguments
     fake_llm_batch_completions_service.create_batch_job.assert_called_with(


### PR DESCRIPTION
# Pull Request Summary

Default nodes_per_worker to 1 if not provided, still infer hardware if not all of cpus/gpus/gpu type/storage/mem provided. Bug was that we'd pass nodes_per_worker as None to the gateway, which arguably can be considered not according to spec

## Test Plan and Usage Guide

Unit tests
