### PR TITLE
add azcopy in vllm dockerfile

### DIFF
--- a/model-engine/model_engine_server/inference/vllm/Dockerfile.vllm
+++ b/model-engine/model_engine_server/inference/vllm/Dockerfile.vllm
@@ -15,11 +15,16 @@ FROM scratch AS vllm-omni-source
 
 FROM ${VLLM_BASE_IMAGE} AS base
 
-RUN apt-get update \
-    && apt-get install -y wget gdb psmisc dumb-init \
+  RUN apt-get update \
+    && apt-get install -y wget curl ca-certificates gdb psmisc dumb-init \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/* \
-    apt-get clean
+    && apt-get clean
+
+RUN curl -fsSL https://aka.ms/downloadazcopy-v10-linux \
+    | tar --strip-components=1 -C /usr/local/bin --no-same-owner --exclude=*.txt -xzvf - \
+    && chmod 755 /usr/local/bin/azcopy \
+    && azcopy --version
 
 WORKDIR /workspace
 

--- a/model-engine/model_engine_server/inference/vllm/Dockerfile.vllm
+++ b/model-engine/model_engine_server/inference/vllm/Dockerfile.vllm
@@ -15,14 +15,20 @@ FROM scratch AS vllm-omni-source
 
 FROM ${VLLM_BASE_IMAGE} AS base
 
-  RUN apt-get update \
+ARG AZCOPY_VERSION=10.32.3
+ARG AZCOPY_SHA256=ab461a0f963363d6fb7ac00dd0e9177e0af91ba22a880576ebe81383fffe95dc
+
+RUN apt-get update \
     && apt-get install -y wget curl ca-certificates gdb psmisc dumb-init \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
-RUN curl -fsSL https://aka.ms/downloadazcopy-v10-linux \
-    | tar --strip-components=1 -C /usr/local/bin --no-same-owner --exclude=*.txt -xzvf - \
+RUN curl -fsSL -o /tmp/azcopy_linux_amd64.tar.gz \
+      "https://github.com/Azure/azure-storage-azcopy/releases/download/v${AZCOPY_VERSION}/azcopy_linux_amd64_${AZCOPY_VERSION}.tar.gz" \
+    && echo "${AZCOPY_SHA256}  /tmp/azcopy_linux_amd64.tar.gz" | sha256sum -c - \
+    && tar --strip-components=1 -C /usr/local/bin --no-same-owner --exclude='*.txt' -xzvf /tmp/azcopy_linux_amd64.tar.gz \
+    && rm /tmp/azcopy_linux_amd64.tar.gz \
     && chmod 755 /usr/local/bin/azcopy \
     && azcopy --version
 


### PR DESCRIPTION
# Pull Request Summary

Currently, `azcopy` is necessary to download checkpoints in azure deployment, but its not baked into the dockerfile. Instead, its installed at runtime. This leads to errors in network-constrained customer environments, where we cannot install 3rd party packages at runtime.

This PR adds `azcopy` directly in the Dockerfile.

## Test Plan and Usage Guide

Tested locally.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Bakes `azcopy` v10.32.3 directly into the vLLM Dockerfile by downloading from a pinned GitHub release URL with SHA-256 checksum verification, addressing runtime install failures in network-constrained Azure environments.
- Also fixes a pre-existing bug where `apt-get clean` was missing the `&&` operator, and adds the `curl` and `ca-certificates` packages that the new download step requires.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; only a P2 architecture-hardcoding note with no current breakage.

The change correctly pins a specific azcopy version, verifies the SHA-256 checksum before executing the binary, and validates the install with a smoke-test. The single finding is a P2 (hardcoded amd64 architecture) that only affects hypothetical cross-platform builds, not current usage.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| model-engine/model_engine_server/inference/vllm/Dockerfile.vllm | Adds azcopy v10.32.3 to the base image with a pinned GitHub release URL, SHA-256 checksum verification, and a smoke-test; also fixes a missing `&&` before `apt-get clean` and adds `curl`/`ca-certificates` as explicit dependencies. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["scratch\n(vllm-omni-source)"] --> B

    B["base\n• apt-get: wget curl ca-certs gdb psmisc dumb-init\n• Download + SHA256-verify azcopy v10.32.3\n• Extract to /usr/local/bin\n• wget s5cmd"]

    B --> C["vllm_base\n• pip install vllm[audio]\n• pip install flashinfer"]

    C --> D["vllm\n• pip install requirements\n• Copy entrypoint.sh"]
    C --> E["vllm_omni\n• pip install vllm-omni\n• pip install requirements"]

    B --> F["vllm_batch\n• pip install requirements-batch\n• pip install model-engine"]
    F --> G["vllm_batch_debug\n• Override ray + vllm files"]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Amodel-engine%2Fmodel_engine_server%2Finference%2Fvllm%2FDockerfile.vllm%3A27-30%0A**Architecture%20hardcoded%20to%20%60amd64%60**%0A%0AThe%20download%20URL%20and%20tar%20filename%20both%20hardcode%20%60amd64%60.%20If%20this%20image%20is%20ever%20built%20on%20an%20%60arm64%60%20host%20%28e.g.%2C%20Apple%20Silicon%20CI%2C%20Graviton%29%2C%20Docker%20will%20silently%20download%20and%20extract%20the%20wrong%20binary%2C%20and%20the%20%60azcopy%20--version%60%20smoke-test%20will%20fail%20at%20build%20time%20with%20an%20exec-format%20error.%20Consider%20parameterising%20the%20architecture%20with%20a%20build%20arg%20%28e.g.%2C%20%60ARG%20TARGETARCH%60%29%20so%20cross-platform%20builds%20can%20supply%20the%20correct%20variant%20without%20changing%20the%20Dockerfile.%0A%0A&pr=819&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Amodel-engine%2Fmodel_engine_server%2Finference%2Fvllm%2FDockerfile.vllm%3A27-30%0A**Architecture%20hardcoded%20to%20%60amd64%60**%0A%0AThe%20download%20URL%20and%20tar%20filename%20both%20hardcode%20%60amd64%60.%20If%20this%20image%20is%20ever%20built%20on%20an%20%60arm64%60%20host%20%28e.g.%2C%20Apple%20Silicon%20CI%2C%20Graviton%29%2C%20Docker%20will%20silently%20download%20and%20extract%20the%20wrong%20binary%2C%20and%20the%20%60azcopy%20--version%60%20smoke-test%20will%20fail%20at%20build%20time%20with%20an%20exec-format%20error.%20Consider%20parameterising%20the%20architecture%20with%20a%20build%20arg%20%28e.g.%2C%20%60ARG%20TARGETARCH%60%29%20so%20cross-platform%20builds%20can%20supply%20the%20correct%20variant%20without%20changing%20the%20Dockerfile.%0A%0A&repo=scaleapi%2Fllm-engine&pr=819&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fllm-engine%22%20on%20the%20existing%20branch%20%22lukas%2Fazcopy%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22lukas%2Fazcopy%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Amodel-engine%2Fmodel_engine_server%2Finference%2Fvllm%2FDockerfile.vllm%3A27-30%0A**Architecture%20hardcoded%20to%20%60amd64%60**%0A%0AThe%20download%20URL%20and%20tar%20filename%20both%20hardcode%20%60amd64%60.%20If%20this%20image%20is%20ever%20built%20on%20an%20%60arm64%60%20host%20%28e.g.%2C%20Apple%20Silicon%20CI%2C%20Graviton%29%2C%20Docker%20will%20silently%20download%20and%20extract%20the%20wrong%20binary%2C%20and%20the%20%60azcopy%20--version%60%20smoke-test%20will%20fail%20at%20build%20time%20with%20an%20exec-format%20error.%20Consider%20parameterising%20the%20architecture%20with%20a%20build%20arg%20%28e.g.%2C%20%60ARG%20TARGETARCH%60%29%20so%20cross-platform%20builds%20can%20supply%20the%20correct%20variant%20without%20changing%20the%20Dockerfile.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
model-engine/model_engine_server/inference/vllm/Dockerfile.vllm:27-30
**Architecture hardcoded to `amd64`**

The download URL and tar filename both hardcode `amd64`. If this image is ever built on an `arm64` host (e.g., Apple Silicon CI, Graviton), Docker will silently download and extract the wrong binary, and the `azcopy --version` smoke-test will fail at build time with an exec-format error. Consider parameterising the architecture with a build arg (e.g., `ARG TARGETARCH`) so cross-platform builds can supply the correct variant without changing the Dockerfile.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["address greptile"](https://github.com/scaleapi/llm-engine/commit/979ddf47e27c83af545c4630ea07388dcee452cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30843443)</sub>

<!-- /greptile_comment -->