### PR TITLE
[MLI-6891] feat: wire forwarder_max_concurrency through K8s forwarder template

### DIFF
--- a/charts/model-engine/templates/service_template_config_map.yaml
+++ b/charts/model-engine/templates/service_template_config_map.yaml
@@ -147,6 +147,8 @@ data:
                 - "forwarder.stream.healthcheck_route=${HEALTHCHECK_ROUTE}"
                 - --set
                 - "forwarder.sync.routes=${FORWARDER_SYNC_ROUTES}"
+                - --set
+                - "max_concurrency=${FORWARDER_MAX_CONCURRENCY}"
               {{- $sync_forwarder_template_env | nindent 14 }}
               readinessProbe:
                 httpGet:
@@ -203,6 +205,8 @@ data:
                 - "forwarder.sync.routes=${FORWARDER_SYNC_ROUTES}"
                 - --set
                 - "forwarder.stream.routes=${FORWARDER_STREAM_ROUTES}"
+                - --set
+                - "max_concurrency=${FORWARDER_MAX_CONCURRENCY}"
               {{- $sync_forwarder_template_env | nindent 14 }}
               readinessProbe:
                 httpGet:
@@ -611,6 +615,8 @@ data:
                   - "forwarder.stream.healthcheck_route=${HEALTHCHECK_ROUTE}"
                   - --set
                   - "forwarder.sync.routes=${FORWARDER_SYNC_ROUTES}"
+                  - --set
+                  - "max_concurrency=${FORWARDER_MAX_CONCURRENCY}"
                 {{- $sync_forwarder_template_env | nindent 16 }}
                 readinessProbe:
                   httpGet:
@@ -667,6 +673,8 @@ data:
                   - "forwarder.sync.routes=${FORWARDER_SYNC_ROUTES}"
                   - --set
                   - "forwarder.stream.routes=${FORWARDER_STREAM_ROUTES}"
+                  - --set
+                  - "max_concurrency=${FORWARDER_MAX_CONCURRENCY}"
                 {{- $sync_forwarder_template_env | nindent 16 }}
                 readinessProbe:
                   httpGet:

--- a/model-engine/model_engine_server/common/dtos/model_endpoints.py
+++ b/model-engine/model_engine_server/common/dtos/model_endpoints.py
@@ -73,8 +73,8 @@ class CreateModelEndpointV1Request(BaseModel):
         description=(
             "Max in-flight requests admitted by the HTTP forwarder container, "
             "independent of `per_worker` / autoscaling. When None (default), the "
-            "forwarder inherits its `--concurrency` flag from `per_worker` (current "
-            "behavior). Upper bound matches LIRA's FORWARDER_MAX_CONCURRENCY_LIMIT."
+            "forwarder uses its config-file default (100). Upper bound matches "
+            "LIRA's FORWARDER_MAX_CONCURRENCY_LIMIT."
         ),
     )
     labels: Dict[str, str]
@@ -122,8 +122,8 @@ class UpdateModelEndpointV1Request(BaseModel):
         description=(
             "Max in-flight requests admitted by the HTTP forwarder container, "
             "independent of `per_worker` / autoscaling. When None (default), the "
-            "forwarder inherits its `--concurrency` flag from `per_worker` (current "
-            "behavior). Upper bound matches LIRA's FORWARDER_MAX_CONCURRENCY_LIMIT."
+            "forwarder uses its config-file default (100). Upper bound matches "
+            "LIRA's FORWARDER_MAX_CONCURRENCY_LIMIT."
         ),
     )
     labels: Optional[Dict[str, str]] = None

--- a/model-engine/model_engine_server/infra/gateways/resources/k8s_endpoint_resource_delegate.py
+++ b/model-engine/model_engine_server/infra/gateways/resources/k8s_endpoint_resource_delegate.py
@@ -235,9 +235,7 @@ def k8s_yaml_exists(key: str) -> bool:
         return key in config_map_str["data"]
 
 
