### PR TITLE
fix(model-engine): harden aioredis pool against stale-socket errors

### DIFF
--- a/model-engine/model_engine_server/api/dependencies.py
+++ b/model-engine/model_engine_server/api/dependencies.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Optional
 import redis.asyncio as aioredis
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPBasic, HTTPBasicCredentials, OAuth2PasswordBearer
+from model_engine_server.common.aioredis_pool import build_aioredis_pool
 from model_engine_server.common.config import hmi_config
 from model_engine_server.common.dtos.model_endpoints import BrokerType
 from model_engine_server.common.env_vars import CIRCLECI
@@ -560,6 +561,6 @@ def get_or_create_aioredis_pool() -> aioredis.ConnectionPool:
 
     expiration_timestamp = hmi_config.cache_redis_url_expiration_timestamp
     if _pool is None or (expiration_timestamp is not None and time.time() > expiration_timestamp):
-        _pool = aioredis.BlockingConnectionPool.from_url(hmi_config.cache_redis_url)
+        _pool = build_aioredis_pool(hmi_config.cache_redis_url)
     assert _pool is not None
     return _pool

--- a/model-engine/model_engine_server/common/aioredis_pool.py
+++ b/model-engine/model_engine_server/common/aioredis_pool.py
@@ -38,18 +38,14 @@ def get_aioredis_connection_kwargs() -> Dict[str, Any]:
         "health_check_interval": HEALTH_CHECK_INTERVAL_SECONDS,
         "retry_on_error": [RedisConnectionError, RedisTimeoutError],
         "retry": Retry(
-            ExponentialBackoff(
-                cap=RETRY_BACKOFF_CAP_SECONDS, base=RETRY_BACKOFF_BASE_SECONDS
-            ),
+            ExponentialBackoff(cap=RETRY_BACKOFF_CAP_SECONDS, base=RETRY_BACKOFF_BASE_SECONDS),
             retries=RETRY_MAX_ATTEMPTS,
         ),
     }
 
 
-def build_aioredis_pool(url: str) -> aioredis.BlockingConnectionPool:
-    return aioredis.BlockingConnectionPool.from_url(
-        url, **get_aioredis_connection_kwargs()
-    )
+def build_aioredis_pool(url: str) -> aioredis.ConnectionPool:
+    return aioredis.BlockingConnectionPool.from_url(url, **get_aioredis_connection_kwargs())
 
 
 def build_aioredis_client(url: str) -> aioredis.Redis:

--- a/model-engine/model_engine_server/common/aioredis_pool.py
+++ b/model-engine/model_engine_server/common/aioredis_pool.py
@@ -1,0 +1,56 @@
+"""Shared construction for aioredis connection pools and clients.
+
+redis-py defaults leave pooled connections vulnerable to middlebox idle
+timeouts (Istio sidecars, cloud load balancers, NAT): when `retry` and
+`retry_on_error` are both unset, `AbstractConnection.__init__` uses
+`Retry(NoBackoff(), 0)` — zero retries — so the first command issued on a
+silently-closed pooled socket surfaces as `ConnectionError` to the caller.
+
+The helpers here turn on TCP keepalive, a pre-command PING after idle periods,
+and transparent retry with exponential backoff. Use them for every long-lived
+aioredis pool or client in this repo.
+"""
+
+from typing import Any, Dict
+
+import redis.asyncio as aioredis
+from redis.asyncio.retry import Retry
+from redis.backoff import ExponentialBackoff
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import TimeoutError as RedisTimeoutError
+
+HEALTH_CHECK_INTERVAL_SECONDS = 30
+SOCKET_CONNECT_TIMEOUT_SECONDS = 5
+RETRY_BACKOFF_CAP_SECONDS = 2.0
+RETRY_BACKOFF_BASE_SECONDS = 0.2
+RETRY_MAX_ATTEMPTS = 3
+
+
+def get_aioredis_connection_kwargs() -> Dict[str, Any]:
+    """Return kwargs for constructing a resilient aioredis pool or client.
+
+    A fresh Retry and error list are returned on every call so callers can
+    never accidentally share mutable state across pools.
+    """
+    return {
+        "socket_keepalive": True,
+        "socket_connect_timeout": SOCKET_CONNECT_TIMEOUT_SECONDS,
+        "health_check_interval": HEALTH_CHECK_INTERVAL_SECONDS,
+        "retry_on_error": [RedisConnectionError, RedisTimeoutError],
+        "retry": Retry(
+            ExponentialBackoff(
+                cap=RETRY_BACKOFF_CAP_SECONDS, base=RETRY_BACKOFF_BASE_SECONDS
+            ),
+            retries=RETRY_MAX_ATTEMPTS,
+        ),
+    }
+
+
+def build_aioredis_pool(url: str) -> aioredis.BlockingConnectionPool:
+    return aioredis.BlockingConnectionPool.from_url(
+        url, **get_aioredis_connection_kwargs()
+    )
+
+
+def build_aioredis_client(url: str) -> aioredis.Redis:
+    return aioredis.from_url(url, **get_aioredis_connection_kwargs())

