### PR TITLE
GFD-2481 model engine internal CVE remediation

### DIFF
--- a/model-engine/Dockerfile.fips
+++ b/model-engine/Dockerfile.fips
@@ -1,4 +1,4 @@
-FROM cgr.dev/scale.com/python-fips:3.10.19-dev
+FROM cgr.dev/scale.com/python-fips:3.10-dev
 WORKDIR /workspace
 USER root
 
@@ -24,7 +24,7 @@ RUN apk update && apk add \
             postgresql-dev \
             libpq-16
 
-RUN curl -Lo /bin/aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.5.9/aws-iam-authenticator_0.5.9_linux_amd64
+RUN curl -Lo /bin/aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.7.11/aws-iam-authenticator_0.7.11_linux_amd64
 RUN chmod +x /bin/aws-iam-authenticator
 
 RUN pip install pip==24.2

--- a/model-engine/Dockerfile.fips
+++ b/model-engine/Dockerfile.fips
@@ -1,4 +1,4 @@
-FROM cgr.dev/scale.com/python-fips:3.10-dev
+FROM cgr.dev/scale.com/python-fips:3.10.20-r7-dev
 WORKDIR /workspace
 USER root
 

--- a/model-engine/Dockerfile.fips
+++ b/model-engine/Dockerfile.fips
@@ -24,8 +24,9 @@ RUN apk update && apk add \
             postgresql-dev \
             libpq-16
 
-RUN curl -Lo /bin/aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.7.11/aws-iam-authenticator_0.7.11_linux_amd64
-RUN chmod +x /bin/aws-iam-authenticator
+RUN curl -Lo /bin/aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.7.11/aws-iam-authenticator_0.7.11_linux_amd64 \
+    && echo "8523d92af5680dbc7af81a75be63ffdb36040e061e8e318d322e01dceff85a1f  /bin/aws-iam-authenticator" | sha256sum -c - \
+    && chmod +x /bin/aws-iam-authenticator
 
 RUN pip install pip==24.2
 RUN chmod -R 777 /workspace

--- a/model-engine/requirements.txt
+++ b/model-engine/requirements.txt
@@ -558,8 +558,8 @@ setuptools==82.0.1
     #   -r requirements.in
     #   kubernetes
     #   kubernetes-asyncio
-wheel>=0.46.1
-    # via -r requirements.in  # CVE-2026-24049
+wheel==0.46.1
+    # via -r requirements.in  # CVE-2026-24049; >=0.46.2 requires packaging>=24.0 which conflicts with packaging==23.1
 sh==1.14.3
     # via -r requirements.in
 shellingham==1.5.4

--- a/model-engine/requirements.txt
+++ b/model-engine/requirements.txt
@@ -558,6 +558,8 @@ setuptools==82.0.1
     #   -r requirements.in
     #   kubernetes
     #   kubernetes-asyncio
+wheel>=0.46.1
+    # via -r requirements.in  # CVE-2026-24049
 sh==1.14.3
     # via -r requirements.in
 shellingham==1.5.4

--- a/model-engine/requirements.txt
+++ b/model-engine/requirements.txt
@@ -326,6 +326,8 @@ kubernetes==25.3.0
     # via -r requirements.in
 kubernetes-asyncio==25.11.0
     # via -r requirements.in
+legacy-cgi==2.6.4
+    # via ddtrace
 mako==1.3.12
     # via
     #   -r requirements.in

--- a/model-engine/requirements.txt
+++ b/model-engine/requirements.txt
@@ -405,7 +405,7 @@ opentelemetry-semantic-conventions==0.62b1
     # via opentelemetry-sdk
 orjson==3.11.7
     # via -r requirements.in
-packaging==23.1
+packaging==24.2
     # via
     #   build
     #   deprecation
@@ -414,6 +414,7 @@ packaging==23.1
     #   kombu
     #   marshmallow
     #   transformers
+    #   wheel
 pg8000==1.31.5
     # via
     #   -r requirements.in
@@ -558,8 +559,8 @@ setuptools==82.0.1
     #   -r requirements.in
     #   kubernetes
     #   kubernetes-asyncio
-wheel==0.46.1
-    # via -r requirements.in  # CVE-2026-24049; >=0.46.2 requires packaging>=24.0 which conflicts with packaging==23.1
+wheel==0.46.2
+    # via -r requirements.in  # CVE-2026-24049 (GHSA-8rrh-rw8j-w5fx); patched in 0.46.2
 sh==1.14.3
     # via -r requirements.in
 shellingham==1.5.4


### PR DESCRIPTION
Remediates 3 Critical and 34 High severity Trivy CVEs in the apps/model-engine-internal FIPS image (ipv4-pr758-61262d88-amd64), the single largest CVE contributor in the June 9 net-new scan (214 total Critical+High findings across dev, FedRAMP prod, IL5 prod, and shared-inference).

Changes:
- model-engine/Dockerfile.fips — upgrades aws-iam-authenticator from v0.5.9 → v0.7.11, resolving 4 High Go stdlib CVEs (CVE-2026-39823, CVE-2026-39825, CVE-2026-39826, CVE-2026-42504) introduced by the old binary's embedded Go 1.17/1.18 toolchain
- model-engine/Dockerfile.fips — bumps the Chainguard base image from cgr.dev/scale.com/python-fips:3.10.19-dev to the latest available 3.10.x-dev tag, replacing the Debian OS package tree (libgnutls30, linux-libc-dev, libpython3.11, openssh, libcap2, libkrb5) with patched Alpine equivalents and eliminating the remaining Critical and majority of High findings
- model-engine/requirements.txt — bumps mako from 1.2.4 → 1.3.11, resolving CVE-2026-41205

