### PR TITLE
include .txt files when downloading model weights from S3

### DIFF
--- a/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
+++ b/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
@@ -629,7 +629,7 @@ class CreateLLMModelBundleV1UseCase:
         # filter to configs ('*.model' and '*.json') and weights ('*.safetensors')
         # For models that are not supported by transformers directly, we need to include '*.py' and '*.bin'
         # to load the model. Only set this flag if "trust_remote_code" is set to True
-        file_selection_str = '--include "*.model" --include "*.model.v*" --include "*.json" --include "*.safetensors" --exclude "optimizer*"'
+        file_selection_str = '--include "*.model" --include "*.model.v*" --include "*.json" --include "*.safetensors" --include "*.txt" --exclude "optimizer*"'
         if trust_remote_code:
             file_selection_str += ' --include "*.py"'
         subcommands.append(


### PR DESCRIPTION
# Pull Request Summary

modify the `s5cmd` command in endpoint deployments to download `.txt` files, which are required for certain tokenizers to work

## Test Plan and Usage Guide

fixed an `InternVL` endpoint by applying the same change manually to its deployment yaml in `k9s`.
