### PR TITLE
fix: Sets terminationGracePeriodSeconds: 60 and adds --graceful-timeout 60 to entrypoint

### DIFF
--- a/charts/model-engine/Chart.yaml
+++ b/charts/model-engine/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.7
+version: 0.1.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/model-engine/templates/gateway_deployment.yaml
+++ b/charts/model-engine/templates/gateway_deployment.yaml
@@ -37,6 +37,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: 60
       priorityClassName: model-engine-high-priority
       containers:
         - name: {{ include "modelEngine.fullname" . }}

--- a/model-engine/model_engine_server/entrypoints/start_fastapi_server.py
+++ b/model-engine/model_engine_server/entrypoints/start_fastapi_server.py
@@ -20,6 +20,8 @@ def start_gunicorn_server(port: int, num_workers: int, debug: bool) -> None:
         f"[::]:{port}",
         "--timeout",
         "60",
+        "--graceful-timeout",
+        "60",
         "--keep-alive",
         "2",
         "--worker-class",


### PR DESCRIPTION
So it matches with --timeout 60 in start_fastapi_server.py

# Pull Request Summary

_What is this PR changing? Why is this change being made? Any caveats you'd like to highlight? Link any relevant documents, links, or screenshots here if applicable._

## Test Plan and Usage Guide

_How did you validate that your PR works correctly? How do you run or demo the code? Provide enough detail so a reviewer can reasonably reproduce the testing procedure. Paste example command line invocations if applicable._
