### PR TITLE
Fix/gcs check hashes

### DIFF
--- a/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
+++ b/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
@@ -724,10 +724,16 @@ class CreateLLMModelBundleV1UseCase:
         # AZCOPY_AUTO_LOGIN_TYPE=WORKLOAD). The pod's KSA must be bound to a GSA with
         # storage.objects.list and storage.objects.get permissions on the checkpoint bucket.
         # Install gcloud CLI on-the-fly for GCS access (similar to azcopy install for Azure)
+        # storage/check_hashes: gcloud storage rsync defaults to check_hashes=always, which
+        # requires the google-crc32c library. That lib is not installed in the inference
+        # container, so the default config causes every download task to fail with
+        # "fast hash calculation tools are not installed". if_fast_else_skip lets the
+        # download proceed without the integrity check when the lib is missing.
         subcommands.append(
             "curl -sSL https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz"
             " | tar -xz -C /opt"
             " && /opt/google-cloud-sdk/bin/gcloud config set disable_usage_reporting true 2>/dev/null"
+            " && /opt/google-cloud-sdk/bin/gcloud config set storage/check_hashes if_fast_else_skip 2>/dev/null"
         )
 
         # gcloud storage rsync only supports --exclude (Python regex), not --include.
@@ -759,10 +765,14 @@ class CreateLLMModelBundleV1UseCase:
                 f"./s5cmd {s3_endpoint_flag} --numworkers 512 cp --concurrency 50 {os.path.join(checkpoint_path, '*')} ./"
             ]
         elif checkpoint_path.startswith("gs://"):
+            # See load_model_weights_sub_commands_gcs for why storage/check_hashes is set —
+            # gcloud storage cp also defaults to check_hashes=always and would fail per file
+            # without the google-crc32c lib in the inference container.
             subcommands = [
                 "curl -sSL https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz"
                 " | tar -xz -C /opt"
-                " && /opt/google-cloud-sdk/bin/gcloud config set disable_usage_reporting true 2>/dev/null",
+                " && /opt/google-cloud-sdk/bin/gcloud config set disable_usage_reporting true 2>/dev/null"
+                " && /opt/google-cloud-sdk/bin/gcloud config set storage/check_hashes if_fast_else_skip 2>/dev/null",
                 f"/opt/google-cloud-sdk/bin/gcloud storage cp -r {os.path.join(checkpoint_path, '*')} ./",
             ]
         else:

--- a/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
+++ b/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
@@ -724,11 +724,10 @@ class CreateLLMModelBundleV1UseCase:
         # AZCOPY_AUTO_LOGIN_TYPE=WORKLOAD). The pod's KSA must be bound to a GSA with
         # storage.objects.list and storage.objects.get permissions on the checkpoint bucket.
         # Install gcloud CLI on-the-fly for GCS access (similar to azcopy install for Azure)
-        # storage/check_hashes: gcloud storage rsync defaults to check_hashes=always, which
-        # requires the google-crc32c library. That lib is not installed in the inference
-        # container, so the default config causes every download task to fail with
-        # "fast hash calculation tools are not installed". if_fast_else_skip lets the
-        # download proceed without the integrity check when the lib is missing.
+        # storage/check_hashes=if_fast_else_skip lets rsync proceed without the
+        # google-crc32c lib (not present in the inference image). The default
+        # check_hashes=always fails every download with "fast hash calculation
+        # tools are not installed".
         subcommands.append(
             "curl -sSL https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz"
             " | tar -xz -C /opt"
@@ -765,9 +764,7 @@ class CreateLLMModelBundleV1UseCase:
                 f"./s5cmd {s3_endpoint_flag} --numworkers 512 cp --concurrency 50 {os.path.join(checkpoint_path, '*')} ./"
             ]
         elif checkpoint_path.startswith("gs://"):
