### PR TITLE
fix(chart): use command instead of args for celery-autoscaler

### DIFF
--- a/charts/model-engine/templates/celery_autoscaler_stateful_set.yaml
+++ b/charts/model-engine/templates/celery_autoscaler_stateful_set.yaml
@@ -36,7 +36,7 @@ spec:
         {{- include "modelEngine.selectorLabels.celeryAutoscaler" . | nindent 8 }}
     spec:
       containers:
-      - args:
+      - command:
         {{- if .Values.datadog.enabled }}
         - ddtrace-run
         {{- end }}


### PR DESCRIPTION
The StatefulSet shipped `args: [python, -m, ...]` without an explicit `command:`. After the runtime image moved to `cgr.dev/chainguard/python:latest` (`ENTRYPOINT=/usr/bin/python`) the result is `/usr/bin/python python -m …`. Python interprets `argv[1]` (`python`) as a script filename and exits 2 with `can't open file /workspace/python`. Switch `args` -> `command` so the full invocation overrides the image `ENTRYPOINT` and runs regardless of base-image entrypoint changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Renames `args` to `command` in the celery-autoscaler StatefulSet so the full Python invocation overrides the image `ENTRYPOINT`, fixing the crash introduced when the base image moved to `cgr.dev/chainguard/python:latest` (which sets `ENTRYPOINT=/usr/bin/python`). The one-line change is correct and consistent with how other autoscaler deployments in the chart are defined.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — targeted one-line fix with no side-effects beyond the intended ENTRYPOINT override.

Single-file, single-line change that correctly addresses the described failure mode. Both the Datadog-enabled path (`ddtrace-run python -m …`) and the default path (`python -m …`) resolve correctly after the change. The fix is consistent with how every other Python-based deployment in this chart is already written.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| charts/model-engine/templates/celery_autoscaler_stateful_set.yaml | Switches container spec from `args` to `command` so the full invocation overrides the image ENTRYPOINT, fixing the broken startup introduced by the chainguard Python base image. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant K as Kubernetes
    participant C as Container Runtime
    participant P as Process

    Note over K,P: BEFORE fix (args only, chainguard image ENTRYPOINT=/usr/bin/python)
    K->>C: start container
    C->>P: /usr/bin/python python -m celery_autoscaler
    P-->>C: exit 2 (can't open file /workspace/python)

    Note over K,P: AFTER fix (command overrides ENTRYPOINT)
    K->>C: start container
    C->>P: python -m celery_autoscaler
    P-->>C: running ✓

    Note over K,P: AFTER fix — with Datadog enabled
    K->>C: start container
    C->>P: ddtrace-run python -m celery_autoscaler
    P-->>C: running with tracing ✓
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(chart): use command instead of args ..."](https://github.com/scaleapi/llm-engine/commit/aa9546078eae0d287d2715bc6d516caf5c55ec96) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31329495)</sub>

<!-- /greptile_comment -->