### PR TITLE
fix(chart): align with minimal-base image and runtime istio flag

### DIFF
--- a/charts/model-engine/templates/endpoint_builder_deployment.yaml
+++ b/charts/model-engine/templates/endpoint_builder_deployment.yaml
@@ -47,11 +47,15 @@ spec:
               containerPort: 5000
               protocol: TCP
           readinessProbe:
+            {{- with ((.Values.endpointBuilder).readinessProbe) }}
+            {{- toYaml . | nindent 12 }}
+            {{- else }}
             exec:
               command:
                 - bash
                 - -c
                 - test -f /tmp/readyz
+            {{- end }}
           command:
             - dumb-init
             - --

--- a/charts/model-engine/templates/service_template_config_map.yaml
+++ b/charts/model-engine/templates/service_template_config_map.yaml
@@ -470,7 +470,7 @@ data:
             metric:
               name: request-concurrency-average
             target:
-              type: Value
+              type: AverageValue
               averageValue: ${CONCURRENCY}
   keda-scaled-object.yaml: |-
     apiVersion: keda.sh/v1alpha1
@@ -966,7 +966,7 @@ data:
           protocol: TCP
           name: http
           ${NODE_PORT_DICT}
-  {{- if .Values.virtualservice.enabled }}
+  {{- if or .Values.virtualservice.enabled (and .Values.config.values .Values.config.values.launch .Values.config.values.launch.istio_enabled) }}
   virtual-service.yaml: |-
     apiVersion: networking.istio.io/v1alpha3
     kind: VirtualService
@@ -987,7 +987,7 @@ data:
                 port:
                   number: 80
   {{- end }}
-  {{- if .Values.destinationrule.enabled }}
+  {{- if or .Values.destinationrule.enabled (and .Values.config.values .Values.config.values.launch .Values.config.values.launch.istio_enabled) }}
   destination-rule.yaml: |-
     apiVersion: networking.istio.io/v1beta1
     kind: DestinationRule


### PR DESCRIPTION
## Summary

Three small Helm chart fixes uncovered while diagnosing a stuck endpoint build on a GKE cluster running model-engine `798747b976d50edb61d464385ee41518c8f19755`. All three are independent and reproducible with `helm template`.

### 1. HPA `target.type` is invalid for `type: Pods`

`service_template_config_map.yaml` (`horizontal-pod-autoscaler.yaml` key) sets `target.type: Value`, but HPA v2 requires `AverageValue` whenever the metric type is `Pods`. The Kubernetes HPA rejects it with `status.conditions[0].reason: InvalidMetricSourceType` and falls back to `minReplicas`. All endpoints in our cluster currently show `<unknown>/2` and `desiredReplicas: 0` because of this — only `minReplicas: 1` keeps them alive.

```diff
           target:
-            type: Value
+            type: AverageValue
             averageValue: ${CONCURRENCY}
```

### 2. Istio templates gated on a flag the runtime doesn't read

