### PR TITLE
fix(dockerfile): pin chainguard base to Python 3.13

### DIFF
--- a/model-engine/Dockerfile
+++ b/model-engine/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1
 
-FROM cgr.dev/chainguard/python:latest-dev AS builder
+FROM cgr.dev/chainguard/python:3.13-dev AS builder
 
 USER root
 WORKDIR /workspace
@@ -50,7 +50,7 @@ RUN mkdir -p /tmp/runtime-bin /tmp/runtime-libs && \
   cd /tmp/aws-iam-authenticator && \
   GOOS=linux GOARCH=${TARGETARCH} go build -o /tmp/runtime-bin/aws-iam-authenticator ./cmd/aws-iam-authenticator
 
-FROM cgr.dev/chainguard/python:latest AS model-engine
+FROM cgr.dev/chainguard/python:3.13 AS model-engine
 
 USER root
 WORKDIR /workspace


### PR DESCRIPTION
## Summary

`cgr.dev/chainguard/python:latest` floats to Python 3.14, which breaks internal deps in model-engine-internal that cap at ≤3.13 (e.g. `scale-s2s-tracing==0.0.8`). Pin to `:3.13` / `:3.13-dev` to restore compatibility.

Unblocks deploying model-engine from llm-engine main.

## Test plan
- [ ] model-engine-internal Docker build succeeds (CI)
- [ ] `just deploy prod` completes without Python version errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Pins the Chainguard Python base image in `model-engine/Dockerfile` from the floating `latest`/`latest-dev` tags to explicit `3.13`/`3.13-dev` tags in both the builder and runtime stages, preventing breakage caused by Chainguard promoting `latest` to Python 3.14. The fix is minimal, correct, and aligns with the root cause described in the PR.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge — a two-line image tag pin with no logic changes.

The change is minimal (two FROM tag updates), clearly motivated, and carries no functional risk. Pinning to `3.13`/`3.13-dev` still receives Chainguard's patch-level security updates while locking the Python minor version, which is the correct trade-off here.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| model-engine/Dockerfile | Pins chainguard Python base image tags from `latest`/`latest-dev` to `3.13`/`3.13-dev` in both builder and runtime stages to prevent unintended drift to Python 3.14. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["cgr.dev/chainguard/python:3.13-dev\n(builder stage)"] -->|"pip install deps\nbuild kubectl + aws-iam-authenticator"| B["Artifacts\n(venv, binaries, libs)"]
    B -->|COPY| C["cgr.dev/chainguard/python:3.13\n(model-engine runtime stage)"]
    C --> D["Final image\nPython 3.13 pinned"]

    style A fill:#4a90d9,color:#fff
    style C fill:#27ae60,color:#fff
    style D fill:#27ae60,color:#fff
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dockerfile): pin chainguard base to ..."](https://github.com/scaleapi/llm-engine/commit/999e942371f6c13315d86891b18056e15cf5fdd2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32073810)</sub>

<!-- /greptile_comment -->