### PR TITLE
feat(api): retain reasoning content in v2 chat completions

### DIFF
--- a/model-engine/model_engine_server/common/dtos/llms/chat_completion.py
+++ b/model-engine/model_engine_server/common/dtos/llms/chat_completion.py
@@ -1,9 +1,19 @@
-from typing import Optional
+from typing import List, Optional, Union
 
 from model_engine_server.common.dtos.llms.completion import StreamError
 from model_engine_server.common.dtos.llms.vllm import VLLMChatCompletionAdditionalParams
-from model_engine_server.common.pydantic_types import BaseModel, Field
+from model_engine_server.common.pydantic_types import AliasChoices, BaseModel, Field, RootModel
 from model_engine_server.common.types.gen.openai import (
+    ChatCompletionRequestAssistantMessage,
+    ChatCompletionRequestDeveloperMessage,
+    ChatCompletionRequestFunctionMessage,
+    ChatCompletionRequestSystemMessage,
+    ChatCompletionRequestToolMessage,
+    ChatCompletionRequestUserMessage,
+    ChatCompletionResponseMessage,
+    ChatCompletionStreamResponseDelta,
+    Choice,
+    Choice1,
     CreateChatCompletionRequest,
     CreateChatCompletionResponse,
     CreateChatCompletionStreamResponse,
@@ -14,8 +24,65 @@ from typing_extensions import Annotated, TypeAlias
 # Fields that are a part of OpenAI spec but are not supported by model engine
 UNSUPPORTED_FIELDS = ["service_tier"]
 
+# The OpenAI spec has no field for the reasoning (thinking) traces emitted by reasoning
+# models, so the generated spec models silently drop them. The subclasses below extend the
+# spec so reasoning content survives a round trip through model engine:
+#   - Responses surface it as `reasoning_content` (the LiteLLM/DeepSeek convention),
+#     accepting either `reasoning` (vLLM) or `reasoning_content` from the inference
+#     framework.
+#   - Request assistant messages accept either name and forward it to the inference
+#     framework as `reasoning` (the field vLLM exposes to chat templates), so chat
+#     templates that render prior-turn reasoning keep working.
+# Both fields are optional. Requests are forwarded and stream chunks serialized with
+# `exclude_none=True`, so those payloads are unchanged for non-reasoning models; sync
+# responses gain a `reasoning_content: null` key alongside the other nullable spec
+# fields (`refusal`, `audio`, ...) that FastAPI already serializes.
+
+
+class ChatCompletionRequestAssistantMessageWithReasoning(ChatCompletionRequestAssistantMessage):
+    reasoning: Annotated[
+        Optional[str],
+        Field(
+            validation_alias=AliasChoices("reasoning", "reasoning_content"),
+            description="The reasoning (thinking) trace of a previous assistant turn, used to"
+            " round trip reasoning back to the model's chat template. Accepts `reasoning`"
+            " (vLLM convention) or `reasoning_content` (LiteLLM/DeepSeek convention) on"
+            " input; forwarded to the inference framework as `reasoning`.\n",
+        ),
+    ] = None
+
+
+class ChatCompletionRequestMessageWithReasoning(
+    RootModel[
+        Union[
+            ChatCompletionRequestDeveloperMessage,
+            ChatCompletionRequestSystemMessage,
+            ChatCompletionRequestUserMessage,
+            ChatCompletionRequestAssistantMessageWithReasoning,
+            ChatCompletionRequestToolMessage,
+            ChatCompletionRequestFunctionMessage,
+        ]
+    ]
+):
+    root: Union[
+        ChatCompletionRequestDeveloperMessage,
+        ChatCompletionRequestSystemMessage,
+        ChatCompletionRequestUserMessage,
+        ChatCompletionRequestAssistantMessageWithReasoning,
+        ChatCompletionRequestToolMessage,
+        ChatCompletionRequestFunctionMessage,
+    ]
+
 
 class ChatCompletionV2Request(CreateChatCompletionRequest, VLLMChatCompletionAdditionalParams):
+    messages: Annotated[  # type: ignore[assignment]
+        List[ChatCompletionRequestMessageWithReasoning],
+        Field(
+            description="A list of messages comprising the conversation so far. Depending on the\n[model](/docs/models) you use, different message types (modalities) are\nsupported, like [text](/docs/guides/text-generation),\n[images](/docs/guides/vision), and [audio](/docs/guides/audio).\n",
+            min_length=1,
+        ),
+    ]
+
     model: Annotated[  # type: ignore[assignment]
         str,
         Field(
@@ -33,8 +100,56 @@ class ChatCompletionV2Request(CreateChatCompletionRequest, VLLMChatCompletionAdd
     ]
 
 
-ChatCompletionV2SyncResponse: TypeAlias = CreateChatCompletionResponse
-ChatCompletionV2StreamSuccessChunk: TypeAlias = CreateChatCompletionStreamResponse
+class ChatCompletionResponseMessageWithReasoning(ChatCompletionResponseMessage):
+    reasoning_content: Annotated[
+        Optional[str],
+        Field(
+            validation_alias=AliasChoices("reasoning_content", "reasoning"),
+            description="The reasoning (thinking) trace produced by reasoning models, when the"
+            " inference framework returns one (e.g. a vLLM reasoning parser). Accepted from"
+            " the framework as `reasoning` or `reasoning_content`; always serialized as"
+            " `reasoning_content`.\n",
+        ),
+    ] = None
+
+
+class ChatCompletionChoiceWithReasoning(Choice):
+    message: ChatCompletionResponseMessageWithReasoning  # type: ignore[assignment]
+
+
+class ChatCompletionV2SyncResponse(CreateChatCompletionResponse):
+    choices: Annotated[  # type: ignore[assignment]
+        List[ChatCompletionChoiceWithReasoning],
+        Field(
+            description="A list of chat completion choices. Can be more than one if `n` is greater than 1."
+        ),
+    ]
+
+
+class ChatCompletionStreamResponseDeltaWithReasoning(ChatCompletionStreamResponseDelta):
+    reasoning_content: Annotated[
+        Optional[str],
+        Field(
+            validation_alias=AliasChoices("reasoning_content", "reasoning"),
+            description="The reasoning (thinking) trace of the chunk message, when the inference"
+            " framework returns one (e.g. a vLLM reasoning parser). Accepted from the"
+            " framework as `reasoning` or `reasoning_content`; always serialized as"
+            " `reasoning_content`.\n",
+        ),
+    ] = None
+
+
+class ChatCompletionStreamChoiceWithReasoning(Choice1):
+    delta: ChatCompletionStreamResponseDeltaWithReasoning  # type: ignore[assignment]
+
+
+class ChatCompletionV2StreamSuccessChunk(CreateChatCompletionStreamResponse):
+    choices: Annotated[  # type: ignore[assignment]
+        List[ChatCompletionStreamChoiceWithReasoning],
+        Field(
+            description='A list of chat completion choices. Can contain more than one elements if `n` is greater than 1. Can also be empty for the\nlast chunk if you set `stream_options: {"include_usage": true}`.\n'
+        ),
+    ]
 
 
 class ChatCompletionV2StreamErrorChunk(BaseModel):

--- a/model-engine/model_engine_server/common/dtos/llms/chat_completion.py
+++ b/model-engine/model_engine_server/common/dtos/llms/chat_completion.py
@@ -79,6 +79,8 @@ class ChatCompletionV2Request(CreateChatCompletionRequest, VLLMChatCompletionAdd
         List[ChatCompletionRequestMessageWithReasoning],
         Field(
             description="A list of messages comprising the conversation so far. Depending on the\n[model](/docs/models) you use, different message types (modalities) are\nsupported, like [text](/docs/guides/text-generation),\n[images](/docs/guides/vision), and [audio](/docs/guides/audio).\n",
+            # Restated from the spec: pydantic field overrides replace the parent
+            # FieldInfo rather than merging, so dropping this would lose the constraint.
             min_length=1,
         ),
     ]

--- a/model-engine/model_engine_server/common/pydantic_types.py
+++ b/model-engine/model_engine_server/common/pydantic_types.py
@@ -1,11 +1,12 @@
 from typing import Any, Type, TypeVar
 
+from pydantic import constr  # noqa: F401
+from pydantic import model_validator  # noqa: F401
+from pydantic import AliasChoices  # noqa: F401
 from pydantic import AnyHttpUrl as PyAnyHttpUrl
 from pydantic import AnyUrl as PyAnyUrl
 from pydantic import AnyWebsocketUrl as PyAnyWebsocketUrl
 from pydantic import BaseModel as PydanticBaseModel
-from pydantic import constr  # noqa: F401
-from pydantic import model_validator  # noqa: F401
 from pydantic import ConfigDict, Field  # noqa: F401
 from pydantic import FileUrl as PyFileUrl
 from pydantic import FtpUrl as PyFtpUrl

--- a/model-engine/model_engine_server/common/pydantic_types.py
+++ b/model-engine/model_engine_server/common/pydantic_types.py
@@ -1,8 +1,8 @@
 from typing import Any, Type, TypeVar
 
+from pydantic import AliasChoices  # noqa: F401
 from pydantic import constr  # noqa: F401
 from pydantic import model_validator  # noqa: F401
-from pydantic import AliasChoices  # noqa: F401
 from pydantic import AnyHttpUrl as PyAnyHttpUrl
 from pydantic import AnyUrl as PyAnyUrl
 from pydantic import AnyWebsocketUrl as PyAnyWebsocketUrl

--- a/model-engine/tests/unit/common/test_chat_completion_dtos.py
+++ b/model-engine/tests/unit/common/test_chat_completion_dtos.py
@@ -1,0 +1,176 @@
+import json
+
+from model_engine_server.common.dtos.llms.chat_completion import (
+    ChatCompletionV2Request,
+    ChatCompletionV2StreamSuccessChunk,
+    ChatCompletionV2SyncResponse,
+)
+
+REASONING_TRACE = "The user wants 17 * 23. 17 * 23 = 391."
+
+
+def _sync_response_payload(message: dict) -> dict:
+    return {
+        "id": "chatcmpl-123",
+        "object": "chat.completion",
+        "created": 1700000000,
+        "model": "gemma-4-31b-it",
+        "choices": [
+            {
+                "index": 0,
+                "finish_reason": "stop",
+                "logprobs": None,
+                "message": message,
+            }
+        ],
+        "usage": {"prompt_tokens": 30, "completion_tokens": 83, "total_tokens": 113},
+    }
+
+
+def _stream_chunk_payload(delta: dict) -> dict:
+    return {
+        "id": "chatcmpl-123",
+        "object": "chat.completion.chunk",
+        "created": 1700000000,
+        "model": "gemma-4-31b-it",
+        "choices": [{"index": 0, "finish_reason": None, "delta": delta}],
+    }
+
+
+def test_sync_response_maps_vllm_reasoning_to_reasoning_content():
+    """vLLM reasoning parsers return the trace under `reasoning`."""
+    payload = _sync_response_payload(
+        {"role": "assistant", "content": "391", "reasoning": REASONING_TRACE}
+    )
+    response = ChatCompletionV2SyncResponse.model_validate(payload)
+
+    assert response.choices[0].message.reasoning_content == REASONING_TRACE
+
+    dumped = json.loads(response.model_dump_json(exclude_none=True))
+    assert dumped["choices"][0]["message"]["reasoning_content"] == REASONING_TRACE
+    assert "reasoning" not in dumped["choices"][0]["message"]
+
+
+def test_sync_response_accepts_reasoning_content_key():
+    payload = _sync_response_payload(
+        {"role": "assistant", "content": "391", "reasoning_content": REASONING_TRACE}
+    )
+    response = ChatCompletionV2SyncResponse.model_validate(payload)
+
+    assert response.choices[0].message.reasoning_content == REASONING_TRACE
+
+
+def test_sync_response_without_reasoning_is_unchanged():
+    payload = _sync_response_payload({"role": "assistant", "content": "391"})
+    response = ChatCompletionV2SyncResponse.model_validate(payload)
+
+    assert response.choices[0].message.reasoning_content is None
+    dumped = json.loads(response.model_dump_json(exclude_none=True))
+    assert "reasoning_content" not in dumped["choices"][0]["message"]
+    assert "reasoning" not in dumped["choices"][0]["message"]
+
+
+def test_stream_chunk_maps_vllm_reasoning_to_reasoning_content():
+    chunk = ChatCompletionV2StreamSuccessChunk.model_validate(
+        _stream_chunk_payload({"role": "assistant", "reasoning": REASONING_TRACE})
+    )
+
+    assert chunk.choices[0].delta.reasoning_content == REASONING_TRACE
+
+    dumped = json.loads(chunk.model_dump_json(exclude_none=True))
+    assert dumped["choices"][0]["delta"]["reasoning_content"] == REASONING_TRACE
+    assert "reasoning" not in dumped["choices"][0]["delta"]
+
+
+def test_stream_chunk_without_reasoning_is_unchanged():
+    chunk = ChatCompletionV2StreamSuccessChunk.model_validate(
+        _stream_chunk_payload({"role": "assistant", "content": "391"})
+    )
+
+    assert chunk.choices[0].delta.reasoning_content is None
+    dumped = json.loads(chunk.model_dump_json(exclude_none=True))
+    assert "reasoning_content" not in dumped["choices"][0]["delta"]
+
+
+def test_request_assistant_message_forwards_reasoning_content_as_reasoning():
+    """Clients send `reasoning_content` back; the inference framework expects `reasoning`."""
+    request = ChatCompletionV2Request.model_validate(
+        {
+            "model": "gemma-4-31b-it",
+            "messages": [
+                {"role": "user", "content": "What is 17*23?"},
+                {
+                    "role": "assistant",
+                    "content": "391",
+                    "reasoning_content": REASONING_TRACE,
+                },
+                {"role": "user", "content": "Are you sure?"},
+            ],
+        }
+    )
+
+    dumped = request.model_dump(exclude_none=True)
+    assistant_message = dumped["messages"][1]
+    assert assistant_message["reasoning"] == REASONING_TRACE
+    assert "reasoning_content" not in assistant_message
+
+
+def test_request_assistant_message_accepts_reasoning_key():
+    request = ChatCompletionV2Request.model_validate(
+        {
+            "model": "gemma-4-31b-it",
+            "messages": [
+                {"role": "assistant", "content": "391", "reasoning": REASONING_TRACE},
+            ],
+        }
+    )
+
+    dumped = request.model_dump(exclude_none=True)
+    assert dumped["messages"][0]["reasoning"] == REASONING_TRACE
+
+
+def test_request_without_reasoning_is_unchanged():
+    request = ChatCompletionV2Request.model_validate(
+        {
+            "model": "gemma-4-31b-it",
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "What is 17*23?"},
+                {"role": "assistant", "content": "391"},
+            ],
+        }
+    )
+
+    dumped = request.model_dump(exclude_none=True)
+    for message in dumped["messages"]:
+        assert "reasoning" not in message
+        assert "reasoning_content" not in message
+
+
+def test_request_tool_call_round_trip_with_reasoning():
+    """Assistant tool-call turns are where reasoning round-tripping matters most."""
+    request = ChatCompletionV2Request.model_validate(
+        {
+            "model": "gemma-4-31b-it",
+            "messages": [
+                {"role": "user", "content": "Edit the doc."},
+                {
+                    "role": "assistant",
+                    "reasoning_content": REASONING_TRACE,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "apply_mutations", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+            ],
+        }
+    )
+
+    dumped = request.model_dump(exclude_none=True)
+    assistant_message = dumped["messages"][1]
+    assert assistant_message["reasoning"] == REASONING_TRACE
+    assert assistant_message["tool_calls"][0]["function"]["name"] == "apply_mutations"

--- a/model-engine/tests/unit/common/test_chat_completion_dtos.py
+++ b/model-engine/tests/unit/common/test_chat_completion_dtos.py
@@ -1,10 +1,12 @@
 import json
 
+import pytest
 from model_engine_server.common.dtos.llms.chat_completion import (
     ChatCompletionV2Request,
     ChatCompletionV2StreamSuccessChunk,
     ChatCompletionV2SyncResponse,
 )
+from model_engine_server.common.pydantic_types import ValidationError
 
 REASONING_TRACE = "The user wants 17 * 23. 17 * 23 = 391."
 
@@ -60,7 +62,7 @@ def test_sync_response_accepts_reasoning_content_key():
     assert response.choices[0].message.reasoning_content == REASONING_TRACE
 
 
-def test_sync_response_without_reasoning_is_unchanged():
+def test_sync_response_without_reasoning_omits_key_with_exclude_none():
     payload = _sync_response_payload({"role": "assistant", "content": "391"})
     response = ChatCompletionV2SyncResponse.model_validate(payload)
 
@@ -68,6 +70,21 @@ def test_sync_response_without_reasoning_is_unchanged():
     dumped = json.loads(response.model_dump_json(exclude_none=True))
     assert "reasoning_content" not in dumped["choices"][0]["message"]
     assert "reasoning" not in dumped["choices"][0]["message"]
+
+
+def test_sync_response_without_reasoning_serializes_stable_null():
+    """The sync route returns the model through FastAPI without exclude_none, so
+    non-reasoning models serialize `reasoning_content: null` alongside the other
+    nullable spec fields (`refusal`, `audio`, ...) the route already emits."""
+    payload = _sync_response_payload({"role": "assistant", "content": "391"})
+    response = ChatCompletionV2SyncResponse.model_validate(payload)
+
+    message = json.loads(response.model_dump_json())["choices"][0]["message"]
+    assert "reasoning_content" in message
+    assert message["reasoning_content"] is None
+    # Pre-existing nullable spec field, serialized the same way.
+    assert "refusal" in message
+    assert message["refusal"] is None
 
 
 def test_stream_chunk_maps_vllm_reasoning_to_reasoning_content():
@@ -145,6 +162,14 @@ def test_request_without_reasoning_is_unchanged():
     for message in dumped["messages"]:
         assert "reasoning" not in message
         assert "reasoning_content" not in message
+
+
+def test_request_requires_at_least_one_message():
+    """The `messages` override re-declares the spec's `min_length=1`: pydantic field
+    overrides replace the parent FieldInfo rather than merging with it, so the
+    constraint must be restated or it is silently lost."""
+    with pytest.raises(ValidationError):
+        ChatCompletionV2Request.model_validate({"model": "gemma-4-31b-it", "messages": []})
 
 
 def test_request_tool_call_round_trip_with_reasoning():


### PR DESCRIPTION
# Pull Request Summary

vLLM reasoning parsers return the model's reasoning (thinking) trace in a non-OpenAI-spec `reasoning` field on the chat completion message. The v2 chat completion DTOs validate upstream output against the generated OpenAI spec models (`common/types/gen/openai.py`), which silently drop the field — so reasoning traces never reach clients, and clients cannot round-trip reasoning back to chat templates that render prior-turn thinking (e.g. vLLM reasoning-parser deployments in agentic tool-calling loops). Today such deployments pay the decode cost of thinking while the trace is discarded in transit.

This PR extends the spec models via subclassing (the generated file is untouched, following the existing `ChatCompletionV2Request` precedent):

- **Sync responses & stream chunks**: messages/deltas gain `reasoning_content` (the LiteLLM/DeepSeek ecosystem convention), populated from either `reasoning` (vLLM) or `reasoning_content` upstream via a validation alias.
- **Requests**: assistant messages accept either `reasoning` or `reasoning_content` and forward the trace to the inference framework as `reasoning` — the field vLLM exposes to chat templates — since requests are forwarded with `model_dump(exclude_none=True)`.

No changes to the router or use cases — `ChatCompletionV2SyncResponse` / `ChatCompletionV2StreamSuccessChunk` keep their names (TypeAlias → subclass), so the existing `model_validate` call sites and the route's `response_model` pick up the extension automatically.

**Caveats:**
- Sync responses gain a `reasoning_content: null` key for non-reasoning models, consistent with the other nullable spec fields (`refusal`, `audio`, …) already serialized by FastAPI. Stream chunks and forwarded requests use `exclude_none=True` and are byte-identical for non-reasoning models.
- The pydantic-v1-based python client (`clients/python`) is not updated here (server DTO changes have historically not been mirrored there); raw HTTP / OpenAI SDK consumers get the field immediately.

## Test Plan and Usage Guide

Added `model-engine/tests/unit/common/test_chat_completion_dtos.py` (9 tests) covering: vLLM `reasoning` → `reasoning_content` mapping for sync and stream responses, acceptance of both input key conventions, request-side forwarding as `reasoning` (including an assistant tool-call turn, the main round-trip case), and unchanged serialization when no reasoning is present.

```
$ pytest tests/unit/common/test_chat_completion_dtos.py
9 passed
```

Also ran `black`, `isort`, `ruff`, and `mypy --config-file model-engine/mypy.ini` on the changed files (all clean).

Verified against a live deployment (vLLM 0.19.1, gemma-4 reasoning parser, GCP dev cluster): the raw endpoint returns `reasoning`, and `/v2/chat/completions` currently drops it; with these DTOs the same payload validates with `reasoning_content` populated.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR passes vLLM reasoning traces through the v2 chat completion layer by extending the generated OpenAI spec models via subclassing (the generated file is untouched). `ChatCompletionV2SyncResponse` and `ChatCompletionV2StreamSuccessChunk` are converted from TypeAliases to proper subclasses, with `reasoning_content` added to response messages and deltas; `ChatCompletionV2Request` gains an overridden `messages` field that routes assistant turns through a new `ChatCompletionRequestAssistantMessageWithReasoning` class that normalises `reasoning`/`reasoning_content` input to a canonical `reasoning` key for downstream forwarding.

- **Response path**: both sync responses and stream chunks accept `reasoning` (vLLM) or `reasoning_content` upstream and always surface `reasoning_content` to clients; non-reasoning stream chunks are byte-identical (serialized with `exclude_none=True`); sync responses gain a nullable `reasoning_content: null` key consistent with existing nullable spec fields.
- **Request path**: assistant messages accept either convention on input and forward to vLLM as `reasoning`, enabling agentic tool-calling loops to round-trip prior-turn thinking traces through chat templates.
- **Test coverage**: nine unit tests validate vLLM mapping, both input conventions, request-side forwarding, backward compatibility for non-reasoning models, and the `messages` min-length constraint that had to be explicitly re-declared on the field override.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is additive, leaves non-reasoning model payloads byte-identical on stream/request paths, and all existing call sites pick up the extension automatically.

All three changed files are DTO/type-layer only with no changes to routing, use-case logic, or persistence. The field aliasing strategy is correct: validation aliases include the Python field names so both construction paths work; serialization always emits the canonical name (`reasoning_content` outbound, `reasoning` to vLLM). The `min_length=1` constraint is explicitly restated on the overridden `messages` field and confirmed by a dedicated test. Nine unit tests cover every combination that matters for production correctness.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| model-engine/model_engine_server/common/dtos/llms/chat_completion.py | Core change: TypeAliases for sync response and stream chunk converted to proper subclasses; reasoning_content field added to response/delta models with validation aliases; messages field overridden with RootModel-based union that includes reasoning-aware assistant message; min_length=1 constraint correctly restated on the override. |
| model-engine/model_engine_server/common/pydantic_types.py | Minor: adds AliasChoices re-export alongside the existing re-exports; import order is slightly reshuffled. |
| model-engine/tests/unit/common/test_chat_completion_dtos.py | New test module with 9 tests covering: vLLM reasoning→reasoning_content mapping for sync and stream, both input key conventions, request-side forwarding as `reasoning`, tool-call round-trip, backward compatibility for non-reasoning models, and the messages min_length=1 constraint. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Router as FastAPI Router
    participant UseCase as ChatCompletion UseCase
    participant vLLM as vLLM (upstream)

    Client->>Router: POST /v2/chat/completions
    Router->>Router: model_validate → ChatCompletionV2Request
    Note over Router: reasoning_content alias → reasoning field
    Router->>UseCase: execute(request)
    UseCase->>UseCase: "request.model_dump(exclude_none=True)"
    Note over UseCase: messages[i].reasoning forwarded as reasoning
    UseCase->>vLLM: "{messages: [{role:assistant, reasoning:...}]}"
    vLLM-->>UseCase: "{choices:[{message:{content:..., reasoning:trace}}]}"
    UseCase->>UseCase: ChatCompletionV2SyncResponse.model_validate(output)
    Note over UseCase: reasoning alias → reasoning_content field
    UseCase-->>Router: ChatCompletionV2SyncResponse
    Router-->>Client: "{choices:[{message:{content:..., reasoning_content:trace}}]}"
```
</details>

<sub>Reviews (4): Last reviewed commit: ["chore: retrigger CI (dropped CircleCI st..."](https://github.com/scaleapi/llm-engine/commit/26aba509623d5dda808935c58aebaa80a20ce34c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36736007)</sub>

<!-- /greptile_comment -->