--- a/model-engine/model_engine_server/core/celery/app.py
+++ b/model-engine/model_engine_server/core/celery/app.py
@@ -9,6 +9,7 @@ from celery import Celery
 from celery.app import backends
 from celery.app.control import Inspect
 from celery.result import AsyncResult
+from model_engine_server.common.aioredis_pool import build_aioredis_client
 from model_engine_server.core.aws.roles import session
 from model_engine_server.core.aws.secrets import get_key_file
 from model_engine_server.core.config import infra_config
@@ -232,7 +233,7 @@ def get_redis_instance(db_index: int = 0) -> Union[Redis, StrictRedis]:
 
 def get_async_redis_instance(db_index: int = 0) -> aioredis.Redis:
     host, port = get_redis_host_port()
-    return aioredis.Redis.from_url(f"redis://{host}:{port}/{db_index}")
+    return build_aioredis_client(f"redis://{host}:{port}/{db_index}")
 
 
 def celery_app(

--- a/model-engine/model_engine_server/core/celery/celery_autoscaler.py
+++ b/model-engine/model_engine_server/core/celery/celery_autoscaler.py
@@ -13,6 +13,7 @@ from typing import Any, DefaultDict, Dict, List, Set, Tuple
 
 import redis.asyncio as aioredis
 import stringcase
+from model_engine_server.common.aioredis_pool import build_aioredis_client
 from azure.core.exceptions import ResourceNotFoundError
 from azure.identity import DefaultAzureCredential
 from azure.servicebus.management import ServiceBusAdministrationClient
@@ -350,7 +351,7 @@ class RedisBroker(AutoscalerBroker):
             get_redis_host_port()
         )  # Switches the redis instance based on CELERY_ELASTICACHE_ENABLED's value
         self.redis = {
-            db_index: aioredis.Redis.from_url(f"redis://{host}:{port}/{db_index}")
+            db_index: build_aioredis_client(f"redis://{host}:{port}/{db_index}")
             for db_index in get_all_db_indexes()
         }
         self.initialized = True

--- a/model-engine/model_engine_server/core/celery/celery_autoscaler.py
+++ b/model-engine/model_engine_server/core/celery/celery_autoscaler.py
@@ -11,9 +11,7 @@ from concurrent.futures import ThreadPoolExecutor
 from math import ceil
 from typing import Any, DefaultDict, Dict, List, Set, Tuple
 
-import redis.asyncio as aioredis
 import stringcase
-from model_engine_server.common.aioredis_pool import build_aioredis_client
 from azure.core.exceptions import ResourceNotFoundError
 from azure.identity import DefaultAzureCredential
 from azure.servicebus.management import ServiceBusAdministrationClient
