### PR TITLE
 fix(model-engine-chart): raise database-setup hook-weight so it runs…

### DIFF
--- a/charts/model-engine/Chart.yaml
+++ b/charts/model-engine/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.4
+version: 0.2.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/model-engine/templates/database_init_job.yaml
+++ b/charts/model-engine/templates/database_init_job.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "modelEngine.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-2"
+    "helm.sh/hook-weight": "-1"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   backoffLimit: 0


### PR DESCRIPTION
## Summary                                                                                                                                    
                                                                                                                                                
Raises the `helm.sh/hook-weight` on `database_init_job.yaml` from `-2` to `-1` so the pre-install DB setup Job runs *after* the ConfigMaps it mounts.                                                                                                                                       
                                                                                                                                                
  ## Why                                                                                                                                        
                                                                                                                                                
On on-prem SGP installs (model-engine@0.2.1 via the `scaleapi/sgp` wrapper chart, deployed through Flux helm-controller v1.2.0), `launch-inference` consistently fails with:       failed pre-install: 1 error occurred:                     
  - job model-engine-database-setup-1 failed: DeadlineExceeded
                                                                                                                                                
The Job pod stays in `ContainerCreating` for 10 minutes, repeatedly emitting:
- MountVolume.SetUp failed for volume "service-template-config" : configmap "model-engine-service-template-config" not found 
- MountVolume.SetUp failed for volume "engine-service-config-volume" : configmap "model-engine-service-config" not found. Then Flux rolls the release back and retries, and the loop repeats indefinitely.
                                                                                                                                                
  ## Root cause                                             
                                                                                                                                                
  All of the following pre-install hooks share `helm.sh/hook-weight: "-2"`:                                                                     
   
  | Hook | kind | name |                                                                                                                        
  |---|---|---|                                             
  | `service_account.yaml` | ServiceAccount | `model-engine` |
  | `service_account_inference.yaml` | ServiceAccount | `model-engine` |                                                                        
  | `inference_framework_config.yaml` | ConfigMap | `model-engine-inference-framework-latest-config` |                                          
  | `service_config_map.yaml` | ConfigMap | `model-engine-service-config` |                                                                     
  | `service_template_config_map.yaml` | ConfigMap | `model-engine-service-template-config` |                                                   
  | `database_init_job.yaml` | Job | `model-engine-database-setup-1` |                                                                          
                                                                                                                                                
  Helm v3 sorts same-weight hooks alphabetically by name. Since `"model-engine-database-setup-1"` < `"model-engine-inference-framework-..."` <  
  `"model-engine-service-config"` < `"model-engine-service-template-config"`, the DB-init Job lands *before* the ConfigMaps it depends on. Helm
  applies the Job, waits for completion, the pod fails to mount non-existent ConfigMaps, the Job hits `activeDeadlineSeconds: 600`, and the     
  entire install rolls back.                                

  Confirmed against the decoded Helm release secret on a failing cluster:                                                                       
  
  SA/model-engine          : Succeeded (14:40:57.394Z)                                                                                          
  SA/model-engine          : Succeeded (14:40:57.467Z)      
  Job/database-setup-1     : Running   (14:40:57.510Z)  ← fires before CMs                                                                      
  CM/inference-framework   : ''        (never ran)                                                                                              
  CM/service-config        : ''        (never ran)                                                                                              
  CM/service-config        : ''        (never ran)                                                                                              
  CM/service-template-cfg  : ''        (never ran)                                                                                              
                                                                                                                                                
  ## Fix
                                                                                                                                                
  Moving the Job to weight `-1` places it in a strictly later weight bucket than the ConfigMaps (`-2`), so Helm guarantees the CMs apply first  regardless of alphabetical order. This matches the existing weight of `database_migration_job.yaml` and follows the chart's own precedent for ordering DB-phase hooks after their config dependencies.                                                                                      
                                                            
No behavior change for AWS/GCP deployments that already had the Job succeeding — they just had lucky name ordering (or `runDbInitScript:  false`) masking the latent bug.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a pre-install hook ordering bug in the model-engine Helm chart by raising `database_init_job.yaml`'s `helm.sh/hook-weight` from `-2` to `-1`, ensuring the DB-setup Job runs after the ConfigMaps it mounts (which are at weight `-3`). The chart version is bumped from `0.2.4` to `0.2.5`.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the core ordering fix is correct and resolves a confirmed production failure; the remaining findings are P2 style/precautionary notes.

The hook-weight change correctly places the init Job at weight -1, strictly after ConfigMaps at weight -3. The chart version bump is appropriate. Both remaining comments are P2: one is a documentation suggestion, and the other is a precautionary note about co-enabling both DB jobs (unlikely in practice and not a regression introduced by this PR).