`virtual-service.yaml` and `destination-rule.yaml` are gated on `Values.virtualservice.enabled` and `Values.destinationrule.enabled`, but the runtime code at `model_engine_server/infra/gateways/resources/k8s_endpoint_resource_delegate.py:1807,1822` reads `config.values.launch.istio_enabled` and unconditionally calls `load_k8s_yaml("virtual-service.yaml", …)` / `destination-rule.yaml` whenever that flag is true. When the two disagree (chart flag false, runtime flag true — easy to do because they're in different keys of `values.yaml`), the build task crashes two seconds in:

```
FileNotFoundError: [Errno 2] No such file or directory:
  '/workspace/model-engine/model_engine_server/infra/gateways/resources/templates/virtual-service.yaml'
  at k8s_endpoint_resource_delegate.py:1807 → load_k8s_yaml("virtual-service.yaml", …)
```

And the endpoint never reaches READY — SGP reports `deployment_timeout`. Couple the chart gating to the runtime flag so the templates are emitted when *either* the chart flag *or* `istio_enabled` is true. Operators who explicitly set `virtualservice.enabled` / `destinationrule.enabled` see no behavior change.

### 3. `endpoint_builder` readiness probe assumes `bash`

The readinessProbe hardcodes `bash -c 'test -f /tmp/readyz'`. Recent minimal-base images (the `798747b…` build, for example) no longer ship `bash`, so the probe permanently fails with:

```
Readiness probe errored: exec: "bash": executable file not found in $PATH
```

The pod stays `0/1 Ready`, which causes `helm --wait` to hit its 1200s timeout and the entire HelmRelease ends up `Stalled` / `RetriesExceeded`. Make the probe overridable through `endpointBuilder.readinessProbe`; default unchanged for backwards compatibility.

## Verification

Rendered the chart with `helm template` against `values_sample.yaml`:

- HPA target.type now renders as `AverageValue`.
- With `virtualservice.enabled=false destinationrule.enabled=false config.values.launch.istio_enabled=true` → VS / DR templates ARE present in the rendered ConfigMap.
- With all three flags false → templates absent (backwards compatible).
- Default `endpointBuilder.readinessProbe` still renders `bash -c …`.
- Override via `--set endpointBuilder.readinessProbe.exec.command='{python3,-c,import os}'` renders correctly.

## How this was found

A `gpt-oss-20b` endpoint deploy through SGP returned `deployment_timeout` even though the pod was `2/2 Running` and serving `/health` 200 OK. The endpoint-builder Celery task had crashed mid-build on the missing `virtual-service.yaml`, so the partial k8s resources existed but the SGP-side state machine never advanced. Patched the ConfigMap directly to unblock; then traced the systemic causes for this PR.

## Out of scope / follow-up

- The minimal-base image dropping `bash` / `cat` / `ls` is an image-build concern. This PR adapts the chart probe to the new reality; restoring shell binaries (if intended) would be a separate image PR.
- Missing `default/internal-gateway` Gateway is a deployer-side concern. Operators who set `istio_enabled: true` must provide a Gateway. May want a `README.md` note for that.
- Some packaged downstream charts wrap `engine-0.2.x` into a parent `model-engine-1.x.x` chart in private registries. Those wrappers will need a re-publish after this lands.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Three targeted Helm chart fixes: corrects the HPA `target.type` from `Value` to `AverageValue` (required for `type: Pods` metrics), aligns the Istio template conditions with the runtime flag so VS/DR YAML is emitted whenever `istio_enabled` is true in `config.values.launch`, and makes the `endpoint_builder` readiness probe overridable via `endpointBuilder.readinessProbe` to support minimal-base images without `bash`.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — all three fixes are independently correct and backwards-compatible; the only gap is a missing documentation entry in values.yaml for the new probe override key.

No P0 or P1 issues. The HPA type fix, Istio condition alignment, and readinessProbe override are all logically sound and correctly implemented in Helm. Score is 4 due to the single P2 documentation gap.

No files require special attention, but `values.yaml` and `values_sample.yaml` should document the new `endpointBuilder.readinessProbe` key.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| charts/model-engine/templates/endpoint_builder_deployment.yaml | Adds an overridable `readinessProbe` via `endpointBuilder.readinessProbe`; falls back to the existing `bash -c test -f /tmp/readyz` default. Helm `with/else` idiom and `nindent 12` indentation are both correct. |
| charts/model-engine/templates/service_template_config_map.yaml | Two independent fixes: corrects HPA `target.type` from invalid `Value` to `AverageValue` for `type: Pods` metrics, and broadens the VS/DR Helm conditions to also emit the templates when `config.values.launch.istio_enabled` is true. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Helm template render] --> B{virtualservice.enabled\nOR config.values.launch.istio_enabled?}
    B -- Yes --> C[Emit virtual-service.yaml in ConfigMap]
    B -- No --> D[Skip virtual-service.yaml]
    A --> E{destinationrule.enabled\nOR config.values.launch.istio_enabled?}
    E -- Yes --> F[Emit destination-rule.yaml in ConfigMap]
    E -- No --> G[Skip destination-rule.yaml]
    A --> H{endpointBuilder.readinessProbe set?}
    H -- Yes --> I[Use user-supplied probe spec]
    H -- No --> J[Default: bash -c test -f /tmp/readyz]
    A --> K[HPA target.type: AverageValue\nfor type: Pods]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acharts%2Fmodel-engine%2Ftemplates%2Fendpoint_builder_deployment.yaml%3A50-58%0AThe%20new%20%60endpointBuilder.readinessProbe%60%20key%20is%20not%20present%20in%20%60values.yaml%60%20or%20%60values_sample.yaml%60.%20Operators%20on%20minimal-base%20images%20who%20need%20this%20override%20have%20no%20documented%20way%20to%20discover%20it.%20Adding%20a%20commented-out%20example%20keeps%20the%20default%20probe%20behaviour%20while%20making%20the%20escape%20hatch%20visible.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%7B%7B-%20with%20%28%28.Values.endpointBuilder%29.readinessProbe%29%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%7B%7B-%20toYaml%20.%20%7C%20nindent%2012%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%7B%7B-%20else%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20exec%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20command%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20-%20bash%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20-%20-c%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20-%20test%20-f%20%2Ftmp%2Freadyz%0A%20%20%20%20%20%20%20%20%20%20%20%20%7B%7B-%20end%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20To%20override%20%28e.g.%20for%20minimal-base%20images%20without%20bash%29%2C%20set%20in%20values.yaml%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20endpointBuilder%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20%20%20readinessProbe%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20%20%20%20%20exec%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20%20%20%20%20%20%20command%3A%20%5B%22sh%22%2C%20%22-c%22%2C%20%22test%20-f%20%2Ftmp%2Freadyz%22%5D%0A%60%60%60%0A%0A&pr=826&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acharts%2Fmodel-engine%2Ftemplates%2Fendpoint_builder_deployment.yaml%3A50-58%0AThe%20new%20%60endpointBuilder.readinessProbe%60%20key%20is%20not%20present%20in%20%60values.yaml%60%20or%20%60values_sample.yaml%60.%20Operators%20on%20minimal-base%20images%20who%20need%20this%20override%20have%20no%20documented%20way%20to%20discover%20it.%20Adding%20a%20commented-out%20example%20keeps%20the%20default%20probe%20behaviour%20while%20making%20the%20escape%20hatch%20visible.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%7B%7B-%20with%20%28%28.Values.endpointBuilder%29.readinessProbe%29%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%7B%7B-%20toYaml%20.%20%7C%20nindent%2012%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%7B%7B-%20else%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20exec%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20command%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20-%20bash%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20-%20-c%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20-%20test%20-f%20%2Ftmp%2Freadyz%0A%20%20%20%20%20%20%20%20%20%20%20%20%7B%7B-%20end%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20To%20override%20%28e.g.%20for%20minimal-base%20images%20without%20bash%29%2C%20set%20in%20values.yaml%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20endpointBuilder%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20%20%20readinessProbe%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20%20%20%20%20exec%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20%20%20%20%20%20%20command%3A%20%5B%22sh%22%2C%20%22-c%22%2C%20%22test%20-f%20%2Ftmp%2Freadyz%22%5D%0A%60%60%60%0A%0A&repo=scaleapi%2Fllm-engine&pr=826&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fllm-engine%22%20on%20the%20existing%20branch%20%22fix%2Fchart-istio-template-gating-and-probes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fchart-istio-template-gating-and-probes%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acharts%2Fmodel-engine%2Ftemplates%2Fendpoint_builder_deployment.yaml%3A50-58%0AThe%20new%20%60endpointBuilder.readinessProbe%60%20key%20is%20not%20present%20in%20%60values.yaml%60%20or%20%60values_sample.yaml%60.%20Operators%20on%20minimal-base%20images%20who%20need%20this%20override%20have%20no%20documented%20way%20to%20discover%20it.%20Adding%20a%20commented-out%20example%20keeps%20the%20default%20probe%20behaviour%20while%20making%20the%20escape%20hatch%20visible.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%7B%7B-%20with%20%28%28.Values.endpointBuilder%29.readinessProbe%29%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%7B%7B-%20toYaml%20.%20%7C%20nindent%2012%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%7B%7B-%20else%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20exec%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20command%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20-%20bash%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20-%20-c%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20-%20test%20-f%20%2Ftmp%2Freadyz%0A%20%20%20%20%20%20%20%20%20%20%20%20%7B%7B-%20end%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20To%20override%20%28e.g.%20for%20minimal-base%20images%20without%20bash%29%2C%20set%20in%20values.yaml%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20endpointBuilder%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20%20%20readinessProbe%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20%20%20%20%20exec%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20%20%20%20%20%20%20command%3A%20%5B%22sh%22%2C%20%22-c%22%2C%20%22test%20-f%20%2Ftmp%2Freadyz%22%5D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
charts/model-engine/templates/endpoint_builder_deployment.yaml:50-58
The new `endpointBuilder.readinessProbe` key is not present in `values.yaml` or `values_sample.yaml`. Operators on minimal-base images who need this override have no documented way to discover it. Adding a commented-out example keeps the default probe behaviour while making the escape hatch visible.

```suggestion
            {{- with ((.Values.endpointBuilder).readinessProbe) }}
            {{- toYaml . | nindent 12 }}
            {{- else }}
            exec:
              command:
                - bash
                - -c
                - test -f /tmp/readyz
            {{- end }}
            # To override (e.g. for minimal-base images without bash), set in values.yaml:
            # endpointBuilder:
            #   readinessProbe:
            #     exec:
            #       command: ["sh", "-c", "test -f /tmp/readyz"]
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(chart): align with minimal-base imag..."](https://github.com/scaleapi/llm-engine/commit/5ad501688b9bad8d2a06e9cd3f8e0104c7fc64d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31596955)</sub>

<!-- /greptile_comment -->