### PR TITLE
fix(chart): remove ddtrace-run from celery autoscaler

### DIFF
--- a/charts/model-engine/templates/celery_autoscaler_stateful_set.yaml
+++ b/charts/model-engine/templates/celery_autoscaler_stateful_set.yaml
@@ -37,9 +37,6 @@ spec:
     spec:
       containers:
       - command:
-        {{- if .Values.datadog.enabled }}
-        - ddtrace-run
-        {{- end }}
         - python
         - -m
         - model_engine_server.core.celery.celery_autoscaler


### PR DESCRIPTION
## Summary
- `DD_TRACE_ENABLED=false` is hardcoded in the chart for the celery autoscaler, making `ddtrace-run` a no-op wrapper
- On ddtrace 4.7.1+ (introduced in #809), the wrapper's startup service-detection code triggers a ddtrace circular import at pod startup
- This floods Datadog with ~50 `status:error` log lines per pod restart and causes spurious PagerDuty P1 alerts

## Test plan
- [ ] Deploy and confirm celery autoscaler pods start without `--- Logging error ---` / ddtrace circular import in logs
- [ ] Confirm no spurious PagerDuty alert fires on next pod restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes `ddtrace-run` from the celery autoscaler pod command. Since `DD_TRACE_ENABLED=false` is hardcoded in the autoscaler's env, the wrapper was always a no-op; on ddtrace 4.7.1+ its startup service-detection code triggers a circular import that floods Datadog with error logs and fires spurious PagerDuty alerts on every pod restart.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the one-line removal is precise, has no functional side-effects (tracing was already disabled via `DD_TRACE_ENABLED=false`), and directly resolves the circular-import alert storm.

The change is minimal and correct: `DD_TRACE_ENABLED=false` was already making `ddtrace-run` a no-op, so removing the wrapper changes no runtime behavior while eliminating the 4.7.1+ startup crash. No other chart templates share this hardcoded-false pattern — gateway, builder, and cacher use `ddtrace-run` only when `datadog.enabled` and without a hardcoded disable flag.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| charts/model-engine/templates/celery_autoscaler_stateful_set.yaml | Removes the `ddtrace-run` command prefix (previously guarded by `datadog.enabled`) from the celery autoscaler; the wrapper was already disabled by the hardcoded `DD_TRACE_ENABLED=false` env var but caused circular-import errors on ddtrace 4.7.1+. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Pod starts] --> B{datadog.enabled?}
    B -- "Before fix (true)" --> C[ddtrace-run wrapper launches]
    C --> D[ddtrace startup: service detection runs]
    D --> E[Circular import triggered\nDD_TRACE_ENABLED=false but too late]
    E --> F["~50 'status:error' log lines\nSpurious PagerDuty P1 alert"]
    B -- "After fix (any)" --> G[python -m celery_autoscaler starts directly]
    G --> H[DD_TRACE_ENABLED=false env respected\nClean startup, no errors]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(chart): remove ddtrace-run from cele..."](https://github.com/scaleapi/llm-engine/commit/f026e9eb1c9fe6a1586904f035d0762ccb14156a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32097615)</sub>

<!-- /greptile_comment -->