-def _strip_optional_set_pairs(
-    template_str: str, substitution_kwargs: ResourceArguments
-) -> str:
+def _strip_optional_set_pairs(template_str: str, substitution_kwargs: ResourceArguments) -> str:
     """Remove conditional `--set "...${KEY}..."` arg-pairs whose KEY is None.
 
     Templates can declare a config override like:

--- a/model-engine/model_engine_server/infra/gateways/resources/k8s_endpoint_resource_delegate.py
+++ b/model-engine/model_engine_server/infra/gateways/resources/k8s_endpoint_resource_delegate.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import re
 from string import Template
 from typing import Any, Dict, List, Optional, Tuple, cast
 
@@ -234,6 +235,28 @@ def k8s_yaml_exists(key: str) -> bool:
         return key in config_map_str["data"]
 
 
+def _strip_optional_set_pairs(
+    template_str: str, substitution_kwargs: ResourceArguments
+) -> str:
+    """Remove conditional `--set "...${KEY}..."` arg-pairs whose KEY is None.
+
+    Templates can declare a config override like:
+        - --set
+        - "max_concurrency=${FORWARDER_MAX_CONCURRENCY}"
+    and this preprocessor drops the pair entirely when the matching kwarg is
+    None, so the container falls back to its own config-file default.
+    """
+    for kwarg_name, value in substitution_kwargs.items():
+        if value is not None:
+            continue
+        pattern = (
+            r"^[ \t]*- --set\s*\n"
+            r'^[ \t]*- "[^"]*\$\{' + re.escape(kwarg_name) + r"\}[^\"]*\"\s*\n"
+        )
+        template_str = re.sub(pattern, "", template_str, flags=re.MULTILINE)
+    return template_str
+
+
 def load_k8s_yaml(key: str, substitution_kwargs: ResourceArguments) -> Dict[str, Any]:
     if LAUNCH_SERVICE_TEMPLATE_FOLDER is not None:
         with open(os.path.join(LAUNCH_SERVICE_TEMPLATE_FOLDER, key), "r") as f:
@@ -243,11 +266,18 @@ def load_k8s_yaml(key: str, substitution_kwargs: ResourceArguments) -> Dict[str,
             config_map_str = yaml.safe_load(f.read())
         template_str = config_map_str["data"][key]
 
-    # Strip None-valued entries so they don't stringify to the literal "None"
-    # in the rendered manifest. Use safe_substitute so that a template
-    # referencing ${KEY} with a None-valued kwarg renders ${KEY} literally
-    # and surfaces a loud K8s/container error at deploy time, rather than a
-    # KeyError deep inside the service-builder celery task.
+    # For kwargs whose value is None, strip any `--set "...${KEY}..."` arg-pair
+    # from the template so the conditional config override isn't rendered at
+    # all. This lets a forwarder/main container opt-in to a config override
+    # only when the caller actually set the value; otherwise the container
+    # falls back to its own config-file default.
+    template_str = _strip_optional_set_pairs(template_str, substitution_kwargs)
+
+    # Strip remaining None-valued entries so they don't stringify to "None".
+    # Use safe_substitute so that a template referencing ${KEY} with a
+    # None-valued kwarg renders ${KEY} literally and surfaces a loud
+    # K8s/container error at deploy time, rather than a KeyError deep
+    # inside the service-builder celery task.
     filtered_kwargs = {k: v for k, v in substitution_kwargs.items() if v is not None}
     yaml_str = Template(template_str).safe_substitute(**filtered_kwargs)
     try:

--- a/model-engine/model_engine_server/infra/gateways/resources/templates/service_template_config_map_circleci.yaml
+++ b/model-engine/model_engine_server/infra/gateways/resources/templates/service_template_config_map_circleci.yaml
@@ -620,6 +620,8 @@ data:
                 - "forwarder.stream.healthcheck_route=${HEALTHCHECK_ROUTE}"
                 - --set
                 - "forwarder.sync.routes=${FORWARDER_SYNC_ROUTES}"
+                - --set
+                - "max_concurrency=${FORWARDER_MAX_CONCURRENCY}"
               env:
                 - name: DD_TRACE_ENABLED
                   value: "${DD_TRACE_ENABLED}"
@@ -892,6 +894,8 @@ data:
                 - "forwarder.stream.healthcheck_route=${HEALTHCHECK_ROUTE}"
                 - --set
                 - "forwarder.sync.routes=${FORWARDER_SYNC_ROUTES}"
+                - --set
+                - "max_concurrency=${FORWARDER_MAX_CONCURRENCY}"
               env:
                 - name: DD_TRACE_ENABLED
                   value: "${DD_TRACE_ENABLED}"
@@ -1126,6 +1130,8 @@ data:
                 - "forwarder.sync.routes=${FORWARDER_SYNC_ROUTES}"
                 - --set
                 - "forwarder.stream.routes=${FORWARDER_STREAM_ROUTES}"
+                - --set
+                - "max_concurrency=${FORWARDER_MAX_CONCURRENCY}"
               env:
                 - name: DD_TRACE_ENABLED
                   value: "${DD_TRACE_ENABLED}"
@@ -1874,6 +1880,8 @@ data:
                 - "forwarder.stream.healthcheck_route=${HEALTHCHECK_ROUTE}"
                 - --set
                 - "forwarder.sync.routes=${FORWARDER_SYNC_ROUTES}"
+                - --set
+                - "max_concurrency=${FORWARDER_MAX_CONCURRENCY}"
               env:
                 - name: DD_TRACE_ENABLED
                   value: "${DD_TRACE_ENABLED}"
@@ -2154,6 +2162,8 @@ data:
                 - "forwarder.stream.healthcheck_route=${HEALTHCHECK_ROUTE}"
                 - --set
                 - "forwarder.sync.routes=${FORWARDER_SYNC_ROUTES}"
+                - --set
+                - "max_concurrency=${FORWARDER_MAX_CONCURRENCY}"
               env:
                 - name: DD_TRACE_ENABLED
                   value: "${DD_TRACE_ENABLED}"
@@ -2396,6 +2406,8 @@ data:
                 - "forwarder.sync.routes=${FORWARDER_SYNC_ROUTES}"
                 - --set
                 - "forwarder.stream.routes=${FORWARDER_STREAM_ROUTES}"
+                - --set
+                - "max_concurrency=${FORWARDER_MAX_CONCURRENCY}"
               env:
                 - name: DD_TRACE_ENABLED
                   value: "${DD_TRACE_ENABLED}"

--- a/model-engine/tests/unit/infra/gateways/resources/test_k8s_endpoint_resource_delegate.py
+++ b/model-engine/tests/unit/infra/gateways/resources/test_k8s_endpoint_resource_delegate.py
@@ -23,6 +23,7 @@ from model_engine_server.infra.gateways.resources.k8s_endpoint_resource_delegate
     DATADOG_ENV_VAR,
     MODEL_CACHE_VOLUME_NAME,
     K8SEndpointResourceDelegate,
+    _strip_optional_set_pairs,
     add_datadog_env_to_container,
     add_pod_metadata_env_to_container,
     get_main_container_from_deployment_template,
@@ -151,6 +152,40 @@ def test_k8s_yaml_exists():
     assert not k8s_yaml_exists(
         "image-cache-abc9001.yaml"
     ), "image-cache-abc9001.yaml should not exist"
+
+
+_OPTIONAL_SET_TEMPLATE = """\
+                - --set
+                - "forwarder.sync.routes=${FORWARDER_SYNC_ROUTES}"
+                - --set
+                - "max_concurrency=${FORWARDER_MAX_CONCURRENCY}"
+              env:
+"""
+
+
+def test_strip_optional_set_pairs_drops_when_none():
+    out = _strip_optional_set_pairs(
+        _OPTIONAL_SET_TEMPLATE, {"FORWARDER_MAX_CONCURRENCY": None, "FORWARDER_SYNC_ROUTES": "x"}
+    )
+    assert "max_concurrency" not in out
+    # Adjacent kwargs that are set must be untouched
+    assert "forwarder.sync.routes=${FORWARDER_SYNC_ROUTES}" in out
+    assert "env:" in out
+
+
+def test_strip_optional_set_pairs_keeps_when_set():
+    out = _strip_optional_set_pairs(
+        _OPTIONAL_SET_TEMPLATE, {"FORWARDER_MAX_CONCURRENCY": 5, "FORWARDER_SYNC_ROUTES": "x"}
+    )
+    assert 'max_concurrency=${FORWARDER_MAX_CONCURRENCY}' in out
+
+
+def test_strip_optional_set_pairs_handles_unknown_key():
+    # A kwarg that doesn't appear in the template — no-op, no exceptions.
+    out = _strip_optional_set_pairs(
+        _OPTIONAL_SET_TEMPLATE, {"SOMETHING_NOT_IN_TEMPLATE": None}
+    )
+    assert out == _OPTIONAL_SET_TEMPLATE
 
 
 def _render_service_template_config_map(extra_args: Optional[List[str]] = None) -> str:

--- a/model-engine/tests/unit/infra/gateways/resources/test_k8s_endpoint_resource_delegate.py
+++ b/model-engine/tests/unit/infra/gateways/resources/test_k8s_endpoint_resource_delegate.py
@@ -177,14 +177,12 @@ def test_strip_optional_set_pairs_keeps_when_set():
     out = _strip_optional_set_pairs(
         _OPTIONAL_SET_TEMPLATE, {"FORWARDER_MAX_CONCURRENCY": 5, "FORWARDER_SYNC_ROUTES": "x"}
     )
-    assert 'max_concurrency=${FORWARDER_MAX_CONCURRENCY}' in out
+    assert "max_concurrency=${FORWARDER_MAX_CONCURRENCY}" in out
 
 
 def test_strip_optional_set_pairs_handles_unknown_key():
     # A kwarg that doesn't appear in the template — no-op, no exceptions.
-    out = _strip_optional_set_pairs(
-        _OPTIONAL_SET_TEMPLATE, {"SOMETHING_NOT_IN_TEMPLATE": None}
-    )
+    out = _strip_optional_set_pairs(_OPTIONAL_SET_TEMPLATE, {"SOMETHING_NOT_IN_TEMPLATE": None})
     assert out == _OPTIONAL_SET_TEMPLATE
 
 


### PR DESCRIPTION
Linear: [MLI-6891](https://linear.app/scale-epd/issue/MLI-6891/wire-forwarder-max-concurrency-into-k8s-forwarder-container-template)
Follow-up to: #835 (MLI-6876)

## Why

MLI-6876 added `forwarder_max_concurrency` to the API schema and plumbed it through to `ResourceArguments` (11 injection sites). But the K8s manifest templates never referenced `${FORWARDER_MAX_CONCURRENCY}` — so the field was silently dropped at the rendering layer. API callers could set the field with no actual effect on the running forwarder.

This PR is the load-bearing piece that makes the field actually work end-to-end on the llm-engine API path.

## What changes

- Adds `--set "max_concurrency=${FORWARDER_MAX_CONCURRENCY}"` to all **6 http-forwarder containers** in `service_template_config_map_circleci.yaml` and the corresponding **4 forwarder containers** in `charts/model-engine/templates/service_template_config_map.yaml`
- Adds a `_strip_optional_set_pairs` preprocessor in `k8s_endpoint_resource_delegate.py` that drops any `- --set` / `- "...${KEY}..."` arg pair from the template when KEY's value is None. Generic — usable by any future optional kwarg using the same pattern
- Updates `forwarder_max_concurrency`'s description in the DTOs to reflect the actual fallback (config-file default, **not** `per_worker` — earlier docstring was inaccurate)

## Backward compatibility

**Zero behavior change for any existing endpoint** that doesn't explicitly set `forwarder_max_concurrency`:

| Caller state | Rendered manifest | Forwarder behavior |
| --- | --- | --- |
| `forwarder_max_concurrency=None` (current default) | No `--set max_concurrency` line | Uses config-file default (100) — same as today |
| `forwarder_max_concurrency=5` | `--set "max_concurrency=5"` | Forwarder admits 5 in-flight requests |

## Tests

Added three focused unit tests for `_strip_optional_set_pairs`:
- `test_strip_optional_set_pairs_drops_when_none`
- `test_strip_optional_set_pairs_keeps_when_set`
- `test_strip_optional_set_pairs_handles_unknown_key`

Also ran the full `test_k8s_endpoint_resource_delegate.py` suite locally — **59 passed, 0 failed**, including the cross-cutting `test_resource_arguments_type_and_add_datadog_env_to_main_container` that renders every forwarder container with full substitution.

## Out of scope

- OpenAPI spec regen: this PR only changes a `description` string on existing fields (no schema-level changes), so I skipped the regen step. Happy to add a follow-up commit with regen if reviewers prefer.

## Rollout chain status

| | Ticket | Repo | State |
|---|---|---|---|
| ✅ | MLI-5366 | scaleapi/models | Merged |
| ✅ | MLI-6876 | scaleapi/llm-engine | Merged (#835) |
| 🟡 | MLI-6875 | scaleapi/launch-python-client | PR #180 open |
| ⏳ | MLI-6874 | scaleapi/models | Not started |
| 🟡 | **MLI-6891** | scaleapi/llm-engine | **this PR** |

After MLI-6891 + MLI-6876 are both in the next llm-engine release, `forwarder_max_concurrency` is functional end-to-end on the API path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the `forwarder_max_concurrency` end-to-end wire-up by adding `--set "max_concurrency=${FORWARDER_MAX_CONCURRENCY}"` to forwarder container templates and introducing a `_strip_optional_set_pairs` preprocessor that cleanly removes the arg-pair from the rendered manifest when the value is `None`, preserving backward compatibility.

- Adds the `max_concurrency` arg to 6 of 7 http-forwarder containers in the CircleCI template and all 4 in the Helm chart; the LWS streaming GPU container in the CircleCI template was missed (see comment).
- Introduces `_strip_optional_set_pairs` as a generic preprocessor for optional `--set` kwargs — correctly placed before `safe_substitute` and covered by three new unit tests.
- Corrects the `forwarder_max_concurrency` docstring on both Create and Update DTOs to reflect the actual config-file fallback default (100) rather than the previously incorrect `per_worker` description.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for all production traffic; only the CircleCI test template for LWS streaming GPU endpoints would render an incorrect manifest when `forwarder_max_concurrency` is explicitly set.

The Helm chart (production) is correctly updated for all four forwarder containers. The one gap is the LWS streaming http-forwarder in the CircleCI template, which was not updated to include `max_concurrency`. Any CI test that renders an LWS streaming GPU deployment with a non-None `forwarder_max_concurrency` would produce a manifest that diverges from the production Helm output, potentially masking the omission during review.

model-engine/model_engine_server/infra/gateways/resources/templates/service_template_config_map_circleci.yaml — the LWS streaming GPU forwarder block (~line 2797) is missing the two-line `max_concurrency` addition present in every other updated container.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| model-engine/model_engine_server/infra/gateways/resources/k8s_endpoint_resource_delegate.py | Adds `_strip_optional_set_pairs` preprocessor that removes `--set "...${KEY}..."` arg-pairs for None-valued kwargs before template substitution; correctly placed before `safe_substitute`. The generic nature of the preprocessor also silently changes behavior for other existing Optional kwargs (e.g. `FORWARDER_TYPE=None`), though that prior behavior was already broken. |
| model-engine/model_engine_server/infra/gateways/resources/templates/service_template_config_map_circleci.yaml | Adds `max_concurrency=${FORWARDER_MAX_CONCURRENCY}` to 6 http-forwarder containers, but misses the LWS streaming GPU forwarder container (~line 2797), leaving it inconsistent with the Helm chart which correctly updated all 4 equivalent containers including its LWS streaming path. |
| charts/model-engine/templates/service_template_config_map.yaml | Adds `max_concurrency=${FORWARDER_MAX_CONCURRENCY}` to all 4 forwarder containers (sync, streaming, LWS sync, LWS streaming), matching the expected coverage. |
| model-engine/model_engine_server/common/dtos/model_endpoints.py | Corrects the docstring for `forwarder_max_concurrency` on both Create and Update DTOs to say the fallback is the config-file default (100), not `per_worker`. |
| model-engine/tests/unit/infra/gateways/resources/test_k8s_endpoint_resource_delegate.py | Adds three focused unit tests for `_strip_optional_set_pairs` covering the drop-when-None, keep-when-set, and unknown-key no-op cases. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `model-engine/model_engine_server/infra/gateways/resources/templates/service_template_config_map_circleci.yaml`, line 2797-2800 ([link](https://github.com/scaleapi/llm-engine/blob/e50c5f19cb6b6fe11d38d6d9bc572b7db0fa664f/model-engine/model_engine_server/infra/gateways/resources/templates/service_template_config_map_circleci.yaml#L2797-L2800)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Missing `max_concurrency` in LWS streaming GPU forwarder**

   The LeaderWorkerSet streaming GPU http-forwarder container (starting ~line 2769) was not updated, while the Helm chart's equivalent path (`{{- else if eq $mode "streaming" }}` in the LWS section, line 677) was correctly updated. `LeaderWorkerSetRunnableImageStreamingGpuArguments` extends `_BaseDeploymentArguments`, which declares `FORWARDER_MAX_CONCURRENCY: Optional[int]`, so when a non-None value is passed the rendered CI manifest will silently omit the `--set max_concurrency` arg while the production manifest includes it. Add the two lines below after line 2799 to match every other forwarder container in this file:

   ```
                     - --set
                     - "max_concurrency=${FORWARDER_MAX_CONCURRENCY}"
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: model-engine/model_engine_server/infra/gateways/resources/templates/service_template_config_map_circleci.yaml
   Line: 2797-2800

   Comment:
   **Missing `max_concurrency` in LWS streaming GPU forwarder**

   The LeaderWorkerSet streaming GPU http-forwarder container (starting ~line 2769) was not updated, while the Helm chart's equivalent path (`{{- else if eq $mode "streaming" }}` in the LWS section, line 677) was correctly updated. `LeaderWorkerSetRunnableImageStreamingGpuArguments` extends `_BaseDeploymentArguments`, which declares `FORWARDER_MAX_CONCURRENCY: Optional[int]`, so when a non-None value is passed the rendered CI manifest will silently omit the `--set max_concurrency` arg while the production manifest includes it. Add the two lines below after line 2799 to match every other forwarder container in this file:

   ```
                     - --set
                     - "max_concurrency=${FORWARDER_MAX_CONCURRENCY}"
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20model-engine%2Fmodel_engine_server%2Finfra%2Fgateways%2Fresources%2Ftemplates%2Fservice_template_config_map_circleci.yaml%0ALine%3A%202797-2800%0A%0AComment%3A%0A**Missing%20%60max_concurrency%60%20in%20LWS%20streaming%20GPU%20forwarder**%0A%0AThe%20LeaderWorkerSet%20streaming%20GPU%20http-forwarder%20container%20%28starting%20~line%202769%29%20was%20not%20updated%2C%20while%20the%20Helm%20chart's%20equivalent%20path%20%28%60%7B%7B-%20else%20if%20eq%20%24mode%20%22streaming%22%20%7D%7D%60%20in%20the%20LWS%20section%2C%20line%20677%29%20was%20correctly%20updated.%20%60LeaderWorkerSetRunnableImageStreamingGpuArguments%60%20extends%20%60_BaseDeploymentArguments%60%2C%20which%20declares%20%60FORWARDER_MAX_CONCURRENCY%3A%20Optional%5Bint%5D%60%2C%20so%20when%20a%20non-None%20value%20is%20passed%20the%20rendered%20CI%20manifest%20will%20silently%20omit%20the%20%60--set%20max_concurrency%60%20arg%20while%20the%20production%20manifest%20includes%20it.%20Add%20the%20two%20lines%20below%20after%20line%202799%20to%20match%20every%20other%20forwarder%20container%20in%20this%20file%3A%0A%0A%60%60%60%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20-%20--set%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20-%20%22max_concurrency%3D%24%7BFORWARDER_MAX_CONCURRENCY%7D%22%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=836&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20model-engine%2Fmodel_engine_server%2Finfra%2Fgateways%2Fresources%2Ftemplates%2Fservice_template_config_map_circleci.yaml%0ALine%3A%202797-2800%0A%0AComment%3A%0A**Missing%20%60max_concurrency%60%20in%20LWS%20streaming%20GPU%20forwarder**%0A%0AThe%20LeaderWorkerSet%20streaming%20GPU%20http-forwarder%20container%20%28starting%20~line%202769%29%20was%20not%20updated%2C%20while%20the%20Helm%20chart's%20equivalent%20path%20%28%60%7B%7B-%20else%20if%20eq%20%24mode%20%22streaming%22%20%7D%7D%60%20in%20the%20LWS%20section%2C%20line%20677%29%20was%20correctly%20updated.%20%60LeaderWorkerSetRunnableImageStreamingGpuArguments%60%20extends%20%60_BaseDeploymentArguments%60%2C%20which%20declares%20%60FORWARDER_MAX_CONCURRENCY%3A%20Optional%5Bint%5D%60%2C%20so%20when%20a%20non-None%20value%20is%20passed%20the%20rendered%20CI%20manifest%20will%20silently%20omit%20the%20%60--set%20max_concurrency%60%20arg%20while%20the%20production%20manifest%20includes%20it.%20Add%20the%20two%20lines%20below%20after%20line%202799%20to%20match%20every%20other%20forwarder%20container%20in%20this%20file%3A%0A%0A%60%60%60%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20-%20--set%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20-%20%22max_concurrency%3D%24%7BFORWARDER_MAX_CONCURRENCY%7D%22%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fllm-engine&pr=836&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fllm-engine%22%20on%20the%20existing%20branch%20%22feat%2FMLI-6891-forwarder-max-concurrency-template-wiring%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2FMLI-6891-forwarder-max-concurrency-template-wiring%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20model-engine%2Fmodel_engine_server%2Finfra%2Fgateways%2Fresources%2Ftemplates%2Fservice_template_config_map_circleci.yaml%0ALine%3A%202797-2800%0A%0AComment%3A%0A**Missing%20%60max_concurrency%60%20in%20LWS%20streaming%20GPU%20forwarder**%0A%0AThe%20LeaderWorkerSet%20streaming%20GPU%20http-forwarder%20container%20%28starting%20~line%202769%29%20was%20not%20updated%2C%20while%20the%20Helm%20chart's%20equivalent%20path%20%28%60%7B%7B-%20else%20if%20eq%20%24mode%20%22streaming%22%20%7D%7D%60%20in%20the%20LWS%20section%2C%20line%20677%29%20was%20correctly%20updated.%20%60LeaderWorkerSetRunnableImageStreamingGpuArguments%60%20extends%20%60_BaseDeploymentArguments%60%2C%20which%20declares%20%60FORWARDER_MAX_CONCURRENCY%3A%20Optional%5Bint%5D%60%2C%20so%20when%20a%20non-None%20value%20is%20passed%20the%20rendered%20CI%20manifest%20will%20silently%20omit%20the%20%60--set%20max_concurrency%60%20arg%20while%20the%20production%20manifest%20includes%20it.%20Add%20the%20two%20lines%20below%20after%20line%202799%20to%20match%20every%20other%20forwarder%20container%20in%20this%20file%3A%0A%0A%60%60%60%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20-%20--set%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20-%20%22max_concurrency%3D%24%7BFORWARDER_MAX_CONCURRENCY%7D%22%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Amodel-engine%2Fmodel_engine_server%2Finfra%2Fgateways%2Fresources%2Ftemplates%2Fservice_template_config_map_circleci.yaml%3A2797-2800%0A**Missing%20%60max_concurrency%60%20in%20LWS%20streaming%20GPU%20forwarder**%0A%0AThe%20LeaderWorkerSet%20streaming%20GPU%20http-forwarder%20container%20%28starting%20~line%202769%29%20was%20not%20updated%2C%20while%20the%20Helm%20chart's%20equivalent%20path%20%28%60%7B%7B-%20else%20if%20eq%20%24mode%20%22streaming%22%20%7D%7D%60%20in%20the%20LWS%20section%2C%20line%20677%29%20was%20correctly%20updated.%20%60LeaderWorkerSetRunnableImageStreamingGpuArguments%60%20extends%20%60_BaseDeploymentArguments%60%2C%20which%20declares%20%60FORWARDER_MAX_CONCURRENCY%3A%20Optional%5Bint%5D%60%2C%20so%20when%20a%20non-None%20value%20is%20passed%20the%20rendered%20CI%20manifest%20will%20silently%20omit%20the%20%60--set%20max_concurrency%60%20arg%20while%20the%20production%20manifest%20includes%20it.%20Add%20the%20two%20lines%20below%20after%20line%202799%20to%20match%20every%20other%20forwarder%20container%20in%20this%20file%3A%0A%0A%60%60%60%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20-%20--set%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20-%20%22max_concurrency%3D%24%7BFORWARDER_MAX_CONCURRENCY%7D%22%0A%60%60%60%0A%0A&pr=836&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Amodel-engine%2Fmodel_engine_server%2Finfra%2Fgateways%2Fresources%2Ftemplates%2Fservice_template_config_map_circleci.yaml%3A2797-2800%0A**Missing%20%60max_concurrency%60%20in%20LWS%20streaming%20GPU%20forwarder**%0A%0AThe%20LeaderWorkerSet%20streaming%20GPU%20http-forwarder%20container%20%28starting%20~line%202769%29%20was%20not%20updated%2C%20while%20the%20Helm%20chart's%20equivalent%20path%20%28%60%7B%7B-%20else%20if%20eq%20%24mode%20%22streaming%22%20%7D%7D%60%20in%20the%20LWS%20section%2C%20line%20677%29%20was%20correctly%20updated.%20%60LeaderWorkerSetRunnableImageStreamingGpuArguments%60%20extends%20%60_BaseDeploymentArguments%60%2C%20which%20declares%20%60FORWARDER_MAX_CONCURRENCY%3A%20Optional%5Bint%5D%60%2C%20so%20when%20a%20non-None%20value%20is%20passed%20the%20rendered%20CI%20manifest%20will%20silently%20omit%20the%20%60--set%20max_concurrency%60%20arg%20while%20the%20production%20manifest%20includes%20it.%20Add%20the%20two%20lines%20below%20after%20line%202799%20to%20match%20every%20other%20forwarder%20container%20in%20this%20file%3A%0A%0A%60%60%60%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20-%20--set%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20-%20%22max_concurrency%3D%24%7BFORWARDER_MAX_CONCURRENCY%7D%22%0A%60%60%60%0A%0A&repo=scaleapi%2Fllm-engine&pr=836&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fllm-engine%22%20on%20the%20existing%20branch%20%22feat%2FMLI-6891-forwarder-max-concurrency-template-wiring%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2FMLI-6891-forwarder-max-concurrency-template-wiring%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Amodel-engine%2Fmodel_engine_server%2Finfra%2Fgateways%2Fresources%2Ftemplates%2Fservice_template_config_map_circleci.yaml%3A2797-2800%0A**Missing%20%60max_concurrency%60%20in%20LWS%20streaming%20GPU%20forwarder**%0A%0AThe%20LeaderWorkerSet%20streaming%20GPU%20http-forwarder%20container%20%28starting%20~line%202769%29%20was%20not%20updated%2C%20while%20the%20Helm%20chart's%20equivalent%20path%20%28%60%7B%7B-%20else%20if%20eq%20%24mode%20%22streaming%22%20%7D%7D%60%20in%20the%20LWS%20section%2C%20line%20677%29%20was%20correctly%20updated.%20%60LeaderWorkerSetRunnableImageStreamingGpuArguments%60%20extends%20%60_BaseDeploymentArguments%60%2C%20which%20declares%20%60FORWARDER_MAX_CONCURRENCY%3A%20Optional%5Bint%5D%60%2C%20so%20when%20a%20non-None%20value%20is%20passed%20the%20rendered%20CI%20manifest%20will%20silently%20omit%20the%20%60--set%20max_concurrency%60%20arg%20while%20the%20production%20manifest%20includes%20it.%20Add%20the%20two%20lines%20below%20after%20line%202799%20to%20match%20every%20other%20forwarder%20container%20in%20this%20file%3A%0A%0A%60%60%60%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20-%20--set%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20-%20%22max_concurrency%3D%24%7BFORWARDER_MAX_CONCURRENCY%7D%22%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
model-engine/model_engine_server/infra/gateways/resources/templates/service_template_config_map_circleci.yaml:2797-2800
**Missing `max_concurrency` in LWS streaming GPU forwarder**

The LeaderWorkerSet streaming GPU http-forwarder container (starting ~line 2769) was not updated, while the Helm chart's equivalent path (`{{- else if eq $mode "streaming" }}` in the LWS section, line 677) was correctly updated. `LeaderWorkerSetRunnableImageStreamingGpuArguments` extends `_BaseDeploymentArguments`, which declares `FORWARDER_MAX_CONCURRENCY: Optional[int]`, so when a non-None value is passed the rendered CI manifest will silently omit the `--set max_concurrency` arg while the production manifest includes it. Add the two lines below after line 2799 to match every other forwarder container in this file:

```
                  - --set
                  - "max_concurrency=${FORWARDER_MAX_CONCURRENCY}"
```


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["\[MLI-6891\] style: apply black 24.8.0 for..."](https://github.com/scaleapi/llm-engine/commit/e50c5f19cb6b6fe11d38d6d9bc572b7db0fa664f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34493500)</sub>

<!-- /greptile_comment -->