### PR TITLE
fix: Adds serviceBuilderQueue

### DIFF
--- a/charts/model-engine/Chart.yaml
+++ b/charts/model-engine/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.8
+version: 0.1.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/model-engine/templates/_helpers.tpl
+++ b/charts/model-engine/templates/_helpers.tpl
@@ -300,6 +300,10 @@ env:
     {{- if .Values.serviceIdentifier }}
     value: {{ .Values.serviceIdentifier }}
     {{- end }}
+   - name: SERVICE_BUILDER_QUEUE
+    {{- if .Values.serviceBuilderQueue }}
+    value: {{ .Values.serviceBuilderQueue }}
+    {{- end }}
   - name: GATEWAY_URL
     value: {{ include "modelEngine.gatewayurl" . }}
   {{- if .Values.aws }}

--- a/charts/model-engine/templates/_helpers.tpl
+++ b/charts/model-engine/templates/_helpers.tpl
@@ -300,7 +300,7 @@ env:
     {{- if .Values.serviceIdentifier }}
     value: {{ .Values.serviceIdentifier }}
     {{- end }}
-   - name: SERVICE_BUILDER_QUEUE
+  - name: SERVICE_BUILDER_QUEUE
     {{- if .Values.serviceBuilderQueue }}
     value: {{ .Values.serviceBuilderQueue }}
     {{- end }}

--- a/charts/model-engine/templates/endpoint_builder_deployment.yaml
+++ b/charts/model-engine/templates/endpoint_builder_deployment.yaml
@@ -55,7 +55,9 @@ spec:
             - worker
             - --loglevel=INFO
             - --concurrency=2
-            {{- if .Values.serviceIdentifier }}
+            {{- if .Values.serviceBuilderQueue }}
+            - --queues={{ .Values.serviceBuilderQueue }}
+            {{- else if .Values.serviceIdentifier }}
             - --queues=model-engine-{{ .Values.serviceIdentifier }}-service-builder
             {{- else }}
             - --queues=model-engine-service-builder

--- a/charts/model-engine/values_sample.yaml
+++ b/charts/model-engine/values_sample.yaml
@@ -398,3 +398,4 @@ recommendedHardware:
       storage: 640Gi
       gpu_type: nvidia-hopper-h100
       nodes_per_worker: 1
+#serviceBuilderQueue:

--- a/model-engine/model_engine_server/common/settings.py
+++ b/model-engine/model_engine_server/common/settings.py
@@ -84,9 +84,11 @@ def get_sync_endpoint_elb_url(deployment_name: str) -> str:
     return f"http://{deployment_name}.{infra_config().dns_host_domain}/predict"
 
 
-def get_service_builder_queue(service_identifier=None):
+def get_service_builder_queue(service_identifier=None, service_builder_queue_name=None):
     return (
-        f"{SERVICE_BUILDER_QUEUE_PREFIX}-{service_identifier}-{SERVICE_BUILDER_QUEUE_SUFFIX}"
+        service_builder_queue_name
+        if service_builder_queue_name
+        else f"{SERVICE_BUILDER_QUEUE_PREFIX}-{service_identifier}-{SERVICE_BUILDER_QUEUE_SUFFIX}"
         if service_identifier
         else f"{SERVICE_BUILDER_QUEUE_PREFIX}-{SERVICE_BUILDER_QUEUE_SUFFIX}"
     )

--- a/model-engine/model_engine_server/common/settings.py
+++ b/model-engine/model_engine_server/common/settings.py
@@ -85,13 +85,12 @@ def get_sync_endpoint_elb_url(deployment_name: str) -> str:
 
 
 def get_service_builder_queue(service_identifier=None, service_builder_queue_name=None):
-    return (
-        service_builder_queue_name
-        if service_builder_queue_name
-        else f"{SERVICE_BUILDER_QUEUE_PREFIX}-{service_identifier}-{SERVICE_BUILDER_QUEUE_SUFFIX}"
-        if service_identifier
-        else f"{SERVICE_BUILDER_QUEUE_PREFIX}-{SERVICE_BUILDER_QUEUE_SUFFIX}"
-    )
+    if service_builder_queue_name:
+        return service_builder_queue_name
+    elif service_identifier:
+        return f"{SERVICE_BUILDER_QUEUE_PREFIX}-{service_identifier}-{SERVICE_BUILDER_QUEUE_SUFFIX}"
+    else:
+        return f"{SERVICE_BUILDER_QUEUE_PREFIX}-{SERVICE_BUILDER_QUEUE_SUFFIX}"
 
 
 def get_quart_server_name(service_identifier=None):

--- a/model-engine/model_engine_server/infra/gateways/live_model_endpoint_infra_gateway.py
+++ b/model-engine/model_engine_server/infra/gateways/live_model_endpoint_infra_gateway.py
@@ -26,6 +26,7 @@ from model_engine_server.infra.gateways.resources.endpoint_resource_gateway impo
 
 BUILD_TASK_NAME = "model_engine_server.service_builder.tasks_v1.build_endpoint"
 SERVICE_IDENTIFIER = os.getenv("SERVICE_IDENTIFIER")
+SERVICE_BUILDER_QUEUE = os.getenv("SERVICE_BUILDER_QUEUE")
 
 
 def redact_restricted_labels(labels: Dict[str, str]) -> None:
@@ -106,7 +107,7 @@ class LiveModelEndpointInfraGateway(ModelEndpointInfraGateway):
         )
         response = self.task_queue_gateway.send_task(
             task_name=BUILD_TASK_NAME,
-            queue_name=get_service_builder_queue(SERVICE_IDENTIFIER),
+            queue_name=get_service_builder_queue(SERVICE_IDENTIFIER, SERVICE_BUILDER_QUEUE),
             # celery request is required to be JSON serializables
             kwargs=dict(build_endpoint_request_json=build_endpoint_request.dict()),
         )
@@ -226,7 +227,7 @@ class LiveModelEndpointInfraGateway(ModelEndpointInfraGateway):
         )
         response = self.task_queue_gateway.send_task(
             task_name=BUILD_TASK_NAME,
-            queue_name=get_service_builder_queue(SERVICE_IDENTIFIER),
+            queue_name=get_service_builder_queue(SERVICE_IDENTIFIER, SERVICE_BUILDER_QUEUE),
             kwargs=dict(build_endpoint_request_json=build_endpoint_request.dict()),
         )
         return response.task_id

--- a/model-engine/tests/unit/common/test_settings.py
+++ b/model-engine/tests/unit/common/test_settings.py
@@ -1,0 +1,16 @@
+from model_engine_server.common.settings import get_service_builder_queue
+
+
+def test_get_service_builder_queue():
+    assert (
+        get_service_builder_queue(service_identifier=None, service_builder_queue_name="test")
+        == "test"
+    )
+    assert (
+        get_service_builder_queue(service_identifier=None, service_builder_queue_name=None)
+        == "model-engine-service-builder"
+    )
+    assert (
+        get_service_builder_queue(service_identifier="test", service_builder_queue_name=None)
+        == "model-engine-test-service-builder"
+    )


### PR DESCRIPTION
Allows to set model engine service builder queue name

Required to run multiple instances of Model Engine in same AWS account

# Pull Request Summary

_What is this PR changing? Why is this change being made? Any caveats you'd like to highlight? Link any relevant documents, links, or screenshots here if applicable._

## Test Plan and Usage Guide

_How did you validate that your PR works correctly? How do you run or demo the code? Provide enough detail so a reviewer can reasonably reproduce the testing procedure. Paste example command line invocations if applicable._
