### PR TITLE
fix(helm): order ConfigMap hooks before database init job

### DIFF
--- a/charts/model-engine/Chart.yaml
+++ b/charts/model-engine/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/model-engine/templates/aws_config_map.yaml
+++ b/charts/model-engine/templates/aws_config_map.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- $labels | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-2"
+    "helm.sh/hook-weight": "-3"
 data:
   config: |-
     [profile {{ $profileName }}]

--- a/charts/model-engine/templates/inference_framework_config.yaml
+++ b/charts/model-engine/templates/inference_framework_config.yaml
@@ -7,7 +7,7 @@ metadata:
     team: infra
   annotations:
     "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-2"
+    "helm.sh/hook-weight": "-3"
 data:
   deepspeed: {{ .Values.inferenceFramework.deepspeed | default "latest" | quote }}
   text_generation_inference: {{ .Values.inferenceFramework.text_generation_inference | default "latest" | quote }}

--- a/charts/model-engine/templates/service_config_map.yaml
+++ b/charts/model-engine/templates/service_config_map.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "modelEngine.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-2"
+    "helm.sh/hook-weight": "-3"
 data:
   launch_service_config: |-
     dd_trace_enabled: {{ .Values.dd_trace_enabled | default false | quote }}
@@ -53,7 +53,7 @@ metadata:
     {{- include "modelEngine.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-2"
+    "helm.sh/hook-weight": "-3"
 data:
   launch_service_config: |-
     dd_trace_enabled: {{ .Values.dd_trace_enabled | default false | quote }}

--- a/charts/model-engine/templates/service_template_config_map.yaml
+++ b/charts/model-engine/templates/service_template_config_map.yaml
@@ -37,7 +37,7 @@ metadata:
     {{- include "modelEngine.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-2"
+    "helm.sh/hook-weight": "-3"
 data:
   {{- range $device := tuple "cpu" "gpu" }}
   {{- range $mode := tuple "async" "sync" "streaming"}}


### PR DESCRIPTION
## Summary

- ConfigMaps and the `database-init` Job both used Helm hook-weight `"-2"`, causing a race condition where the Job pod tries to mount ConfigMaps before the kubelet cache has synced them
- Moved all ConfigMap pre-install hook weights from `"-2"` to `"-3"` so they are fully created and cached before the database init Job (weight `"-2"`) starts
- Bumped chart version to `0.2.3`

**Affected templates:**
- `service_config_map.yaml`
- `service_template_config_map.yaml`
- `aws_config_map.yaml`
- `inference_framework_config.yaml`

**Root cause:** On fresh installs, Helm creates all hooks at the same weight simultaneously. The database-init Job pod references ConfigMaps via `volumes[].configMap`, but the kubelet projected volume cache hasn't synced yet, resulting in:
```
failed to sync configmap cache: timed out waiting for the condition
```
The Job stays stuck in `ContainerCreating`, hits its deadline, and Flux enters an uninstall-reinstall remediation loop.

## Test plan
- [ ] `helm lint charts/model-engine/` passes
- [ ] `helm template` renders correctly
- [ ] Fresh install on a cluster where model-engine was previously failing with database-setup-job stuck in ContainerCreating

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a Helm hook race condition on fresh installs where ConfigMaps (previously hook-weight `"-2"`) were created simultaneously with the `database-setup` Job (also `"-2"`), causing the Job pod to fail to mount volumes (`failed to sync configmap cache`). The fix moves all four ConfigMap hook weights to `"-3"`, ensuring they are fully created before the Job at `"-2"` starts. Chart version is bumped to `0.2.3`.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is correct, targeted, and all remaining findings are minor style suggestions.

The hook weight ordering change (ConfigMaps at -3, database-init Job at -2) directly addresses the documented race condition. All three ConfigMaps referenced by modelEngine.volumes are covered. The only finding is a P2 suggestion to add an explanatory comment on the weight values, which does not block merge.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| charts/model-engine/Chart.yaml | Chart version bumped from 0.2.2 to 0.2.3 — appropriate for the hook ordering change. |
| charts/model-engine/templates/aws_config_map.yaml | Hook weight changed from -2 to -3; ConfigMap is referenced in modelEngine.volumes (config-volume) and must precede the database-init Job. |
| charts/model-engine/templates/service_config_map.yaml | Both ConfigMap documents updated from weight -2 to -3; directly referenced via launch-service-config and infra-service-config volumes in the database-init Job. |
| charts/model-engine/templates/service_template_config_map.yaml | Hook weight changed from -2 to -3; ConfigMap is mounted as service-template-config volume in the database-init Job. |
| charts/model-engine/templates/inference_framework_config.yaml | Hook weight changed from -2 to -3; this ConfigMap is not directly referenced in modelEngine.volumes but the change is harmless and consistent. Note: it only has pre-install (no pre-upgrade), which is a pre-existing condition. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Helm
    participant ConfigMaps as ConfigMaps (weight -3)
    participant DBInit as database-init Job (weight -2)
    participant DBMigration as database-migration Job (weight -1)
    participant Spellbook as spellbook-init Job (weight 0)

    Helm->>ConfigMaps: Create aws_config_map, service_config_map,<br/>service_template_config_map, inference_framework_config
    Note over ConfigMaps: Kubelet syncs ConfigMap cache
    Helm->>DBInit: Create Job pod (mounts ConfigMaps as volumes)
    Note over DBInit: Volumes available — no race condition
    Helm->>DBMigration: Run database migrations
    Helm->>Spellbook: Run spellbook init
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acharts%2Fmodel-engine%2Ftemplates%2Faws_config_map.yaml%3A17%0A**Missing%20comment%20explaining%20hook-weight%20ordering**%0A%0AThe%20weight%20%60%22-3%22%60%20encodes%20an%20intentional%20ordering%20dependency%3A%20ConfigMaps%20must%20be%20fully%20created%20and%20kubelet-cached%20before%20the%20%60database-setup%60%20Job%20%28weight%20%60%22-2%22%60%29%20starts%20mounting%20them%20as%20volumes.%20Without%20a%20comment%2C%20a%20future%20maintainer%20who%20adjusts%20this%20value%20could%20silently%20reintroduce%20the%20race%20condition.%20Per%20project%20convention%2C%20non-obvious%20precedence%20relationships%20like%20this%20should%20be%20annotated.%0A%0A%60%60%60suggestion%0A%20%20%20%20%22helm.sh%2Fhook-weight%22%3A%20%22-3%22%20%23%20Must%20be%20lower%20than%20database-init-job%20%28-2%29%20so%20ConfigMaps%20exist%20before%20the%20Job%20pod%20mounts%20them%0A%60%60%60%0A%0AThe%20same%20comment%20should%20be%20added%20to%20%60service_config_map.yaml%60%2C%20%60service_template_config_map.yaml%60%2C%20and%20%60inference_framework_config.yaml%60.%0A%0A**Rule%20Used%3A**%20Add%20comments%20to%20explain%20complex%20or%20non-obvious%20log...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D928586f9-9432-435e-a385-026fa49318a2%29%29%0A%0A**Learnt%20From**%0A%5Bscaleapi%2Fscaleapi%23126958%5D%28https%3A%2F%2Fgithub.com%2Fscaleapi%2Fscaleapi%2Fpull%2F126958%29%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acharts%2Fmodel-engine%2Ftemplates%2Faws_config_map.yaml%3A17%0A**Missing%20comment%20explaining%20hook-weight%20ordering**%0A%0AThe%20weight%20%60%22-3%22%60%20encodes%20an%20intentional%20ordering%20dependency%3A%20ConfigMaps%20must%20be%20fully%20created%20and%20kubelet-cached%20before%20the%20%60database-setup%60%20Job%20%28weight%20%60%22-2%22%60%29%20starts%20mounting%20them%20as%20volumes.%20Without%20a%20comment%2C%20a%20future%20maintainer%20who%20adjusts%20this%20value%20could%20silently%20reintroduce%20the%20race%20condition.%20Per%20project%20convention%2C%20non-obvious%20precedence%20relationships%20like%20this%20should%20be%20annotated.%0A%0A%60%60%60suggestion%0A%20%20%20%20%22helm.sh%2Fhook-weight%22%3A%20%22-3%22%20%23%20Must%20be%20lower%20than%20database-init-job%20%28-2%29%20so%20ConfigMaps%20exist%20before%20the%20Job%20pod%20mounts%20them%0A%60%60%60%0A%0AThe%20same%20comment%20should%20be%20added%20to%20%60service_config_map.yaml%60%2C%20%60service_template_config_map.yaml%60%2C%20and%20%60inference_framework_config.yaml%60.%0A%0A**Rule%20Used%3A**%20Add%20comments%20to%20explain%20complex%20or%20non-obvious%20log...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D928586f9-9432-435e-a385-026fa49318a2%29%29%0A%0A**Learnt%20From**%0A%5Bscaleapi%2Fscaleapi%23126958%5D%28https%3A%2F%2Fgithub.com%2Fscaleapi%2Fscaleapi%2Fpull%2F126958%29%0A%0A&repo=scaleapi%2Fllm-engine"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: charts/model-engine/templates/aws_config_map.yaml
Line: 17

Comment:
**Missing comment explaining hook-weight ordering**

The weight `"-3"` encodes an intentional ordering dependency: ConfigMaps must be fully created and kubelet-cached before the `database-setup` Job (weight `"-2"`) starts mounting them as volumes. Without a comment, a future maintainer who adjusts this value could silently reintroduce the race condition. Per project convention, non-obvious precedence relationships like this should be annotated.

```suggestion
    "helm.sh/hook-weight": "-3" # Must be lower than database-init-job (-2) so ConfigMaps exist before the Job pod mounts them
```

The same comment should be added to `service_config_map.yaml`, `service_template_config_map.yaml`, and `inference_framework_config.yaml`.

**Rule Used:** Add comments to explain complex or non-obvious log... ([source](https://app.greptile.com/review/custom-context?memory=928586f9-9432-435e-a385-026fa49318a2))

**Learnt From**
[scaleapi/scaleapi#126958](https://github.com/scaleapi/scaleapi/pull/126958)

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/helm-hook-w..."](https://github.com/scaleapi/llm-engine/commit/0d7316e88b87cc6db3e293ed0bdba81458de613d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28412986)</sub>

**Context used:**

- Rule used - Add comments to explain complex or non-obvious log... ([source](https://app.greptile.com/review/custom-context?memory=928586f9-9432-435e-a385-026fa49318a2))

**Learnt From**
[scaleapi/scaleapi#126958](https://github.com/scaleapi/scaleapi/pull/126958)

<!-- /greptile_comment -->