### PR TITLE
fix(client): drop v1-incompat discriminator on InputItem (b48)

### DIFF
--- a/clients/python/llmengine/data_types/gen/openai.py
+++ b/clients/python/llmengine/data_types/gen/openai.py
@@ -11516,7 +11516,7 @@ class EvalRunList(BaseModel):
 
 class InputItem(BaseModel):
     __root__: Annotated[
-        Union[EasyInputMessage, Item, ItemReferenceParam], Field(discriminator="type")
+        Union[EasyInputMessage, Item, ItemReferenceParam], Field()
     ]
 
 

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scale-llm-engine"
-version = "0.0.0.beta47"
+version = "0.0.0.beta48"
 description = "Scale LLM Engine Python client"
 license = "Apache-2.0"
 authors = ["Phil Chen <phil.chen@scale.com>"]


### PR DESCRIPTION
## Summary
Drop `Field(discriminator=\"type\")` from `InputItem.__root__` in `gen/openai.py`. Under pydantic v2 + v1 compat, the discriminator on this union triggers:

```
pydantic.v1.errors.ConfigError: Field 'type' is not the same for all submodels of 'Item'
```

at module-load time, breaking any consumer that imports `llmengine` (e.g. `egp-api-backend`).

## Background
This is the exact fix @brandon.allen applied in #776 (1d50898 'feat: support openai 2 in python client'). A later commit (bd8a98f 'fix: address python client review feedback') ran codegen which wiped the manual fix. b47 (this repo's main) still carries the bug; b48 re-applies the patch.

## Impact
- **JSON in/out: identical.** Every submodel has a `Literal[...]` type field, so validation still selects the correct submodel by value.
- **Validation: O(n) try-each instead of O(1) jump.** Negligible for typical usage.
- **Error messages on invalid input: generic union error instead of 'invalid discriminator value'.**
- **Downstream:** `egp-api-backend` (the immediate consumer) doesn't use `InputItem` at all — it only uses `Completion` and `Model`. Zero runtime impact there.

Other 9 `discriminator=\"type\"` sites in `gen/openai.py` are left intact; they don't recurse into RootModel unions so they don't hit the v1-compat failure.

