### PR TITLE
MLI-3695 Add disable EC2 metadata for batch completions

### DIFF
--- a/model-engine/model_engine_server/inference/vllm/vllm_batch.py
+++ b/model-engine/model_engine_server/inference/vllm/vllm_batch.py
@@ -105,6 +105,7 @@ async def download_model(checkpoint_path: str, target_dir: str, trust_remote_cod
     # Need to override these env vars so s5cmd uses AWS_PROFILE
     env["AWS_ROLE_ARN"] = ""
     env["AWS_WEB_IDENTITY_TOKEN_FILE"] = ""
+    env["AWS_EC2_METADATA_DISABLED"] = "true" # Disable EC2 metadata for GKE (won't affect EKS)
     process = subprocess.Popen(
         s5cmd,
         shell=True,  # nosemgrep

--- a/model-engine/model_engine_server/inference/vllm/vllm_batch.py
+++ b/model-engine/model_engine_server/inference/vllm/vllm_batch.py
@@ -105,7 +105,7 @@ async def download_model(checkpoint_path: str, target_dir: str, trust_remote_cod
     # Need to override these env vars so s5cmd uses AWS_PROFILE
     env["AWS_ROLE_ARN"] = ""
     env["AWS_WEB_IDENTITY_TOKEN_FILE"] = ""
-    env["AWS_EC2_METADATA_DISABLED"] = "true" # Disable EC2 metadata for GKE (won't affect EKS)
+    env["AWS_EC2_METADATA_DISABLED"] = "true"  # Disable EC2 metadata for GKE (won't affect EKS)
     process = subprocess.Popen(
         s5cmd,
         shell=True,  # nosemgrep


### PR DESCRIPTION
# Pull Request Summary

_What is this PR changing? Why is this change being made? Any caveats you'd like to highlight? Link any relevant documents, links, or screenshots here if applicable._

This PR adds `AWS_EC2_METADATA_DISABLED=true` to the environment when launching s5cmd in the batch inference script. This prevents the AWS SDK from attempting to access the EC2 metadata service, which is not available in GKE.


## Test Plan and Usage Guide

_How did you validate that your PR works correctly? How do you run or demo the code? Provide enough detail so a reviewer can reasonably reproduce the testing procedure. Paste example command line invocations if applicable._
