### PR TITLE
fix(helm): use $ scope for Values inside range in service_account.yaml

### DIFF
--- a/charts/model-engine/Chart.yaml
+++ b/charts/model-engine/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/model-engine/templates/service_account.yaml
+++ b/charts/model-engine/templates/service_account.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: {{- printf " %s" $namespace }}
   labels:
     {{- $labels | nindent 4 }}
-  {{- if or $annotations .Values.azure .Values.gcp }}
+  {{- if or $annotations $.Values.azure $.Values.gcp }}
   annotations:
     {{- with $annotations }}
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
## Summary

- Line 13 of `service_account.yaml` uses `.Values.azure` and `.Values.gcp` inside a `range` block, where `.` is rebound to the range element — causing `can't evaluate field Values in type interface {}`
- Changed to `$.Values.azure` / `$.Values.gcp` to reference the top-level scope (consistent with lines 18, 21, 27 which already use `$`)
- Bumped chart version to `0.2.4`

Bug was introduced in 0.2.2 when azure/gcp annotations were added to the service account template.

## Test plan
- [ ] `helm template` renders successfully with and without `azure`/`gcp` values

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a Helm template scoping bug in `service_account.yaml` where `.Values.azure` and `.Values.gcp` were referenced inside a `range` block — causing a render error because `.` is rebound to the iteration element inside `range`. The fix replaces the bare `.Values` references with `$.Values` (root scope), consistent with how lines 18–31 already dereference those values. The chart version is correctly bumped to `0.2.4`.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is minimal, correct, and unambiguously resolves the Helm render failure introduced in 0.2.2.

A single targeted change replaces two bare `.Values.*` references with `$.Values.*` inside a `range` block, making the guard condition consistent with every other value reference in the same template. No logic is altered, no new behaviour is introduced, and the chart version bump follows semver conventions. No P0/P1 findings.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| charts/model-engine/templates/service_account.yaml | Single-line fix: `.Values.azure` / `.Values.gcp` on the `if or` guard (line 13) now use `$.Values.*`, matching the root-scope references already used throughout the rest of the template. |
| charts/model-engine/Chart.yaml | Chart version bumped from 0.2.3 to 0.2.4 to reflect the bug-fix release. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["range over serviceAccountNamespaces"] --> B["Evaluate annotation guard\n`if or $annotations $.Values.azure $.Values.gcp`"]
    B -->|"$.Values.azure set"| C["Add azure.workload.identity/client-id annotation\n`$.Values.azure.client_id`"]
    B -->|"$.Values.gcp set"| D["Add iam.gke.io/gcp-service-account annotation\n`$.Values.gcp.iam_service_account`"]
    B -->|"$annotations set"| E["Render custom annotations"]
    B -->|"none set"| F["Skip annotations block"]
    C --> G["$.Values.azure → add imagePullSecrets"]
    D --> H["End range iteration"]
    E --> H
    F --> H
    G --> H
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(helm): use $ scope for Values inside..."](https://github.com/scaleapi/llm-engine/commit/9e0fc4de0bbfdcf9cbb9a561b5531c0237f747fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28555436)</sub>

<!-- /greptile_comment -->