### PR TITLE
changed host flag to be 0.0.0.0 to be compatible with both ipv4 and ipv6

### DIFF
--- a/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
+++ b/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
@@ -820,7 +820,7 @@ class CreateLLMModelBundleV1UseCase:
         if chat_template_override:
             sglang_args.chat_template = chat_template_override
 
-        sglang_cmd = f"python3 -m sglang.launch_server --model-path {huggingface_repo} --served-model-name {model_name} --port 5005 --host '::'"
+        sglang_cmd = f"python3 -m sglang.launch_server --model-path {huggingface_repo} --served-model-name {model_name} --port 5005 --host 0.0.0.0"
         for field in SGLangEndpointAdditionalArgs.model_fields.keys():
             config_value = getattr(sglang_args, field, None)
             if config_value is not None:
@@ -952,7 +952,7 @@ class CreateLLMModelBundleV1UseCase:
             if hmi_config.sensitive_log_mode:
                 vllm_args.disable_log_requests = True
 
-            vllm_cmd = f"python -m vllm_server --model {final_weights_folder} --served-model-name {model_name} {final_weights_folder} --port 5005 --host '::'"
+            vllm_cmd = f"python -m vllm_server --model {final_weights_folder} --served-model-name {model_name} {final_weights_folder} --port 5005 --host 0.0.0.0"
             for field in VLLMEndpointAdditionalArgs.model_fields.keys():
                 config_value = getattr(vllm_args, field, None)
                 if config_value is not None:


### PR DESCRIPTION
# Pull Request Summary

This IPv6 host flag is blocking my K8s cluster istio proxy from successfully completing a health check against the model endpoint. This in turn prevents my request from getting routed from the model-engine gateway to the endpoint since there is application logic blocking this. I am told the `0.0.0.0` address works for both IPv4 and IPv6 but do not have an environment to test on IPv6

## Test Plan and Usage Guide

I have tested this in an image running on a K8s cluster in our federal staging environment. 
