### PR TITLE
switch cacher and endpoint builder to the same updateMode as the gateway

### DIFF
--- a/charts/model-engine/Chart.yaml
+++ b/charts/model-engine/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.6
+version: 0.1.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/model-engine/templates/cacher_vpa.yaml
+++ b/charts/model-engine/templates/cacher_vpa.yaml
@@ -11,7 +11,7 @@ spec:
     kind: Deployment
     name: {{ include "modelEngine.cachername" . }}
   updatePolicy:
-    updateMode: "Auto"
+    updateMode: {{ .Values.autoscaling.vertical.updateMode }}
   resourcePolicy:
     containerPolicies:
       - containerName: {{ include "modelEngine.cachername" . }}

--- a/charts/model-engine/templates/endpoint_builder_vpa.yaml
+++ b/charts/model-engine/templates/endpoint_builder_vpa.yaml
@@ -11,7 +11,7 @@ spec:
     kind: Deployment
     name: {{ include "modelEngine.buildername" . }}
   updatePolicy:
-    updateMode: "Auto"
+    updateMode: {{ .Values.autoscaling.vertical.updateMode }}
   resourcePolicy:
     containerPolicies:
       - containerName: {{ include "modelEngine.buildername" . }}


### PR DESCRIPTION
# Pull Request Summary

Change the vpa recommender settings to have gateway, cacher, and endpoint builder share the same updateMode; currently it's set so the cacher and endpoint builder are more aggressive in getting scaled in recommendations. Also I noticed a boot loop with the cacher, this should fix things

## Test Plan and Usage Guide

_How did you validate that your PR works correctly? How do you run or demo the code? Provide enough detail so a reviewer can reasonably reproduce the testing procedure. Paste example command line invocations if applicable._
