### PR TITLE
Enhance model engine with max concurrency support for sync endpoints

### DIFF
--- a/charts/model-engine/templates/service_template_config_map.yaml
+++ b/charts/model-engine/templates/service_template_config_map.yaml
@@ -126,6 +126,8 @@ data:
                 - "${FORWARDER_PORT}"
                 - --num-workers
                 - "${FORWARDER_WORKER_COUNT}"
+                - --max-concurrency
+                - "${CONCURRENT_REQUESTS_PER_WORKER}"
                 - --set
                 - "forwarder.sync.predict_route=${PREDICT_ROUTE}"
                 - --set
@@ -172,6 +174,8 @@ data:
                 - "${FORWARDER_PORT}"
                 - --num-workers
                 - "${FORWARDER_WORKER_COUNT}"
+                - --max-concurrency
+                - "${CONCURRENT_REQUESTS_PER_WORKER}"
                 - --set
                 - "forwarder.sync.predict_route=${PREDICT_ROUTE}"
                 - --set
@@ -558,6 +562,8 @@ data:
                   - "${FORWARDER_PORT}"
                   - --num-workers
                   - "${FORWARDER_WORKER_COUNT}"
+                  - --max-concurrency
+                  - "${CONCURRENT_REQUESTS_PER_WORKER}"
                   - --set
                   - "forwarder.sync.predict_route=${PREDICT_ROUTE}"
                   - --set
@@ -604,6 +610,8 @@ data:
                   - "${FORWARDER_PORT}"
                   - --num-workers
                   - "${FORWARDER_WORKER_COUNT}"
+                  - --max-concurrency
+                  - "${CONCURRENT_REQUESTS_PER_WORKER}"
                   - --set
                   - "forwarder.sync.predict_route=${PREDICT_ROUTE}"
                   - --set


### PR DESCRIPTION
This pull request introduces improvements to how the maximum concurrency per worker is configured, validated, and propagated across the model engine deployment and autoscaling logic. The main changes ensure that the concurrency setting is passed from configuration templates through to runtime, validated for autoscaling safety, and surfaced in resource reporting.

**Configuration and Runtime Propagation:**

* Added the `--max-concurrency` argument to the forwarder container command in `service_template_config_map.yaml`, allowing per-worker concurrency to be set via environment variable (`CONCURRENT_REQUESTS_PER_WORKER`). [[1]](diffhunk://#diff-2d71a44f35e550408c3b8e34099ae4700ef76db9daf52c55ee29d19eddb2edf5R129-R130) [[2]](diffhunk://#diff-2d71a44f35e550408c3b8e34099ae4700ef76db9daf52c55ee29d19eddb2edf5R177-R178) [[3]](diffhunk://#diff-2d71a44f35e550408c3b8e34099ae4700ef76db9daf52c55ee29d19eddb2edf5R565-R566) [[4]](diffhunk://#diff-2d71a44f35e550408c3b8e34099ae4700ef76db9daf52c55ee29d19eddb2edf5R613-R614)
* Updated the HTTP forwarder entrypoint to accept `--max-concurrency` as a command-line argument, storing it in the environment for use in concurrency limiter setup.
* Modified the concurrency limiter initialization to prefer the environment variable over config file settings, ensuring runtime concurrency matches deployment configuration.

**Validation Enhancements:**

* Improved the `validate_concurrent_requests_per_worker` function to check that, for sync/streaming endpoints, `per_worker` is less than half of `concurrent_requests_per_worker` to prevent autoscaling issues. This validation is now called with the additional `per_worker` parameter during endpoint creation and update. [[1]](diffhunk://#diff-8b394c3a7804db903fa9d0df9de9b5774b9628ad337be44c806c2e1f6f9d7a0cR132) [[2]](diffhunk://#diff-8b394c3a7804db903fa9d0df9de9b5774b9628ad337be44c806c2e1f6f9d7a0cR143-R154) [[3]](diffhunk://#diff-8b394c3a7804db903fa9d0df9de9b5774b9628ad337be44c806c2e1f6f9d7a0cL302-R315) [[4]](diffhunk://#diff-8b394c3a7804db903fa9d0df9de9b5774b9628ad337be44c806c2e1f6f9d7a0cL491-R504)

**Resource Reporting and Autoscaling:**

* Added logic to extract the `concurrent_requests_per_worker` value from the forwarder container’s command in deployment configs, making it available for autoscaling parameter calculations and resource reporting. [[1]](diffhunk://#diff-911a837ade807a791fecafa1c27a7229966cc0ff9d4f07c18aaa645998401f94R264-R281) [[2]](diffhunk://#diff-911a837ade807a791fecafa1c27a7229966cc0ff9d4f07c18aaa645998401f94R2044-R2055) [[3]](diffhunk://#diff-911a837ade807a791fecafa1c27a7229966cc0ff9d4f07c18aaa645998401f94L2248-R2287)
* Updated autoscaling parameter constructors to use the extracted concurrency value instead of a hardcoded default, ensuring accurate scaling and reporting for sync/streaming endpoints. [[1]](diffhunk://#diff-911a837ade807a791fecafa1c27a7229966cc0ff9d4f07c18aaa645998401f94R1934) [[2]](diffhunk://#diff-911a837ade807a791fecafa1c27a7229966cc0ff9d4f07c18aaa645998401f94L1925-R1950) [[3]](diffhunk://#diff-911a837ade807a791fecafa1c27a7229966cc0ff9d4f07c18aaa645998401f94L1944-R1964)

These changes collectively improve the robustness and transparency of concurrency configuration and autoscaling for model endpoints.

# Pull Request Summary

Addressing MLI-3412

## Test Plan and Usage Guide

_How did you validate that your PR works correctly? How do you run or demo the code? Provide enough detail so a reviewer can reasonably reproduce the testing procedure. Paste example command line invocations if applicable._