-            # See load_model_weights_sub_commands_gcs for why storage/check_hashes is set —
-            # gcloud storage cp also defaults to check_hashes=always and would fail per file
-            # without the google-crc32c lib in the inference container.
+            # Same check_hashes rationale as load_model_weights_sub_commands_gcs.
             subcommands = [
                 "curl -sSL https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz"
                 " | tar -xz -C /opt"

--- a/model-engine/tests/unit/domain/test_llm_use_cases.py
+++ b/model-engine/tests/unit/domain/test_llm_use_cases.py
@@ -664,7 +664,8 @@ def test_load_model_weights_sub_commands(
     expected_result = [
         "curl -sSL https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz"
         " | tar -xz -C /opt"
-        " && /opt/google-cloud-sdk/bin/gcloud config set disable_usage_reporting true 2>/dev/null",
+        " && /opt/google-cloud-sdk/bin/gcloud config set disable_usage_reporting true 2>/dev/null"
+        " && /opt/google-cloud-sdk/bin/gcloud config set storage/check_hashes if_fast_else_skip 2>/dev/null",
         "/opt/google-cloud-sdk/bin/gcloud storage rsync -r"
         ' --exclude="optimizer.*" --exclude=".*\\.py$"'
         " gs://fake-bucket/fake-checkpoint test_folder",
@@ -683,7 +684,8 @@ def test_load_model_weights_sub_commands(
     expected_result = [
         "curl -sSL https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz"
         " | tar -xz -C /opt"
-        " && /opt/google-cloud-sdk/bin/gcloud config set disable_usage_reporting true 2>/dev/null",
+        " && /opt/google-cloud-sdk/bin/gcloud config set disable_usage_reporting true 2>/dev/null"
+        " && /opt/google-cloud-sdk/bin/gcloud config set storage/check_hashes if_fast_else_skip 2>/dev/null",
         "/opt/google-cloud-sdk/bin/gcloud storage rsync -r"
         ' --exclude="optimizer.*"'
         " gs://fake-bucket/fake-checkpoint test_folder",
@@ -717,7 +719,8 @@ def test_load_model_files_sub_commands_trt_llm_gcs(
     expected_result = [
         "curl -sSL https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz"
         " | tar -xz -C /opt"
-        " && /opt/google-cloud-sdk/bin/gcloud config set disable_usage_reporting true 2>/dev/null",
+        " && /opt/google-cloud-sdk/bin/gcloud config set disable_usage_reporting true 2>/dev/null"
+        " && /opt/google-cloud-sdk/bin/gcloud config set storage/check_hashes if_fast_else_skip 2>/dev/null",
         "/opt/google-cloud-sdk/bin/gcloud storage cp -r gs://fake-bucket/fake-checkpoint/* ./",
     ]
     assert expected_result == subcommands


### PR DESCRIPTION
# Pull Request Summary

_What is this PR changing? Why is this change being made? Any caveats you'd like to highlight? Link any relevant documents, links, or screenshots here if applicable._

## Test Plan and Usage Guide

_How did you validate that your PR works correctly? How do you run or demo the code? Provide enough detail so a reviewer can reasonably reproduce the testing procedure. Paste example command line invocations if applicable._

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes GCS checkpoint/weight downloads that were failing because the inference image lacks the `google-crc32c` library required by `gcloud storage`'s default `check_hashes=always` mode. The fix appends `gcloud config set storage/check_hashes if_fast_else_skip` to the SDK install command in both `load_model_weights_sub_commands_gcs` and `load_model_files_sub_commands_trt_llm`, with corresponding test updates in all three affected test cases.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — minimal, focused fix with full test coverage and clear inline documentation.

No P0/P1 issues found. Both affected code paths are updated consistently, tests cover all three GCS cases, and the code comments clearly explain the rationale. The chosen `if_fast_else_skip` value is appropriate for environments without `google-crc32c`.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py | Adds `gcloud config set storage/check_hashes if_fast_else_skip` to both GCS download paths; fix is well-targeted and the string concatenation is correct. |
| model-engine/tests/unit/domain/test_llm_use_cases.py | All three GCS test cases updated to include the new `check_hashes` config command in the expected subcommand strings. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Pod
    participant GCS

    Pod->>Pod: curl | tar → install gcloud SDK
    Pod->>Pod: gcloud config set disable_usage_reporting true
    Pod->>Pod: gcloud config set storage/check_hashes if_fast_else_skip
    Pod->>GCS: gcloud storage rsync / cp (checkpoint files)
    GCS-->>Pod: checkpoint files (hash check skipped if no CRC32c lib)
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(gcs): tighten check\_hashes rational..."](https://github.com/scaleapi/llm-engine/commit/77bdf325880416aef6cb97a59266c7eb99eccd9d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30969049)</sub>

<!-- /greptile_comment -->