charts/model-engine/templates/database_init_job.yaml — review the P2 ordering note about init/migration both running at weight -1 if both flags are ever enabled simultaneously.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| charts/model-engine/templates/database_init_job.yaml | Core fix: hook-weight raised from -2 to -1 to guarantee CMs (at -3) are applied before the Job; now shares weight with database_migration_job, raising a minor ordering concern when both are simultaneously enabled. |
| charts/model-engine/Chart.yaml | Chart version bumped from 0.2.4 to 0.2.5 to reflect the template change — correct and expected. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Helm
    participant K8s
    note over Helm,K8s: weight -3 (first batch)
    Helm->>K8s: Apply ConfigMap: model-engine-inference-framework-latest-config
    Helm->>K8s: Apply ConfigMap: model-engine-service-config
    Helm->>K8s: Apply ConfigMap: model-engine-service-template-config
    K8s-->>Helm: All -3 hooks complete
    note over Helm,K8s: weight -1 (second batch) — AFTER this fix
    Helm->>K8s: Apply Job: model-engine-database-migration-N
    K8s-->>Helm: migration job complete
    Helm->>K8s: Apply Job: model-engine-database-setup-N
    K8s-->>Helm: setup/init job complete
    note over Helm,K8s: weight 0+ — normal chart resources
    Helm->>K8s: Deploy remaining resources
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acharts%2Fmodel-engine%2Ftemplates%2Fdatabase_init_job.yaml%3A10%0A**Add%20ordering%20comment%20per%20hook-weight%20convention**%0A%0AThe%20non-obvious%20relationship%20between%20weight%20values%20%28CMs%20at%20%60-3%60%2C%20DB%20jobs%20at%20%60-1%60%29%20is%20exactly%20the%20kind%20of%20precedence%20context%20that%20has%20burned%20you%20once%20already.%20A%20brief%20inline%20comment%20would%20prevent%20future%20maintainers%20from%20inadvertently%20%22fixing%22%20this%20back%20to%20%60-2%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%22helm.sh%2Fhook-weight%22%3A%20%22-1%22%20%20%23%20Must%20be%20%3E%20CM%20weight%20%28-3%29%20so%20ConfigMaps%20exist%20before%20this%20Job%20starts%0A%60%60%60%0A%0A**Rule%20Used%3A**%20Add%20comments%20to%20explain%20complex%20or%20non-obvious%20log...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D928586f9-9432-435e-a385-026fa49318a2%29%29%0A%0A**Learned%20From**%0A%5Bscaleapi%2Fscaleapi%23126958%5D%28https%3A%2F%2Fgithub.com%2Fscaleapi%2Fscaleapi%2Fpull%2F126958%29%0A%0A%23%23%23%20Issue%202%20of%202%0Acharts%2Fmodel-engine%2Ftemplates%2Fdatabase_init_job.yaml%3A10%0A**Init%20and%20migration%20jobs%20now%20share%20the%20same%20hook%20weight**%0A%0A%60database_migration_job.yaml%60%20is%20also%20at%20weight%20%60-1%60.%20Within%20the%20same%20weight%20group%2C%20Helm%20sorts%20hooks%20alphabetically%20by%20resource%20name%2C%20which%20means%20%60model-engine-database-migration-N%60%20sorts%20before%20%60model-engine-database-setup-N%60%20%28%60m%60%20%3C%20%60s%60%29.%20If%20both%20%60runDbInitScript%60%20and%20%60runDbMigrationScript%60%20are%20enabled%20simultaneously%20%28e.g.%20a%20fresh%20install%20with%20migrations%29%2C%20the%20migration%20job%20will%20fire%20before%20the%20init%20job%2C%20reversing%20the%20previously%20enforced%20ordering.%0A%0AThe%20previous%20weight%20of%20%60-2%60%20for%20the%20init%20job%20explicitly%20guaranteed%20init%20%E2%86%92%20migration%20sequencing.%20Verify%20that%20the%20two%20scripts%20are%20never%20co-enabled%2C%20or%20keep%20the%20init%20job%20at%20a%20lower%20weight%20%28e.g.%20%60-2%60%29%20now%20that%20the%20ConfigMaps%20have%20already%20been%20moved%20to%20%60-3%60.%0A%0A&pr=810&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acharts%2Fmodel-engine%2Ftemplates%2Fdatabase_init_job.yaml%3A10%0A**Add%20ordering%20comment%20per%20hook-weight%20convention**%0A%0AThe%20non-obvious%20relationship%20between%20weight%20values%20%28CMs%20at%20%60-3%60%2C%20DB%20jobs%20at%20%60-1%60%29%20is%20exactly%20the%20kind%20of%20precedence%20context%20that%20has%20burned%20you%20once%20already.%20A%20brief%20inline%20comment%20would%20prevent%20future%20maintainers%20from%20inadvertently%20%22fixing%22%20this%20back%20to%20%60-2%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%22helm.sh%2Fhook-weight%22%3A%20%22-1%22%20%20%23%20Must%20be%20%3E%20CM%20weight%20%28-3%29%20so%20ConfigMaps%20exist%20before%20this%20Job%20starts%0A%60%60%60%0A%0A**Rule%20Used%3A**%20Add%20comments%20to%20explain%20complex%20or%20non-obvious%20log...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D928586f9-9432-435e-a385-026fa49318a2%29%29%0A%0A**Learned%20From**%0A%5Bscaleapi%2Fscaleapi%23126958%5D%28https%3A%2F%2Fgithub.com%2Fscaleapi%2Fscaleapi%2Fpull%2F126958%29%0A%0A%23%23%23%20Issue%202%20of%202%0Acharts%2Fmodel-engine%2Ftemplates%2Fdatabase_init_job.yaml%3A10%0A**Init%20and%20migration%20jobs%20now%20share%20the%20same%20hook%20weight**%0A%0A%60database_migration_job.yaml%60%20is%20also%20at%20weight%20%60-1%60.%20Within%20the%20same%20weight%20group%2C%20Helm%20sorts%20hooks%20alphabetically%20by%20resource%20name%2C%20which%20means%20%60model-engine-database-migration-N%60%20sorts%20before%20%60model-engine-database-setup-N%60%20%28%60m%60%20%3C%20%60s%60%29.%20If%20both%20%60runDbInitScript%60%20and%20%60runDbMigrationScript%60%20are%20enabled%20simultaneously%20%28e.g.%20a%20fresh%20install%20with%20migrations%29%2C%20the%20migration%20job%20will%20fire%20before%20the%20init%20job%2C%20reversing%20the%20previously%20enforced%20ordering.%0A%0AThe%20previous%20weight%20of%20%60-2%60%20for%20the%20init%20job%20explicitly%20guaranteed%20init%20%E2%86%92%20migration%20sequencing.%20Verify%20that%20the%20two%20scripts%20are%20never%20co-enabled%2C%20or%20keep%20the%20init%20job%20at%20a%20lower%20weight%20%28e.g.%20%60-2%60%29%20now%20that%20the%20ConfigMaps%20have%20already%20been%20moved%20to%20%60-3%60.%0A%0A&repo=scaleapi%2Fllm-engine&pr=810&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: charts/model-engine/templates/database_init_job.yaml
Line: 10