## Local verification
Built wheel, installed into a pydantic==2.11.9 venv (matches egp-api-backend's pin):

- Before: `from llmengine import Completion, Model` → `ConfigError`
- After: imports cleanly; ChatCompletionV2Request/Response work; all 9 Item submodels import; InputItem/Item/ItemResource/OutputItem1 import; InputMessage instantiation + validation roundtrips

## Follow-ups (separate tickets)
- Fix OpenAPI schema or datamodel-code-generator config so next regen doesn't re-introduce this
- Add import smoke test to llm-engine CI under pydantic 2 + v1 compat so regressions fail fast

## Test plan
- [x] Local import smoke test under pydantic==2.11.9
- [ ] Publish b48 to CodeArtifact
- [ ] egp-api-backend CI passes with b48 pin (scaleapi/scaleapi#140646)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Re-applies the manual fix from #776 that was accidentally reverted by a codegen run: drops `discriminator="type"` from `InputItem.__root__` because `Item` is itself a `__root__`-based union (RootModel) and does not expose a uniform `type` field, causing pydantic v1-compat to raise `ConfigError` at module-load time. The version is bumped to `b48` accordingly. Validation correctness is unaffected; union resolution falls back to sequential try-each instead of O(1) discriminator lookup, which is negligible for typical payloads.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the one-line fix correctly resolves a module-load crash with no JSON or validation regressions.

The change is a targeted, well-understood removal of a pydantic v1-compat incompatible option. The PR description documents root cause, local verification, and downstream impact. The only remaining feedback is a P2 style suggestion to add an explanatory comment/TODO ticket so the next codegen run is easier to catch.

No files require special attention; consider adding the inline comment with a ticket number before the next codegen run to avoid re-introducing the bug.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| clients/python/llmengine/data_types/gen/openai.py | Removes discriminator="type" from InputItem.__root__ to fix pydantic v1-compat ConfigError; fix is correct because Item is itself a __root__ union with no uniform type field |
| clients/python/pyproject.toml | Version bumped from 0.0.0.beta47 to 0.0.0.beta48 to publish the fix; change is straightforward |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[InputItem.__root__] --> B{Union resolution}
    B -->|before fix| C[ConfigError at import\nItem has no uniform type field]
    B -->|after fix - sequential try-each| D[EasyInputMessage]
    B -->|after fix - sequential try-each| E[Item - __root__ union\nwith its own discriminator]
    B -->|after fix - sequential try-each| F[ItemReferenceParam]
    E --> G[InputMessage / OutputMessage / FileSearchToolCall / ...]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aclients%2Fpython%2Fllmengine%2Fdata_types%2Fgen%2Fopenai.py%3A11517-11520%0A**Missing%20workaround%20comment%20and%20TODO%20ticket%20link**%0A%0AThis%20is%20an%20intentional%20manual%20fix%20to%20a%20generated%20file%20that%20will%20be%20silently%20reverted%20the%20next%20time%20codegen%20runs%20%28as%20happened%20between%20%23776%20and%20bd8a98f%29.%20Without%20an%20inline%20comment%20explaining%20*why*%20the%20discriminator%20was%20removed%2C%20future%20reviewers%20%28or%20the%20codegen%20follow-up%20ticket%29%20have%20no%20breadcrumb.%20Per%20the%20repo's%20conventions%2C%20complex%20workarounds%20should%20carry%20an%20explanatory%20comment%2C%20and%20TODO%20comments%20should%20include%20a%20ticket%20number%20so%20they're%20searchable.%0A%0A%60%60%60suggestion%0Aclass%20InputItem%28BaseModel%29%3A%0A%20%20%20%20%23%20TODO%28%3Cticket%3E%29%3A%20Remove%20Field%28%29%20workaround%20once%20codegen%20is%20fixed%20to%20omit%0A%20%20%20%20%23%20discriminator%3D%22type%22%20here.%20Item%20is%20itself%20a%20__root__%20union%20%28RootModel%29%20and%0A%20%20%20%20%23%20does%20not%20expose%20a%20uniform%20%60type%60%20field%2C%20so%20pydantic%20v1-compat%20raises%0A%20%20%20%20%23%20ConfigError%3A%20%22Field%20'type'%20is%20not%20the%20same%20for%20all%20submodels%20of%20'Item'%22%0A%20%20%20%20%23%20at%20module-load%20time%20when%20discriminator%3D%22type%22%20is%20present.%20Validation%20still%0A%20%20%20%20%23%20works%20correctly%20via%20sequential%20union%20try-each.%0A%20%20%20%20__root__%3A%20Annotated%5B%0A%20%20%20%20%20%20%20%20Union%5BEasyInputMessage%2C%20Item%2C%20ItemReferenceParam%5D%2C%20Field%28%29%0A%20%20%20%20%5D%0A%60%60%60%0A%0A**Rule%20Used%3A**%20Add%20comments%20to%20explain%20complex%20or%20non-obvious%20log...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D928586f9-9432-435e-a385-026fa49318a2%29%29%0A%0A**Learned%20From**%0A%5Bscaleapi%2Fscaleapi%23126958%5D%28https%3A%2F%2Fgithub.com%2Fscaleapi%2Fscaleapi%2Fpull%2F126958%29%0A%0A&pr=814&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aclients%2Fpython%2Fllmengine%2Fdata_types%2Fgen%2Fopenai.py%3A11517-11520%0A**Missing%20workaround%20comment%20and%20TODO%20ticket%20link**%0A%0AThis%20is%20an%20intentional%20manual%20fix%20to%20a%20generated%20file%20that%20will%20be%20silently%20reverted%20the%20next%20time%20codegen%20runs%20%28as%20happened%20between%20%23776%20and%20bd8a98f%29.%20Without%20an%20inline%20comment%20explaining%20*why*%20the%20discriminator%20was%20removed%2C%20future%20reviewers%20%28or%20the%20codegen%20follow-up%20ticket%29%20have%20no%20breadcrumb.%20Per%20the%20repo's%20conventions%2C%20complex%20workarounds%20should%20carry%20an%20explanatory%20comment%2C%20and%20TODO%20comments%20should%20include%20a%20ticket%20number%20so%20they're%20searchable.%0A%0A%60%60%60suggestion%0Aclass%20InputItem%28BaseModel%29%3A%0A%20%20%20%20%23%20TODO%28%3Cticket%3E%29%3A%20Remove%20Field%28%29%20workaround%20once%20codegen%20is%20fixed%20to%20omit%0A%20%20%20%20%23%20discriminator%3D%22type%22%20here.%20Item%20is%20itself%20a%20__root__%20union%20%28RootModel%29%20and%0A%20%20%20%20%23%20does%20not%20expose%20a%20uniform%20%60type%60%20field%2C%20so%20pydantic%20v1-compat%20raises%0A%20%20%20%20%23%20ConfigError%3A%20%22Field%20'type'%20is%20not%20the%20same%20for%20all%20submodels%20of%20'Item'%22%0A%20%20%20%20%23%20at%20module-load%20time%20when%20discriminator%3D%22type%22%20is%20present.%20Validation%20still%0A%20%20%20%20%23%20works%20correctly%20via%20sequential%20union%20try-each.%0A%20%20%20%20__root__%3A%20Annotated%5B%0A%20%20%20%20%20%20%20%20Union%5BEasyInputMessage%2C%20Item%2C%20ItemReferenceParam%5D%2C%20Field%28%29%0A%20%20%20%20%5D%0A%60%60%60%0A%0A**Rule%20Used%3A**%20Add%20comments%20to%20explain%20complex%20or%20non-obvious%20log...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D928586f9-9432-435e-a385-026fa49318a2%29%29%0A%0A**Learned%20From**%0A%5Bscaleapi%2Fscaleapi%23126958%5D%28https%3A%2F%2Fgithub.com%2Fscaleapi%2Fscaleapi%2Fpull%2F126958%29%0A%0A&repo=scaleapi%2Fllm-engine&pr=814&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: clients/python/llmengine/data_types/gen/openai.py
Line: 11517-11520

Comment:
**Missing workaround comment and TODO ticket link**

This is an intentional manual fix to a generated file that will be silently reverted the next time codegen runs (as happened between #776 and bd8a98f). Without an inline comment explaining *why* the discriminator was removed, future reviewers (or the codegen follow-up ticket) have no breadcrumb. Per the repo's conventions, complex workarounds should carry an explanatory comment, and TODO comments should include a ticket number so they're searchable.

```suggestion
class InputItem(BaseModel):
    # TODO(<ticket>): Remove Field() workaround once codegen is fixed to omit
    # discriminator="type" here. Item is itself a __root__ union (RootModel) and
    # does not expose a uniform `type` field, so pydantic v1-compat raises
    # ConfigError: "Field 'type' is not the same for all submodels of 'Item'"
    # at module-load time when discriminator="type" is present. Validation still
    # works correctly via sequential union try-each.
    __root__: Annotated[
        Union[EasyInputMessage, Item, ItemReferenceParam], Field()
    ]
```

**Rule Used:** Add comments to explain complex or non-obvious log... ([source](https://app.greptile.com/review/custom-context?memory=928586f9-9432-435e-a385-026fa49318a2))

**Learned From**
[scaleapi/scaleapi#126958](https://github.com/scaleapi/scaleapi/pull/126958)

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(client): drop v1-incompat discrimina..."](https://github.com/scaleapi/llm-engine/commit/fc20406845ccd8abec86f7551d4459b50f394847) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29328922)</sub>

**Context used:**

- Rule used - Add comments to explain complex or non-obvious log... ([source](https://app.greptile.com/review/custom-context?memory=928586f9-9432-435e-a385-026fa49318a2))

**Learned From**
[scaleapi/scaleapi#126958](https://github.com/scaleapi/scaleapi/pull/126958)
- Rule used - Include ticket numbers in TODO comments to make cl... ([source](https://app.greptile.com/review/custom-context?memory=60a8285f-4fe2-4f02-9b88-5ea4ff033fb8))

**Learned From**
[scaleapi/scaleapi#126926](https://github.com/scaleapi/scaleapi/pull/126926)

<!-- /greptile_comment -->