### PR TITLE
[DO NOT MERGE] Also scan 'default' namespace in celery autoscaler (#828)

### DIFF
--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -5,5 +5,5 @@ setup(
     python_requires=">=3.8",
     version="0.0.0.beta45",
     packages=find_packages(),
-    package_data={"llmengine": ["py.typed"]},
+    package_data={"llmengine": ["py.typed"]},  # type: ignore[arg-type]
 )

--- a/model-engine/model_engine_server/core/celery/celery_autoscaler.py
+++ b/model-engine/model_engine_server/core/celery/celery_autoscaler.py
@@ -80,57 +80,69 @@ async def list_deployments(apps_api) -> Dict[Tuple[str, str], CeleryAutoscalerPa
     from model_engine_server.common.config import hmi_config
 
     endpoint_namespace = hmi_config.endpoint_namespace
+    # Also scan "default" so non-launch celery deployments (e.g. nucleus workers) are still
+    # autoscaled. Previously the autoscaler scanned every namespace; #770 scoped it to a single
+    # namespace for startup speed but inadvertently dropped these.
+    # Dedupe to avoid double-scanning if endpoint_namespace itself is "default".
+    namespaces_to_scan = list(dict.fromkeys([endpoint_namespace, "default"]))
     celery_deployments_params = {}
-    namespace_start_time = time.time()
-    deployments = await apps_api.list_namespaced_deployment(namespace=endpoint_namespace)
-    logger.info(
-        f"list_namespaced_deployment in {endpoint_namespace} took {time.time() - namespace_start_time} seconds"
-    )
-    for deployment in deployments.items:
-        deployment_name = deployment.metadata.name
-        annotations = deployment.metadata.annotations
-
-        if not annotations:
+    for namespace_name in namespaces_to_scan:
+        namespace_start_time = time.time()
+        try:
+            deployments = await apps_api.list_namespaced_deployment(namespace=namespace_name)
+        except ApiException as exc:
+            # Don't let a failure in one namespace (e.g. missing RBAC) wipe out scaling for the
+            # other. Log and move on; the next iteration of the outer loop will retry.
+            logger.error(f"Failed to list deployments in namespace {namespace_name}: {exc}")
             continue
+        logger.info(
+            f"list_namespaced_deployment in {namespace_name} took {time.time() - namespace_start_time} seconds"
+        )
+        for deployment in deployments.items:
+            deployment_name = deployment.metadata.name
+            annotations = deployment.metadata.annotations
 
-        # Parse parameters
-        params = {}
-
-        if "celery.scaleml.autoscaler/broker" in annotations:
-            deployment_broker = annotations["celery.scaleml.autoscaler/broker"]
-        else:
-            deployment_broker = ELASTICACHE_REDIS_BROKER
-
-        if deployment_broker != autoscaler_broker:
-            logger.debug(
-                f"Skipping deployment {deployment_name}; deployment's broker {deployment_broker} is not {autoscaler_broker}"
-            )
-            continue
-
-        for f in dataclasses.fields(CeleryAutoscalerParams):
-            k = f.name
-            v = annotations.get(f"celery.scaleml.autoscaler/{stringcase.camelcase(k)}")
-            if not v:
+            if not annotations:
                 continue
 
+            # Parse parameters
+            params = {}
+
+            if "celery.scaleml.autoscaler/broker" in annotations:
+                deployment_broker = annotations["celery.scaleml.autoscaler/broker"]
+            else:
+                deployment_broker = ELASTICACHE_REDIS_BROKER
+
+            if deployment_broker != autoscaler_broker:
+                logger.debug(
+                    f"Skipping deployment {deployment_name}; deployment's broker {deployment_broker} is not {autoscaler_broker}"
+                )
+                continue
+
+            for f in dataclasses.fields(CeleryAutoscalerParams):
+                k = f.name
+                v = annotations.get(f"celery.scaleml.autoscaler/{stringcase.camelcase(k)}")
+                if not v:
+                    continue
+
+                try:
+                    if k == "task_visibility":
+                        v = TaskVisibility.from_name(v)
+                    v = f.type(v)
+                except (ValueError, KeyError):
+                    logger.exception(f"Unable to convert {f.name}: {v} to {f.type}")
+
+                params[k] = v
+
             try:
-                if k == "task_visibility":
-                    v = TaskVisibility.from_name(v)
-                v = f.type(v)
-            except (ValueError, KeyError):
-                logger.exception(f"Unable to convert {f.name}: {v} to {f.type}")
+                celery_autoscaler_params = CeleryAutoscalerParams(**params)
+            except TypeError:
+                logger.debug(
+                    f"Missing params, skipping deployment : {deployment_name} in {namespace_name}"
+                )
+                continue
 
-            params[k] = v
-
-        try:
-            celery_autoscaler_params = CeleryAutoscalerParams(**params)
-        except TypeError:
-            logger.debug(
-                f"Missing params, skipping deployment : {deployment_name} in {endpoint_namespace}"
-            )
-            continue
-
-        celery_deployments_params[(deployment_name, endpoint_namespace)] = celery_autoscaler_params
+            celery_deployments_params[(deployment_name, namespace_name)] = celery_autoscaler_params
 
     return celery_deployments_params
 

--- a/model-engine/model_engine_server/db/migrations/alembic/versions/2026_04_24_0000-b2c3d4e5f6g7_add_temporal_task_queue_column.py
+++ b/model-engine/model_engine_server/db/migrations/alembic/versions/2026_04_24_0000-b2c3d4e5f6g7_add_temporal_task_queue_column.py
@@ -1,0 +1,31 @@
+"""add temporal_task_queue column
+
+Revision ID: b2c3d4e5f6g7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-04-24 00:00:00.000000
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'b2c3d4e5f6g7'
+down_revision = 'a1b2c3d4e5f6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'endpoints',
+        sa.Column('temporal_task_queue', sa.String, nullable=True),
+        schema='hosted_model_inference',
+    )
+
+
+def downgrade() -> None:
+    op.drop_column(
+        'endpoints',
+        'temporal_task_queue',
+        schema='hosted_model_inference',
+    )


### PR DESCRIPTION
* Also scan 'default' namespace in celery autoscaler

PR #770 scoped the autoscaler's deployment scan to a single namespace (hmi_config.endpoint_namespace, i.e. 'scale-deploy') for startup speed. This inadvertently broke autoscaling for non-launch celery deployments that live in the 'default' namespace, e.g.
nucleus-embed-image-clip-continuous-sqs, which use the same celery autoscaler annotations but are not model-engine async endpoints.

Add 'default' as a second namespace to scan, restoring the previous behavior for those deployments while keeping the startup-speed win.

A follow-up could make this configurable via env var; hardcoding for now to keep this change small and surgical.



* Pin types-setuptools below 82.0.0.20260508 to fix mypy CI

The 2026-05-08 release of types-setuptools tightened the type for `package_data` in ways that fail strict mypy on clients/python/setup.py. Pin to the previous compatible version range.

mypy --install-types spawns its own `pip install`, so add PIP_CONSTRAINT pointing at requirements-dev.txt so the pin is honored for transitive deps too (types-pyOpenSSL pulls in types-cffi which otherwise upgrades types-setuptools).



* Revert "Pin types-setuptools below 82.0.0.20260508 to fix mypy CI"

This reverts commit 439555a6802209f671452fb732caf0411c453d62.

* Address review: harden per-namespace errors, dedupe, ignore stub regression

- celery_autoscaler: wrap list_namespaced_deployment in try/except ApiException per namespace so a failure in one (e.g. missing RBAC in "default") doesn't silence autoscaling for the other.
- celery_autoscaler: dedupe namespaces_to_scan via dict.fromkeys in case hmi_config.endpoint_namespace is "default" in a dev/test env.
- clients/python/setup.py: add `# type: ignore[arg-type]` for package_data to work around a type stub regression in types-setuptools 82.0.0.20260508.



* Fix black formatting on logger.error call

---------

# Pull Request Summary

_What is this PR changing? Why is this change being made? Any caveats you'd like to highlight? Link any relevant documents, links, or screenshots here if applicable._

## Test Plan and Usage Guide

_How did you validate that your PR works correctly? How do you run or demo the code? Provide enough detail so a reviewer can reasonably reproduce the testing procedure. Paste example command line invocations if applicable._

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Restores autoscaling for non-launch celery deployments in the `"default"` namespace by scanning both `endpoint_namespace` and `"default"` in `list_deployments`; uses `dict.fromkeys` to dedupe and wraps each namespace call in a per-namespace `ApiException` guard so a single RBAC failure doesn't silently break the other namespace.
- Adds a nullable `temporal_task_queue` column to the `endpoints` table via a new Alembic migration; the migration chain is correct but the revision ID uses a manually-crafted sequential string with a non-hex character (`g`), unlike every other migration in the project.
- Adds `# type: ignore[arg-type]` to `clients/python/setup.py` to work around a mypy strict-mode regression in `types-setuptools` 82.x.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the autoscaler logic is correct and the only notable issue is a style concern in the migration file.

No P0 or P1 findings. The core autoscaler change (dual-namespace scan with deduplication and per-namespace error handling) is logically sound. The migration chain is valid. The only finding is a P2 style issue with the non-hex revision ID.

The Alembic migration file should have its revision ID regenerated with alembic tooling to follow project conventions.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| model-engine/model_engine_server/core/celery/celery_autoscaler.py | Adds "default" as a second namespace to scan; deduplication via dict.fromkeys and per-namespace ApiException handling are correct. No functional issues found. |
| clients/python/setup.py | Adds # type: ignore[arg-type] to suppress mypy stub regression in types-setuptools 82.x; minimal and targeted. |
| model-engine/model_engine_server/db/migrations/alembic/versions/2026_04_24_0000-b2c3d4e5f6g7_add_temporal_task_queue_column.py | Adds nullable temporal_task_queue column to the endpoints table; migration chain is correct (down_revision matches a1b2c3d4e5f6), but the revision ID uses a non-hex character (g) unlike all other migrations in the project. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[list_deployments called] --> B[Build namespaces_to_scan\ndict.fromkeys endpoint_namespace + default]
    B --> C{For each namespace}
    C --> D[list_namespaced_deployment]
    D -->|ApiException| E[logger.error\ncontinue to next namespace]
    D -->|Success| F[logger.info timing]
    F --> G{For each deployment}
    G --> H{Has annotations?}
    H -->|No| G
    H -->|Yes| I{Broker matches\nautoscaler_broker?}
    I -->|No| G
    I -->|Yes| J[Parse CeleryAutoscalerParams]
    J -->|TypeError| G
    J -->|OK| K[Store in celery_deployments_params\nkeyed by name + namespace]
    K --> G
    G -->|Done| C
    C -->|Done| L[Return celery_deployments_params]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Amodel-engine%2Fmodel_engine_server%2Fdb%2Fmigrations%2Falembic%2Fversions%2F2026_04_24_0000-b2c3d4e5f6g7_add_temporal_task_queue_column.py%3A12-13%0A**Non-hex%20revision%20ID%20deviates%20from%20project%20convention**%0A%0AThe%20revision%20ID%20%60b2c3d4e5f6g7%60%20contains%20%60g%60%2C%20which%20is%20not%20a%20valid%20hexadecimal%20character.%20Every%20other%20migration%20in%20this%20project%20uses%20a%20proper%2012-char%20hex%20string%20%28e.g.%20%60fa3267c80731%60%2C%20%6062da4f8b3403%60%29.%20While%20Alembic%20treats%20revision%20IDs%20as%20opaque%20strings%20and%20the%20migration%20will%20technically%20function%2C%20the%20manually-crafted%20sequential%20pattern%20could%20collide%20with%20another%20developer's%20migration%20if%20they%20follow%20the%20same%20convention.%20Consider%20regenerating%20this%20file%20with%20%60alembic%20revision%20--autogenerate%60%20to%20get%20a%20real%20random%20ID.%0A%0A&pr=829&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Amodel-engine%2Fmodel_engine_server%2Fdb%2Fmigrations%2Falembic%2Fversions%2F2026_04_24_0000-b2c3d4e5f6g7_add_temporal_task_queue_column.py%3A12-13%0A**Non-hex%20revision%20ID%20deviates%20from%20project%20convention**%0A%0AThe%20revision%20ID%20%60b2c3d4e5f6g7%60%20contains%20%60g%60%2C%20which%20is%20not%20a%20valid%20hexadecimal%20character.%20Every%20other%20migration%20in%20this%20project%20uses%20a%20proper%2012-char%20hex%20string%20%28e.g.%20%60fa3267c80731%60%2C%20%6062da4f8b3403%60%29.%20While%20Alembic%20treats%20revision%20IDs%20as%20opaque%20strings%20and%20the%20migration%20will%20technically%20function%2C%20the%20manually-crafted%20sequential%20pattern%20could%20collide%20with%20another%20developer's%20migration%20if%20they%20follow%20the%20same%20convention.%20Consider%20regenerating%20this%20file%20with%20%60alembic%20revision%20--autogenerate%60%20to%20get%20a%20real%20random%20ID.%0A%0A&repo=scaleapi%2Fllm-engine&pr=829&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fllm-engine%22%20on%20the%20existing%20branch%20%22maya%2Fcelery-autoscaler-default-ns-onto-2f90%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22maya%2Fcelery-autoscaler-default-ns-onto-2f90%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Amodel-engine%2Fmodel_engine_server%2Fdb%2Fmigrations%2Falembic%2Fversions%2F2026_04_24_0000-b2c3d4e5f6g7_add_temporal_task_queue_column.py%3A12-13%0A**Non-hex%20revision%20ID%20deviates%20from%20project%20convention**%0A%0AThe%20revision%20ID%20%60b2c3d4e5f6g7%60%20contains%20%60g%60%2C%20which%20is%20not%20a%20valid%20hexadecimal%20character.%20Every%20other%20migration%20in%20this%20project%20uses%20a%20proper%2012-char%20hex%20string%20%28e.g.%20%60fa3267c80731%60%2C%20%6062da4f8b3403%60%29.%20While%20Alembic%20treats%20revision%20IDs%20as%20opaque%20strings%20and%20the%20migration%20will%20technically%20function%2C%20the%20manually-crafted%20sequential%20pattern%20could%20collide%20with%20another%20developer's%20migration%20if%20they%20follow%20the%20same%20convention.%20Consider%20regenerating%20this%20file%20with%20%60alembic%20revision%20--autogenerate%60%20to%20get%20a%20real%20random%20ID.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
model-engine/model_engine_server/db/migrations/alembic/versions/2026_04_24_0000-b2c3d4e5f6g7_add_temporal_task_queue_column.py:12-13
**Non-hex revision ID deviates from project convention**

The revision ID `b2c3d4e5f6g7` contains `g`, which is not a valid hexadecimal character. Every other migration in this project uses a proper 12-char hex string (e.g. `fa3267c80731`, `62da4f8b3403`). While Alembic treats revision IDs as opaque strings and the migration will technically function, the manually-crafted sequential pattern could collide with another developer's migration if they follow the same convention. Consider regenerating this file with `alembic revision --autogenerate` to get a real random ID.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Cherry-pick temporal\_task\_queue migratio..."](https://github.com/scaleapi/llm-engine/commit/48ad144f3348ced531352069384c39312b118ee6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31950431)</sub>

<!-- /greptile_comment -->