### PR TITLE
Remove unsafe request logging

### DIFF
--- a/model-engine/model_engine_server/api/tasks_v1.py
+++ b/model-engine/model_engine_server/api/tasks_v1.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import Any, Dict
 
 from fastapi import APIRouter, Depends, HTTPException
 from model_engine_server.api.dependencies import (
@@ -40,6 +41,28 @@ inference_task_router_v1 = APIRouter(prefix="/v1")
 logger = make_logger(logger_name())
 
 
+def _task_request_log_extra(
+    *,
+    model_endpoint_id: str,
+    request: EndpointPredictV1Request,
+    auth: User,
+) -> Dict[str, Any]:
+    args = request.args.root if request.args is not None else None
+    return {
+        "model_endpoint_id": model_endpoint_id,
+        "user_id": auth.user_id,
+        "team_id": auth.team_id,
+        "has_url": request.url is not None,
+        "has_args": args is not None,
+        "args_key_count": len(args) if isinstance(args, dict) else None,
+        "has_cloudpickle": request.cloudpickle is not None,
+        "has_callback_url": request.callback_url is not None,
+        "has_callback_auth": request.callback_auth is not None,
+        "has_destination_path": request.destination_path is not None,
+        "return_pickled": request.return_pickled,
+    }
+
+
 @inference_task_router_v1.post("/async-tasks", response_model=CreateAsyncTaskV1Response)
 async def create_async_inference_task(
     model_endpoint_id: str,
@@ -50,7 +73,14 @@ async def create_async_inference_task(
     """
     Runs an async inference prediction.
     """
-    logger.info(f"POST /async-tasks {request} to endpoint {model_endpoint_id} for {auth}")
+    logger.info(
+        "POST /async-tasks",
+        extra=_task_request_log_extra(
+            model_endpoint_id=model_endpoint_id,
+            request=request,
+            auth=auth,
+        ),
+    )
     try:
         use_case = CreateAsyncInferenceTaskV1UseCase(
             model_endpoint_service=external_interfaces.model_endpoint_service,
@@ -112,7 +142,14 @@ async def create_sync_inference_task(
     """
     Runs a sync inference prediction.
     """
-    logger.info(f"POST /sync-tasks with {request} to endpoint {model_endpoint_id} for {auth}")
+    logger.info(
+        "POST /sync-tasks",
+        extra=_task_request_log_extra(
+            model_endpoint_id=model_endpoint_id,
+            request=request,
+            auth=auth,
+        ),
+    )
     try:
         use_case = CreateSyncInferenceTaskV1UseCase(
             model_endpoint_service=external_interfaces.model_endpoint_service,
@@ -161,7 +198,14 @@ async def create_streaming_inference_task(
     """
     Runs a streaming inference prediction.
     """
-    logger.info(f"POST /streaming-tasks with {request} to endpoint {model_endpoint_id} for {auth}")
+    logger.info(
+        "POST /streaming-tasks",
+        extra=_task_request_log_extra(
+            model_endpoint_id=model_endpoint_id,
+            request=request,
+            auth=auth,
+        ),
+    )
     try:
         use_case = CreateStreamingInferenceTaskV1UseCase(
             model_endpoint_service=external_interfaces.model_endpoint_service,

--- a/model-engine/model_engine_server/inference/post_inference_hooks.py
+++ b/model-engine/model_engine_server/inference/post_inference_hooks.py
@@ -143,7 +143,7 @@ class LoggingHook(PostInferenceHook):
             if matches:  # pragma: no cover
                 logger.info(  # pragma: no cover
                     "The JSON string contains double quotes or escape characters.",
-                    extra={"json_string": json_string, "matches": matches},
+                    extra={"json_length": len(json_string), "match_count": len(matches)},
                 )
             else:
                 logger.info("The JSON string is valid.")  # pragma: no cover

--- a/model-engine/tests/unit/api/test_tasks.py
+++ b/model-engine/tests/unit/api/test_tasks.py
@@ -1,8 +1,11 @@
+import json
 from typing import Any, Dict, Tuple
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from model_engine_server.api.tasks_v1 import _task_request_log_extra
 from model_engine_server.common.dtos.tasks import EndpointPredictV1Request
+from model_engine_server.core.auth.authentication_repository import User
 from model_engine_server.domain.entities import ModelBundle, ModelEndpoint
 from model_engine_server.domain.exceptions import (
     InvalidRequestException,
@@ -10,6 +13,39 @@ from model_engine_server.domain.exceptions import (
     ObjectNotFoundException,
     UpstreamServiceError,
 )
+
+
+def test_task_request_log_extra_does_not_include_secret_payload():
+    fake_secret = "ghp_1234567890abcdefghijklmnopqrstuvwxyz123456"
+    request = EndpointPredictV1Request(
+        url=f"https://example.com/predict?token={fake_secret}",
+        args={"prompt": f"use token {fake_secret}", "count": 1},
+        callback_url=f"https://example.com/callback?token={fake_secret}",
+        cloudpickle=f"serialized-{fake_secret}",
+        return_pickled=True,
+    )
+    auth = User(user_id="test_user_id", team_id="test_team_id")
+
+    extra = _task_request_log_extra(
+        model_endpoint_id="test_model_endpoint_id",
+        request=request,
+        auth=auth,
+    )
+
+    assert extra == {
+        "model_endpoint_id": "test_model_endpoint_id",
+        "user_id": "test_user_id",
+        "team_id": "test_team_id",
+        "has_url": True,
+        "has_args": True,
+        "args_key_count": 2,
+        "has_cloudpickle": True,
+        "has_callback_url": True,
+        "has_callback_auth": False,
+        "has_destination_path": False,
+        "return_pickled": True,
+    }
+    assert fake_secret not in json.dumps(extra)
 
 
 def test_create_async_task_success(

--- a/model-engine/tests/unit/inference/test_http_forwarder.py
+++ b/model-engine/tests/unit/inference/test_http_forwarder.py
@@ -11,7 +11,10 @@ from fastapi import BackgroundTasks, FastAPI
 from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 from model_engine_server.common.dtos.tasks import EndpointPredictV1Request
-from model_engine_server.domain.entities.model_endpoint_entity import ModelEndpointConfig
+from model_engine_server.domain.entities.model_endpoint_entity import (
+    ModelEndpointConfig,
+    ModelEndpointType,
+)
 from model_engine_server.inference.forwarding.forwarding import Forwarder
 from model_engine_server.inference.forwarding.http_forwarder import (
     MultiprocessingConcurrencyLimiter,
@@ -234,6 +237,43 @@ def test_handler_with_logging(post_inference_hooks_handler_with_logging):
         )
     except Exception as e:
         pytest.fail(f"Unexpected exception: {e}")
+
+
+def test_logging_hook_does_not_log_secret_payload(mock_request):
+    fake_secret = "ghp_1234567890abcdefghijklmnopqrstuvwxyz123456"
+    mock_request.args = {"prompt": f"use token {fake_secret}"}
+    streaming_storage_gateway = FakeStreamingStorageGateway()
+    hook_handler = PostInferenceHooksHandler(
+        endpoint_name="test_endpoint_name",
+        bundle_name="test_bundle_name",
+        post_inference_hooks=["logging"],
+        user_id="test_user_id",
+        billing_queue="billing_queue",
+        billing_tags=[],
+        default_callback_url=None,
+        default_callback_auth=None,
+        monitoring_metrics_gateway=DatadogInferenceMonitoringMetricsGateway(),
+        endpoint_id="test_endpoint_id",
+        endpoint_type=ModelEndpointType.SYNC,
+        bundle_id="test_bundle_id",
+        labels={"owner": "test"},
+        streaming_storage_gateway=streaming_storage_gateway,
+    )
+
+    with mock.patch("model_engine_server.inference.post_inference_hooks.logger") as mock_logger:
+        hook_handler.handle(
+            request_payload=mock_request,
+            response=JSONResponse(content={"completion": f"done {fake_secret}"}),
+            task_id="test_task_id",
+        )
+
+    info_call = mock_logger.info.call_args_list[0]
+    log_kwargs = info_call.kwargs
+    assert "json_string" not in log_kwargs["extra"]
+    assert "matches" not in log_kwargs["extra"]
+    assert log_kwargs["extra"]["json_length"] > 0
+    assert log_kwargs["extra"]["match_count"] > 0
+    assert fake_secret not in json.dumps(log_kwargs)
 
 
 # Test the fastapi app


### PR DESCRIPTION
Closed. This PR was replaced because it included internal triage context in a public repository.