Test Plan and Usage Guide

- [ ] CI builds the updated Dockerfile.fips successfully and produces a new image tag
- [ ] Post-build: run docker run --rm <new-image> go version /bin/aws-iam-authenticator and confirm Go ≥ 1.25.10 — if not, a newer aws-iam-authenticator release or source build with a newer toolchain is required before merge
- [ ] Post-build Trivy scan on the new image returns zero Critical/High findings (required to clear the CCB promotion security gate)
- [ ] New image tag is pinned in argo-values (staging, fedramp, il5), argocd-shared-inference-catalog, and forward-deployed-infra/infra-launcher/images.yaml via a follow-up MR
- [ ] Promotion sequence: PROMOTE_STAGING_JOB=true (dev → staging) → CCB ticket → CCB_PROMOTION_JOB=true (fedramp + il5)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR remediates Critical and High Trivy CVEs in the FIPS image by bumping the Chainguard base image to `cgr.dev/scale.com/python-fips:3.10.20-r7-dev`, upgrading `aws-iam-authenticator` from v0.5.9 → v0.7.11 (now with SHA-256 integrity verification), and updating `mako`, `wheel`, `packaging`, and `legacy-cgi` in `requirements.txt`.

- **`Dockerfile.fips`**: Base image bumped to `3.10.20-r7-dev`; authenticator binary now pinned with a SHA-256 digest and verified via `sha256sum -c` before `chmod +x`, addressing the supply-chain gap flagged in prior review.
- **`requirements.txt`**: `mako` pinned to 1.3.12 (not 1.3.11 as stated in the description — 1.3.12 also covers CVE-2026-44307, an incomplete-fix follow-up); `wheel==0.46.2` added explicitly with inline CVE annotation; `legacy-cgi==2.6.4` added as a transitive `ddtrace` dependency.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all changes are targeted CVE remediations with no functional behavior changes.

The Dockerfile changes are straightforward version bumps with the integrity check now present for the binary. The requirements.txt changes pin specific package versions to patched releases. No application logic is touched and the supply-chain verification gap from the prior review has been closed.

No files require special attention; the only observations are a description/code version mismatch for mako and a manual CVE annotation in an autogenerated file that will be lost on next regeneration.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| model-engine/Dockerfile.fips | Base image bumped to 3.10.20-r7-dev and aws-iam-authenticator upgraded to v0.7.11 with SHA-256 verification added; changes are clean and address the targeted CVEs. |
| model-engine/requirements.txt | mako pinned to 1.3.12 (one patch above the 1.3.11 stated in the PR description), wheel and legacy-cgi added for CVE fixes; requirements otherwise consistent with uv-compiled output. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Docker Build Start] --> B[FROM cgr.dev/scale.com/python-fips:3.10.20-r7-dev]
    B --> C[apk update && apk add system packages]
    C --> D[curl aws-iam-authenticator v0.7.11 binary]
    D --> E{sha256sum -c check}
    E -- mismatch --> F[Build FAILS ❌]
    E -- match --> G[chmod +x /bin/aws-iam-authenticator]
    G --> H[pip install pip==24.2]
    H --> I[pip install requirements.txt]
    I --> J[pip install -e model-engine]
    J --> K[FIPS Image Ready ✅]

    subgraph requirements_txt_CVEs ["requirements.txt CVE patches"]
        R1[mako 1.3.12 — CVE-2026-41205 + CVE-2026-44307]
        R2[wheel 0.46.2 — CVE-2026-24049]
        R3[packaging 24.2 — version bump]
        R4[legacy-cgi 2.6.4 — ddtrace transitive dep]
    end

    I -.-> requirements_txt_CVEs
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Docker Build Start] --> B[FROM cgr.dev/scale.com/python-fips:3.10.20-r7-dev]
    B --> C[apk update && apk add system packages]
    C --> D[curl aws-iam-authenticator v0.7.11 binary]
    D --> E{sha256sum -c check}
    E -- mismatch --> F[Build FAILS ❌]
    E -- match --> G[chmod +x /bin/aws-iam-authenticator]
    G --> H[pip install pip==24.2]
    H --> I[pip install requirements.txt]
    I --> J[pip install -e model-engine]
    J --> K[FIPS Image Ready ✅]

    subgraph requirements_txt_CVEs ["requirements.txt CVE patches"]
        R1[mako 1.3.12 — CVE-2026-41205 + CVE-2026-44307]
        R2[wheel 0.46.2 — CVE-2026-24049]
        R3[packaging 24.2 — version bump]
        R4[legacy-cgi 2.6.4 — ddtrace transitive dep]
    end

    I -.-> requirements_txt_CVEs
```

</a>
</details>

<sub>Reviews (5): Last reviewed commit: ["bump package further"](https://github.com/scaleapi/llm-engine/commit/fd7eebdf1d921ca52e3608f1293031b3a6cc3936) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37698042)</sub>

<!-- /greptile_comment -->