### PR TITLE
fix(client): remove invalid min_items=1 on str __root__ fields (b47)

### DIFF
--- a/clients/python/llmengine/data_types/gen/openai.py
+++ b/clients/python/llmengine/data_types/gen/openai.py
@@ -6875,7 +6875,7 @@ class VectorStoreObject(BaseModel):
 
 
 class QueryItem(BaseModel):
-    __root__: Annotated[str, Field(description="A list of queries to search for.", min_items=1)]
+    __root__: Annotated[str, Field(description="A list of queries to search for.")]
 
 
 class RankingOptions(BaseModel):
@@ -6937,7 +6937,7 @@ class VectorStoreSearchResultItem(BaseModel):
 
 
 class SearchQueryItem(BaseModel):
-    __root__: Annotated[str, Field(description="The query used for this search.", min_items=1)]
+    __root__: Annotated[str, Field(description="The query used for this search.")]
 
 
 class VectorStoreSearchResultsPage(BaseModel):

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scale-llm-engine"
-version = "0.0.0.beta46"
+version = "0.0.0.beta47"
 description = "Scale LLM Engine Python client"
 license = "Apache-2.0"
 authors = ["Phil Chen <phil.chen@scale.com>"]


### PR DESCRIPTION
## Summary
- `gen/openai.py` ships two classes (`QueryItem`, `SearchQueryItem`) where `__root__: Annotated[str, Field(..., min_items=1)]`. `min_items` is a list/sequence constraint; on a `str` field pydantic v1 compat raises `ValueError: ... field constraints are set but not enforced: min_items` at import time.
- Drop the meaningless constraint and bump to `0.0.0.beta47`.

## Impact
- b46 cannot be imported under pydantic v2 with v1 compat. Any downstream that does `import llmengine` (e.g. `egp-api-backend`) fails at startup.
- Blocking the egp-api-backend security remediation PR (scaleapi/scaleapi#140646) which pins b46.

## Root cause
`gen/openai.py` is generated from the OpenAPI schema via datamodel-code-generator. The bad constraint was introduced between b45 and b46 by upstream schema commits (`0cbb58d`, `ae53ee6`). This PR patches the generated file directly to unblock downstream; a follow-up is needed to fix the source schema so the constraint doesn't regress on next regen.

## Test plan
- [ ] `python -c "from llmengine.data_types.gen.openai import QueryItem, SearchQueryItem"` succeeds under pydantic v2 + v1 compat
- [ ] After publish to scale-pypi as b47, egp-api-backend `main` imports cleanly in container smoke test
- [ ] Follow-up issue filed for OpenAPI schema fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the invalid `min_items=1` constraint from the `__root__: str` fields on `QueryItem` and `SearchQueryItem` in the generated `openai.py` file, and bumps the package version to `0.0.0.beta47`. The fix correctly resolves an import-time `ValueError` raised by pydantic v2 under v1 compat mode, since `min_items` is a list/sequence constraint that is not applicable to `str` fields.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — targeted one-line fix per class with no logic changes, and the removed constraint was definitively invalid on `str` fields.

Both changes are minimal and correct: dropping `min_items` from `str` fields resolves the pydantic v2 import error without altering any behaviour, and the version bump is appropriate. No new logic, no risk of regression.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| clients/python/llmengine/data_types/gen/openai.py | Removes `min_items=1` from `__root__: str` fields on `QueryItem` and `SearchQueryItem` — the correct fix for a pydantic v2 import-time ValueError. |
| clients/python/pyproject.toml | Version bumped from `0.0.0.beta46` to `0.0.0.beta47` to reflect the bug-fix release. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["import llmengine (b46)"] -->|"pydantic v2 + v1 compat"| B["ValueError: min_items on str field\nin QueryItem / SearchQueryItem"]
    B --> C["ImportError — module unusable"]

    D["import llmengine (b47)"] -->|"min_items=1 removed"| E["QueryItem.__root__: str\nSearchQueryItem.__root__: str"]
    E --> F["Module imports cleanly ✓"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(client): remove invalid min\_items=1 ..."](https://github.com/scaleapi/llm-engine/commit/3cea868e152401b2f6df79f002e01819d308cd75) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29315612)</sub>

<!-- /greptile_comment -->