@@ -23,6 +21,7 @@ from kubernetes_asyncio import client
 from kubernetes_asyncio import config as kube_config
 from kubernetes_asyncio.client.rest import ApiException
 from kubernetes_asyncio.config.config_exception import ConfigException
+from model_engine_server.common.aioredis_pool import build_aioredis_client
 from model_engine_server.core.aws.roles import session
 from model_engine_server.core.celery import (
     TaskVisibility,

--- a/model-engine/model_engine_server/entrypoints/start_batch_job_orchestration.py
+++ b/model-engine/model_engine_server/entrypoints/start_batch_job_orchestration.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import redis.asyncio as aioredis
 from model_engine_server.api.dependencies import get_monitoring_metrics_gateway
+from model_engine_server.common.aioredis_pool import build_aioredis_pool
 from model_engine_server.common.config import hmi_config
 from model_engine_server.common.dtos.model_endpoints import BrokerType
 from model_engine_server.common.env_vars import CIRCLECI
@@ -65,7 +66,7 @@ async def run_batch_job(
 ):
     tracing_gateway = get_tracing_gateway()
     session = get_session_async_null_pool()
-    pool = aioredis.BlockingConnectionPool.from_url(hmi_config.cache_redis_url)
+    pool = build_aioredis_pool(hmi_config.cache_redis_url)
     redis: aioredis.Redis[Any] = aioredis.Redis(connection_pool=pool)
     sqs_task_queue_gateway = CeleryTaskQueueGateway(
         broker_type=BrokerType.SQS, tracing_gateway=tracing_gateway

--- a/model-engine/model_engine_server/infra/gateways/redis_inference_autoscaling_metrics_gateway.py
+++ b/model-engine/model_engine_server/infra/gateways/redis_inference_autoscaling_metrics_gateway.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 import redis.asyncio as aioredis
+from model_engine_server.common.aioredis_pool import build_aioredis_client
 from model_engine_server.domain.gateways.inference_autoscaling_metrics_gateway import (
     InferenceAutoscalingMetricsGateway,
 )
@@ -19,7 +20,7 @@ class RedisInferenceAutoscalingMetricsGateway(InferenceAutoscalingMetricsGateway
             # If aioredis cannot create a connection pool, reraise that as an error because the
             # default error message is cryptic and not obvious.
             try:
-                self._redis = aioredis.from_url(redis_info, health_check_interval=60)
+                self._redis = build_aioredis_client(redis_info)
             except Exception as exc:
                 raise RuntimeError(
                     "If redis_info is specified, RedisInferenceAutoscalingMetricsGateway must be"

--- a/model-engine/model_engine_server/infra/repositories/redis_feature_flag_repository.py
+++ b/model-engine/model_engine_server/infra/repositories/redis_feature_flag_repository.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 import redis.asyncio as aioredis
+from model_engine_server.common.aioredis_pool import build_aioredis_client
 from model_engine_server.infra.repositories.feature_flag_repository import FeatureFlagRepository
 
 
@@ -15,7 +16,7 @@ class RedisFeatureFlagRepository(FeatureFlagRepository):
             # If aioredis cannot create a connection pool, reraise that as an error because the
             # default error message is cryptic and not obvious.
             try:
-                self._redis = aioredis.from_url(redis_info, health_check_interval=60)
+                self._redis = build_aioredis_client(redis_info)
             except Exception as exc:
                 raise RuntimeError(
                     "If redis_info is specified, RedisFeatureFlagRepository must be"

--- a/model-engine/model_engine_server/infra/repositories/redis_model_endpoint_cache_repository.py
+++ b/model-engine/model_engine_server/infra/repositories/redis_model_endpoint_cache_repository.py
@@ -3,6 +3,7 @@ import os
 from typing import Optional
 
 import redis.asyncio as aioredis
+from model_engine_server.common.aioredis_pool import build_aioredis_client
 from model_engine_server.domain.entities import ModelEndpointInfraState
 from model_engine_server.infra.repositories.model_endpoint_cache_repository import (
     ModelEndpointCacheRepository,
@@ -23,7 +24,7 @@ class RedisModelEndpointCacheRepository(ModelEndpointCacheRepository):
             # If aioredis cannot create a connection pool, reraise that as an error because the
             # default error message is cryptic and not obvious.
             try:
-                self._redis = aioredis.from_url(redis_info, health_check_interval=60)
+                self._redis = build_aioredis_client(redis_info)
             except Exception as exc:
                 raise RuntimeError(
                     "If redis_info is specified, RedisModelEndpointCacheRepository must be"

--- a/model-engine/model_engine_server/service_builder/tasks_v1.py
+++ b/model-engine/model_engine_server/service_builder/tasks_v1.py
@@ -8,6 +8,7 @@ import redis.asyncio as aioredis
 from celery.signals import worker_process_init
 from celery.utils.log import get_task_logger
 from model_engine_server.api.dependencies import get_monitoring_metrics_gateway
+from model_engine_server.common.aioredis_pool import build_aioredis_pool
 from model_engine_server.common.config import hmi_config
 from model_engine_server.common.constants import READYZ_FPATH
 from model_engine_server.common.dtos.endpoint_builder import (
@@ -155,7 +156,7 @@ async def _build_endpoint(
         # Redis connection
         if infra_config().debug_mode:  # pragma: no cover
             logger.info("Connecting to Redis", extra={"redis_url": hmi_config.cache_redis_url})
-        pool = aioredis.BlockingConnectionPool.from_url(hmi_config.cache_redis_url)
+        pool = build_aioredis_pool(hmi_config.cache_redis_url)
         redis = aioredis.Redis(connection_pool=pool)
         if infra_config().debug_mode:  # pragma: no cover
             logger.info("Redis connection established successfully")

--- a/model-engine/tests/unit/common/test_aioredis_pool.py
+++ b/model-engine/tests/unit/common/test_aioredis_pool.py
@@ -1,8 +1,4 @@
 import redis.asyncio as aioredis
-from redis.asyncio.retry import Retry
-from redis.exceptions import ConnectionError as RedisConnectionError
-from redis.exceptions import TimeoutError as RedisTimeoutError
-
 from model_engine_server.common.aioredis_pool import (
     HEALTH_CHECK_INTERVAL_SECONDS,
     RETRY_MAX_ATTEMPTS,
@@ -11,6 +7,9 @@ from model_engine_server.common.aioredis_pool import (
     build_aioredis_pool,
     get_aioredis_connection_kwargs,
 )
+from redis.asyncio.retry import Retry
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import TimeoutError as RedisTimeoutError
 
 
 def test_kwargs_include_keepalive_health_check_and_retry():

--- a/model-engine/tests/unit/common/test_aioredis_pool.py
+++ b/model-engine/tests/unit/common/test_aioredis_pool.py
@@ -1,0 +1,50 @@
+import redis.asyncio as aioredis
+from redis.asyncio.retry import Retry
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import TimeoutError as RedisTimeoutError
+
+from model_engine_server.common.aioredis_pool import (
+    HEALTH_CHECK_INTERVAL_SECONDS,
+    RETRY_MAX_ATTEMPTS,
+    SOCKET_CONNECT_TIMEOUT_SECONDS,
+    build_aioredis_client,
+    build_aioredis_pool,
+    get_aioredis_connection_kwargs,
+)
+
+
+def test_kwargs_include_keepalive_health_check_and_retry():
+    kwargs = get_aioredis_connection_kwargs()
+    assert kwargs["socket_keepalive"] is True
+    assert kwargs["socket_connect_timeout"] == SOCKET_CONNECT_TIMEOUT_SECONDS
+    assert kwargs["health_check_interval"] == HEALTH_CHECK_INTERVAL_SECONDS
+    assert kwargs["retry_on_error"] == [RedisConnectionError, RedisTimeoutError]
+    assert isinstance(kwargs["retry"], Retry)
+
+
+def test_kwargs_do_not_share_mutable_state_across_calls():
+    first = get_aioredis_connection_kwargs()
+    second = get_aioredis_connection_kwargs()
+    assert first["retry"] is not second["retry"]
+    assert first["retry_on_error"] is not second["retry_on_error"]
+
+
+def test_build_aioredis_pool_applies_kwargs_to_connection():
+    pool = build_aioredis_pool("redis://localhost:6379/0")
+    assert isinstance(pool, aioredis.BlockingConnectionPool)
+    conn = pool.connection_class(**pool.connection_kwargs)
+    assert conn.socket_keepalive is True
+    assert conn.socket_connect_timeout == SOCKET_CONNECT_TIMEOUT_SECONDS
+    assert conn.health_check_interval == HEALTH_CHECK_INTERVAL_SECONDS
+    # retries is the only reliable way to tell we replaced the default
+    # NoBackoff(0) with our configured Retry.
+    assert conn.retry._retries == RETRY_MAX_ATTEMPTS
+
+
+def test_build_aioredis_client_applies_kwargs_to_connection():
+    client = build_aioredis_client("redis://localhost:6379/0")
+    pool = client.connection_pool
+    conn = pool.connection_class(**pool.connection_kwargs)
+    assert conn.socket_keepalive is True
+    assert conn.health_check_interval == HEALTH_CHECK_INTERVAL_SECONDS
+    assert conn.retry._retries == RETRY_MAX_ATTEMPTS


### PR DESCRIPTION
## Summary
- Centralises aioredis pool/client construction in a new `common/aioredis_pool.py` helper that enables TCP keepalive, a periodic health-check PING (`health_check_interval=30`), and transparent retry on `ConnectionError`/`TimeoutError` with exponential backoff (3 attempts).
- Applies the helper to every long-lived Redis pool/client in model-engine: API dependencies, batch orchestrator entrypoint, service builder, celery app + autoscaler, and the `redis_info` branches in `RedisModelEndpointCacheRepository`, `RedisFeatureFlagRepository`, and `RedisInferenceAutoscalingMetricsGateway`.

## Why
The deployed gateway has been throwing recurring 500s like:
```
File ".../redis_model_endpoint_cache_repository.py:57"
  info = await self._redis.get(endpoint_id_key)
File ".../redis/asyncio/connection.py:739"
  redis.exceptions.ConnectionError: Error UNKNOWN while writing to socket. Connection lost.
```

Root cause is client-side: the shared `BlockingConnectionPool` in `api/dependencies.py` was constructed with no kwargs, so per redis-py 4.6.0's `AbstractConnection.__init__`, the connection's retry was set to `Retry(NoBackoff(), 0)` — literally zero retries. The first command issued on a silently-dropped pooled socket (Istio sidecar / NAT / Azure LB idle timeout) raised straight to the caller via `_disconnect_raise`. The `health_check_interval=60` already present inside each repo's `__init__` only ran on the `redis_info` branch and was dead code in prod (which always passes `redis_client`).

After this change, a stale pooled socket triggers: retry catches the `ConnectionError` → `_disconnect_raise` closes the dead socket but does not re-raise (it's in `retry_on_error`) → backoff → reconnect → command succeeds. Callers see no 500.

## Test plan
- [x] New unit tests in `tests/unit/common/test_aioredis_pool.py` verify the kwargs flow into the underlying `Connection` and that `retry`/`retry_on_error` are not shared across pools.
- [ ] Verify in deployed env: monitor model-engine logs for the recurring `ConnectionError: Error UNKNOWN while writing to socket` 500s that surfaced ~45-60min after pod restart.
- [ ] Confirm existing repo unit tests (`test_redis_model_endpoint_cache_repository.py`, `test_redis_feature_flag_repository.py`) still pass under CI — they patch `aioredis.Redis.from_url`, which `aioredis.from_url` (used by the new helper) routes through, so they should be unaffected.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralises aioredis pool/client construction in a new `common/aioredis_pool.py` helper and applies it across all long-lived Redis connections in model-engine, adding TCP keepalive, a `health_check_interval=30` PING, and exponential-backoff retry on `ConnectionError`/`TimeoutError` to fix recurring 500s caused by silently-dropped pooled sockets (Istio/NAT idle timeout). The approach is sound: a fresh `Retry` and `retry_on_error` list are returned on every call to prevent mutable-state sharing across pools, and the three repositories that previously had a dead `health_check_interval=60` code path now consistently get retry logic too.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all remaining findings are P2 style suggestions that do not block correctness.

The core fix is well-reasoned and correctly implemented: fresh mutable objects per call prevent cross-pool contamination, health check and retry are properly wired, and the migration is applied uniformly. Both P2 comments (missing `socket_timeout` for active-I/O hangs, private `_retries` attribute in tests) are improvements but not bugs in the changed code path.

model-engine/model_engine_server/common/aioredis_pool.py — consider adding `socket_timeout` for completeness.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| model-engine/model_engine_server/common/aioredis_pool.py | New helper centralising resilient aioredis pool/client construction with keepalive, health-check ping, and exponential-backoff retry; minor: no `socket_timeout` for active I/O hangs. |
| model-engine/tests/unit/common/test_aioredis_pool.py | Unit tests verify kwargs flow and mutable-state isolation; tests rely on private `_retries` attribute that may be fragile across redis-py upgrades. |
| model-engine/model_engine_server/api/dependencies.py | Replaced bare `BlockingConnectionPool.from_url` with `build_aioredis_pool`; pool expiry/replacement logic unchanged and pre-existing unclosed-pool concern remains out of scope. |
| model-engine/model_engine_server/core/celery/celery_autoscaler.py | Replaced `aioredis.Redis.from_url` with `build_aioredis_client`; direct `aioredis` import cleanly removed since no other usage remains. |
| model-engine/model_engine_server/infra/repositories/redis_model_endpoint_cache_repository.py | Replaced `aioredis.from_url(…, health_check_interval=60)` with `build_aioredis_client`; health check interval is now 30s (from centralised constant) and retry is added. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant aioredis.Redis
    participant BlockingConnectionPool
    participant Connection

    Caller->>aioredis.Redis: command (e.g. GET)
    aioredis.Redis->>BlockingConnectionPool: get_connection()
    BlockingConnectionPool->>Connection: acquire (idle socket)
    alt idle > health_check_interval (30s)
        Connection->>Connection: PING (health check)
        Connection-->>Connection: ConnectionError (stale socket)
    end
    Note over Connection: retry_on_error catches ConnectionError
    Connection->>Connection: _disconnect_raise → close dead socket
    loop ExponentialBackoff (up to 3 attempts)
        Connection->>Connection: reconnect
        Connection->>aioredis.Redis: execute command
    end
    aioredis.Redis-->>Caller: result (no 500)
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Amodel-engine%2Fmodel_engine_server%2Fcommon%2Faioredis_pool.py%3A35-44%0A**Consider%20adding%20%60socket_timeout%60%20for%20active%20I%2FO%20hangs**%0A%0AThe%20new%20kwargs%20harden%20against%20*idle*%20stale%20sockets%20via%20%60health_check_interval%60%20and%20TCP%20keepalive%2C%20but%20don't%20set%20%60socket_timeout%60.%20A%20connection%20that%20stalls%20mid-read%2Fwrite%20%28e.g.%20a%20network%20partition%20during%20an%20active%20operation%29%20will%20hang%20indefinitely.%20Adding%20%60socket_timeout%60%20alongside%20%60socket_connect_timeout%60%20would%20make%20%60TimeoutError%60%20catchable%20by%20the%20retry%20mechanism%20already%20configured%20in%20%60retry_on_error%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20return%20%7B%0A%20%20%20%20%20%20%20%20%22socket_keepalive%22%3A%20True%2C%0A%20%20%20%20%20%20%20%20%22socket_connect_timeout%22%3A%20SOCKET_CONNECT_TIMEOUT_SECONDS%2C%0A%20%20%20%20%20%20%20%20%22socket_timeout%22%3A%20SOCKET_CONNECT_TIMEOUT_SECONDS%2C%0A%20%20%20%20%20%20%20%20%22health_check_interval%22%3A%20HEALTH_CHECK_INTERVAL_SECONDS%2C%0A%20%20%20%20%20%20%20%20%22retry_on_error%22%3A%20%5BRedisConnectionError%2C%20RedisTimeoutError%5D%2C%0A%20%20%20%20%20%20%20%20%22retry%22%3A%20Retry%28%0A%20%20%20%20%20%20%20%20%20%20%20%20ExponentialBackoff%28cap%3DRETRY_BACKOFF_CAP_SECONDS%2C%20base%3DRETRY_BACKOFF_BASE_SECONDS%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20retries%3DRETRY_MAX_ATTEMPTS%2C%0A%20%20%20%20%20%20%20%20%29%2C%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Amodel-engine%2Ftests%2Funit%2Fcommon%2Ftest_aioredis_pool.py%3A40%0A**Private%20attribute%20%60_retries%60%20is%20fragile%20across%20redis-py%20versions**%0A%0A%60conn.retry._retries%60%20accesses%20a%20private%20attribute%3B%20if%20redis-py%20renames%20or%20restructures%20%60Retry%60%20internals%20this%20assertion%20will%20break%20silently%20or%20raise%20%60AttributeError%60.%20The%20test%20comment%20even%20acknowledges%20this%20is%20a%20workaround.%20Consider%20also%20asserting%20on%20the%20backoff%20type%20to%20add%20coverage%20without%20relying%20solely%20on%20a%20private%20field%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20assert%20conn.retry._retries%20%3D%3D%20RETRY_MAX_ATTEMPTS%0A%20%20%20%20from%20redis.backoff%20import%20ExponentialBackoff%0A%20%20%20%20assert%20isinstance%28conn.retry._backoff%2C%20ExponentialBackoff%29%0A%60%60%60%0A%0A&pr=816&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Amodel-engine%2Fmodel_engine_server%2Fcommon%2Faioredis_pool.py%3A35-44%0A**Consider%20adding%20%60socket_timeout%60%20for%20active%20I%2FO%20hangs**%0A%0AThe%20new%20kwargs%20harden%20against%20*idle*%20stale%20sockets%20via%20%60health_check_interval%60%20and%20TCP%20keepalive%2C%20but%20don't%20set%20%60socket_timeout%60.%20A%20connection%20that%20stalls%20mid-read%2Fwrite%20%28e.g.%20a%20network%20partition%20during%20an%20active%20operation%29%20will%20hang%20indefinitely.%20Adding%20%60socket_timeout%60%20alongside%20%60socket_connect_timeout%60%20would%20make%20%60TimeoutError%60%20catchable%20by%20the%20retry%20mechanism%20already%20configured%20in%20%60retry_on_error%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20return%20%7B%0A%20%20%20%20%20%20%20%20%22socket_keepalive%22%3A%20True%2C%0A%20%20%20%20%20%20%20%20%22socket_connect_timeout%22%3A%20SOCKET_CONNECT_TIMEOUT_SECONDS%2C%0A%20%20%20%20%20%20%20%20%22socket_timeout%22%3A%20SOCKET_CONNECT_TIMEOUT_SECONDS%2C%0A%20%20%20%20%20%20%20%20%22health_check_interval%22%3A%20HEALTH_CHECK_INTERVAL_SECONDS%2C%0A%20%20%20%20%20%20%20%20%22retry_on_error%22%3A%20%5BRedisConnectionError%2C%20RedisTimeoutError%5D%2C%0A%20%20%20%20%20%20%20%20%22retry%22%3A%20Retry%28%0A%20%20%20%20%20%20%20%20%20%20%20%20ExponentialBackoff%28cap%3DRETRY_BACKOFF_CAP_SECONDS%2C%20base%3DRETRY_BACKOFF_BASE_SECONDS%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20retries%3DRETRY_MAX_ATTEMPTS%2C%0A%20%20%20%20%20%20%20%20%29%2C%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Amodel-engine%2Ftests%2Funit%2Fcommon%2Ftest_aioredis_pool.py%3A40%0A**Private%20attribute%20%60_retries%60%20is%20fragile%20across%20redis-py%20versions**%0A%0A%60conn.retry._retries%60%20accesses%20a%20private%20attribute%3B%20if%20redis-py%20renames%20or%20restructures%20%60Retry%60%20internals%20this%20assertion%20will%20break%20silently%20or%20raise%20%60AttributeError%60.%20The%20test%20comment%20even%20acknowledges%20this%20is%20a%20workaround.%20Consider%20also%20asserting%20on%20the%20backoff%20type%20to%20add%20coverage%20without%20relying%20solely%20on%20a%20private%20field%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20assert%20conn.retry._retries%20%3D%3D%20RETRY_MAX_ATTEMPTS%0A%20%20%20%20from%20redis.backoff%20import%20ExponentialBackoff%0A%20%20%20%20assert%20isinstance%28conn.retry._backoff%2C%20ExponentialBackoff%29%0A%60%60%60%0A%0A&repo=scaleapi%2Fllm-engine&pr=816&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: model-engine/model_engine_server/common/aioredis_pool.py
Line: 35-44

Comment:
**Consider adding `socket_timeout` for active I/O hangs**

The new kwargs harden against *idle* stale sockets via `health_check_interval` and TCP keepalive, but don't set `socket_timeout`. A connection that stalls mid-read/write (e.g. a network partition during an active operation) will hang indefinitely. Adding `socket_timeout` alongside `socket_connect_timeout` would make `TimeoutError` catchable by the retry mechanism already configured in `retry_on_error`.

```suggestion
    return {
        "socket_keepalive": True,
        "socket_connect_timeout": SOCKET_CONNECT_TIMEOUT_SECONDS,
        "socket_timeout": SOCKET_CONNECT_TIMEOUT_SECONDS,
        "health_check_interval": HEALTH_CHECK_INTERVAL_SECONDS,
        "retry_on_error": [RedisConnectionError, RedisTimeoutError],
        "retry": Retry(
            ExponentialBackoff(cap=RETRY_BACKOFF_CAP_SECONDS, base=RETRY_BACKOFF_BASE_SECONDS),
            retries=RETRY_MAX_ATTEMPTS,
        ),
    }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: model-engine/tests/unit/common/test_aioredis_pool.py
Line: 40

Comment:
**Private attribute `_retries` is fragile across redis-py versions**

`conn.retry._retries` accesses a private attribute; if redis-py renames or restructures `Retry` internals this assertion will break silently or raise `AttributeError`. The test comment even acknowledges this is a workaround. Consider also asserting on the backoff type to add coverage without relying solely on a private field:

```suggestion
    assert conn.retry._retries == RETRY_MAX_ATTEMPTS
    from redis.backoff import ExponentialBackoff
    assert isinstance(conn.retry._backoff, ExponentialBackoff)
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["chore: appease lint (black, isort, ruff,..."](https://github.com/scaleapi/llm-engine/commit/d0f11ae7a44b45f07fb6a689082e309cb636db97) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29669850)</sub>

<!-- /greptile_comment -->