Comment:
**Add ordering comment per hook-weight convention**

The non-obvious relationship between weight values (CMs at `-3`, DB jobs at `-1`) is exactly the kind of precedence context that has burned you once already. A brief inline comment would prevent future maintainers from inadvertently "fixing" this back to `-2`.

```suggestion
    "helm.sh/hook-weight": "-1"  # Must be > CM weight (-3) so ConfigMaps exist before this Job starts
```

**Rule Used:** Add comments to explain complex or non-obvious log... ([source](https://app.greptile.com/review/custom-context?memory=928586f9-9432-435e-a385-026fa49318a2))

**Learned From**
[scaleapi/scaleapi#126958](https://github.com/scaleapi/scaleapi/pull/126958)

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: charts/model-engine/templates/database_init_job.yaml
Line: 10

Comment:
**Init and migration jobs now share the same hook weight**

`database_migration_job.yaml` is also at weight `-1`. Within the same weight group, Helm sorts hooks alphabetically by resource name, which means `model-engine-database-migration-N` sorts before `model-engine-database-setup-N` (`m` < `s`). If both `runDbInitScript` and `runDbMigrationScript` are enabled simultaneously (e.g. a fresh install with migrations), the migration job will fire before the init job, reversing the previously enforced ordering.

The previous weight of `-2` for the init job explicitly guaranteed init → migration sequencing. Verify that the two scripts are never co-enabled, or keep the init job at a lower weight (e.g. `-2`) now that the ConfigMaps have already been moved to `-3`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(model-engine-chart): raise database-..."](https://github.com/scaleapi/llm-engine/commit/bffa96797eb36297686898a71d99498b89896a29) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28783218)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - Add comments to explain complex or non-obvious log... ([source](https://app.greptile.com/review/custom-context?memory=928586f9-9432-435e-a385-026fa49318a2))

**Learned From**
[scaleapi/scaleapi#126958](https://github.com/scaleapi/scaleapi/pull/126958)

<!-- /greptile_comment -->