### PR TITLE
feat: record and expose status_reason on model endpoints

### DIFF
--- a/model-engine/model_engine_server/common/dtos/model_endpoints.py
+++ b/model-engine/model_engine_server/common/dtos/model_endpoints.py
@@ -159,6 +159,10 @@ class GetModelEndpointV1Response(BaseModel):
     metadata: Optional[Dict[str, Any]] = Field(default=None)  # TODO: JSON type
     bundle_name: str
     status: ModelEndpointStatus
+    status_reason: Optional[str] = Field(
+        default=None,
+        description="Human-readable reason for the current status, e.g. the failure cause when status is UPDATE_FAILED.",
+    )
     post_inference_hooks: Optional[List[str]] = Field(default=None)
     default_callback_url: Optional[HttpUrlStr] = Field(default=None)
     default_callback_auth: Optional[CallbackAuth] = Field(default=None)

--- a/model-engine/model_engine_server/db/migrations/alembic/versions/2026_06_16_1200-c4d5e6f7a8b9_add_status_reason_column.py
+++ b/model-engine/model_engine_server/db/migrations/alembic/versions/2026_06_16_1200-c4d5e6f7a8b9_add_status_reason_column.py
@@ -1,0 +1,31 @@
+"""add status_reason column
+
+Revision ID: c4d5e6f7a8b9
+Revises: a1b2c3d4e5f6
+Create Date: 2026-06-16 12:00:00.000000
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'c4d5e6f7a8b9'
+down_revision = 'a1b2c3d4e5f6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'endpoints',
+        sa.Column('status_reason', sa.Text, nullable=True),
+        schema='hosted_model_inference',
+    )
+
+
+def downgrade() -> None:
+    op.drop_column(
+        'endpoints',
+        'status_reason',
+        schema='hosted_model_inference',
+    )

--- a/model-engine/model_engine_server/db/models/hosted_model_inference.py
+++ b/model-engine/model_engine_server/db/models/hosted_model_inference.py
@@ -465,6 +465,9 @@ class Endpoint(Base):
     # Endpoints should eventually end up as READY barring any bugs.
     # EndpointStatus.ready.value
     endpoint_status = Column(Text, default="READY")
+    # Human-readable reason for the current status, set when a build fails (status
+    # UPDATE_FAILED) so the failure cause can be surfaced to API consumers.
+    status_reason = Column(Text, nullable=True)
     current_bundle = relationship("Bundle")
     owner = Column(String(SHORT_STRING))
     public_inference = Column(Boolean, default=False)
@@ -484,6 +487,7 @@ class Endpoint(Base):
         endpoint_type: str = "async",
         destination: Optional[str] = None,
         endpoint_status: Optional[str] = "READY",  # EndpointStatus.ready.value
+        status_reason: Optional[str] = None,
         owner: Optional[str] = None,
         public_inference: Optional[bool] = False,
         task_expires_seconds: Optional[int] = None,
@@ -498,6 +502,7 @@ class Endpoint(Base):
         self.endpoint_type = endpoint_type
         self.destination = destination
         self.endpoint_status = endpoint_status
+        self.status_reason = status_reason
         self.owner = owner
         self.public_inference = public_inference
         self.task_expires_seconds = task_expires_seconds

--- a/model-engine/model_engine_server/domain/entities/model_endpoint_entity.py
+++ b/model-engine/model_engine_server/domain/entities/model_endpoint_entity.py
@@ -132,6 +132,7 @@ class ModelEndpointRecord(OwnedEntity):
     endpoint_type: ModelEndpointType
     destination: str
     status: ModelEndpointStatus
+    status_reason: Optional[str] = None
     current_model_bundle: ModelBundle
     owner: str
     public_inference: Optional[bool] = None

--- a/model-engine/model_engine_server/domain/use_cases/model_endpoint_use_cases.py
+++ b/model-engine/model_engine_server/domain/use_cases/model_endpoint_use_cases.py
@@ -78,6 +78,7 @@ def model_endpoint_entity_to_get_model_endpoint_response(
         metadata=model_endpoint.record.metadata,
         bundle_name=model_endpoint.record.current_model_bundle.name,
         status=model_endpoint.record.status,
+        status_reason=model_endpoint.record.status_reason,
         post_inference_hooks=post_inference_hooks,
         default_callback_url=default_callback_url,  # type: ignore
         default_callback_auth=default_callback_auth,

--- a/model-engine/model_engine_server/infra/repositories/db_model_endpoint_record_repository.py
+++ b/model-engine/model_engine_server/infra/repositories/db_model_endpoint_record_repository.py
@@ -51,6 +51,7 @@ def translate_model_endpoint_orm_to_model_endpoint_record(
         endpoint_type=model_endpoint_orm.endpoint_type,
         destination=model_endpoint_orm.destination,
         status=model_endpoint_orm.endpoint_status,
+        status_reason=model_endpoint_orm.status_reason,
         current_model_bundle=current_model_bundle,
         public_inference=model_endpoint_orm.public_inference,
         task_expires_seconds=model_endpoint_orm.task_expires_seconds,
@@ -121,6 +122,7 @@ class DbModelEndpointRecordRepository(ModelEndpointRecordRepository, DbRepositor
         creation_task_id: str,
         status: str,
         owner: str,
+        status_reason: Optional[str] = None,
         public_inference: Optional[bool] = False,
         task_expires_seconds: Optional[int] = None,
         queue_message_timeout_seconds: Optional[int] = None,
@@ -134,6 +136,7 @@ class DbModelEndpointRecordRepository(ModelEndpointRecordRepository, DbRepositor
             destination=destination,
             creation_task_id=creation_task_id,
             endpoint_status=status,
+            status_reason=status_reason,
             owner=owner,
             public_inference=public_inference,
             task_expires_seconds=task_expires_seconds,
@@ -310,6 +313,7 @@ class DbModelEndpointRecordRepository(ModelEndpointRecordRepository, DbRepositor
         creation_task_id: Optional[str] = None,
         destination: Optional[str] = None,
         status: Optional[str] = None,
+        status_reason: Optional[str] = None,
         public_inference: Optional[bool] = None,
         task_expires_seconds: Optional[int] = None,
         queue_message_timeout_seconds: Optional[int] = None,
@@ -335,6 +339,11 @@ class DbModelEndpointRecordRepository(ModelEndpointRecordRepository, DbRepositor
                 task_expires_seconds=task_expires_seconds,
                 queue_message_timeout_seconds=queue_message_timeout_seconds,
             )
+            # status_reason is handled separately from dict_not_none so an explicit
+            # clear (empty string -> NULL) is possible when an endpoint recovers to a
+            # healthy state, while omitting it (None) leaves any existing reason intact.
+            if status_reason is not None:
+                update_kwargs["status_reason"] = status_reason or None
             await OrmModelEndpoint.update_by_name_owner(
                 session=session,
                 name=model_endpoint_orm.name,

--- a/model-engine/model_engine_server/infra/repositories/model_endpoint_record_repository.py
+++ b/model-engine/model_engine_server/infra/repositories/model_endpoint_record_repository.py
@@ -49,6 +49,7 @@ class ModelEndpointRecordRepository(ABC):
         creation_task_id: str,
         status: str,
         owner: str,
+        status_reason: Optional[str] = None,
         public_inference: Optional[bool] = False,
         task_expires_seconds: Optional[int] = None,
         queue_message_timeout_seconds: Optional[int] = None,
@@ -67,6 +68,8 @@ class ModelEndpointRecordRepository(ABC):
             status: A status field on the endpoint, keeps track of endpoint state,
                 used to coordinate edit operations on the endpoint
             owner: Team who owns endpoint
+            status_reason: Human-readable reason for the current status (e.g. the failure
+                cause when status is UPDATE_FAILED)
             public_inference: Whether the endpoint is publicly accessible
             task_expires_seconds: For async endpoints, how long a task can wait in queue before expiring
             queue_message_timeout_seconds: For async endpoints, queue message visibility/lock timeout
@@ -85,6 +88,7 @@ class ModelEndpointRecordRepository(ABC):
         creation_task_id: Optional[str] = None,
         destination: Optional[str] = None,
         status: Optional[str] = None,
+        status_reason: Optional[str] = None,
         public_inference: Optional[bool] = None,
         task_expires_seconds: Optional[int] = None,
         queue_message_timeout_seconds: Optional[int] = None,
@@ -99,6 +103,8 @@ class ModelEndpointRecordRepository(ABC):
             creation_task_id: The task id corresponding to endpoint creation
             destination: The destination where async tasks should be sent.
             status: Status field on the endpoint, used to coordinate endpoint edit operations
+            status_reason: Human-readable reason for the current status (e.g. the failure
+                cause when status is UPDATE_FAILED)
             public_inference: Whether the endpoint is publicly accessible
             task_expires_seconds: For async endpoints, how long a task can wait in queue before expiring
             queue_message_timeout_seconds: For async endpoints, queue message visibility/lock timeout

--- a/model-engine/model_engine_server/infra/services/live_endpoint_builder_service.py
+++ b/model-engine/model_engine_server/infra/services/live_endpoint_builder_service.py
@@ -83,6 +83,16 @@ BUILD_CONTEXT_TEMP_ROOT = os.path.join(WORKSPACE_PATH, "model-engine", ".build-c
 
 INITIAL_K8S_CACHE_TTL_SECONDS: int = 180
 MAX_IMAGE_TAG_LEN = 128
+# Cap the persisted failure reason so a verbose traceback/string can't blow up the column.
+MAX_STATUS_REASON_LEN = 500
+
+
+def _sanitize_status_reason(message: str) -> str:
+    """Collapse whitespace and cap length for a status_reason persisted on an endpoint."""
+    collapsed = " ".join(message.split())
+    if len(collapsed) > MAX_STATUS_REASON_LEN:
+        return collapsed[: MAX_STATUS_REASON_LEN - 1].rstrip() + "…"
+    return collapsed
 
 RESTRICTED_ENV_VARS_KEYS = {
     "BASE": [
@@ -342,15 +352,19 @@ class LiveEndpointBuilderService(EndpointBuilderService):
                     model_endpoint_id=endpoint_id,
                     destination=create_or_update_response.destination,
                     status=ModelEndpointStatus.READY,
+                    # Clear any reason from a prior failed attempt now that we're healthy.
+                    status_reason="",
                 )
 
             except Exception as error:  # noqa
                 log_error("Failed endpoint build process!")
-                # Update status as failed endpoint creation on unhandled error
+                # Update status as failed endpoint creation on unhandled error, recording
+                # the cause so it can be surfaced to API consumers.
                 try:
                     await self.model_endpoint_record_repository.update_model_endpoint_record(
                         model_endpoint_id=endpoint_id,
                         status=ModelEndpointStatus.UPDATE_FAILED,
+                        status_reason=_sanitize_status_reason(str(error)),
                     )
                 except Exception as error_update:
                     log_error("Failed to update endpoint build status to FAILED")
@@ -717,6 +731,8 @@ class LiveEndpointBuilderService(EndpointBuilderService):
                     await self.model_endpoint_record_repository.update_model_endpoint_record(
                         model_endpoint_id=build_endpoint_request.model_endpoint_record.id,
                         status=ModelEndpointStatus.UPDATE_FAILED,
+                        status_reason="Image build failed. Check that the bundle's image "
+                        "and dependencies are valid and accessible.",
                     )
 
                     if s3_logs_location is not None:

--- a/model-engine/model_engine_server/infra/services/live_model_endpoint_service.py
+++ b/model-engine/model_engine_server/infra/services/live_model_endpoint_service.py
@@ -410,6 +410,7 @@ class LiveModelEndpointService(ModelEndpointService):
                 await self.model_endpoint_record_repository.update_model_endpoint_record(
                     model_endpoint_id=model_endpoint_id,
                     status=ModelEndpointStatus.UPDATE_FAILED,
+                    status_reason="Failed to delete the endpoint's infrastructure.",
                 )
                 raise EndpointDeleteFailedException
 

--- a/model-engine/tests/unit/domain/test_model_endpoint_use_cases.py
+++ b/model-engine/tests/unit/domain/test_model_endpoint_use_cases.py
@@ -18,7 +18,11 @@ from model_engine_server.common.resource_limits import (
     STORAGE_LIMIT,
 )
 from model_engine_server.core.auth.authentication_repository import User
-from model_engine_server.domain.entities import ModelBundle, ModelEndpoint
+from model_engine_server.domain.entities import (
+    ModelBundle,
+    ModelEndpoint,
+    ModelEndpointStatus,
+)
 from model_engine_server.domain.exceptions import (
     EndpointBillingTagsMalformedException,
     EndpointLabelsException,
@@ -778,6 +782,25 @@ async def test_get_model_endpoint_use_case_success(
     response_2 = await use_case.execute(user=user, model_endpoint_id=model_endpoint_2.record.id)
     assert isinstance(response_2, GetModelEndpointV1Response)
     assert response_2.resource_state.nodes_per_worker == 2
+
+
+@pytest.mark.asyncio
+async def test_get_model_endpoint_use_case_surfaces_status_reason(
+    test_api_key: str,
+    fake_model_endpoint_service,
+    model_endpoint_1: ModelEndpoint,
+):
+    # A failed endpoint's status_reason should flow through to the API response.
+    model_endpoint_1.record.status = ModelEndpointStatus.UPDATE_FAILED
+    model_endpoint_1.record.status_reason = "CUDA out of memory"
+    fake_model_endpoint_service.add_model_endpoint(model_endpoint_1)
+    use_case = GetModelEndpointByIdV1UseCase(model_endpoint_service=fake_model_endpoint_service)
+    user = User(user_id=test_api_key, team_id=test_api_key, is_privileged_user=True)
+
+    response = await use_case.execute(user=user, model_endpoint_id=model_endpoint_1.record.id)
+
+    assert response.status == ModelEndpointStatus.UPDATE_FAILED
+    assert response.status_reason == "CUDA out of memory"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

When an endpoint build fails (status `UPDATE_FAILED`), the cause is only logged and discarded — the GET model-endpoint API exposes `status` but no reason. A downstream consumer (Scale's SGP / GenAI platform) polls this endpoint to surface deploy results to users, so today a failed deploy can only show a generic "failed" message with no actionable cause (CUDA OOM, bad checkpoint, image pull failure, etc.).

This threads a `status_reason` through the stack so the failure cause is persisted and returned by the API:

- Add nullable `status_reason` column to the `endpoints` table (+ Alembic migration).
- Add `status_reason` to the ORM model, `ModelEndpointRecord` entity, the ORM→entity translation, and the create/update repository methods.
- Expose `status_reason` on `GetModelEndpointV1Response` and map it in the use case.
- Capture the cause at the `UPDATE_FAILED` sites (sanitized build error, image-build failure, infra-delete failure) and clear it when an endpoint returns to `READY`.

## Test plan

- [x] Unit test: a failed endpoint's `status_reason` flows through to `GetModelEndpointV1Response`.
- [ ] _Maintainer verification:_ full unit suite + Alembic migration run (the author couldn't install deps locally — the repo's pip registry requires CodeArtifact auth; changes are byte-compiled clean and logic-validated standalone).

## Notes

Opened from a fork while repo write access is pending. Happy to adjust field naming / sanitization length / which call sites capture a reason to match team conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR threads a `status_reason` field through the full stack — DB column, ORM model, domain entity, repository, and API response DTO — so that human-readable failure causes (e.g., CUDA OOM, image pull errors) are persisted on `UPDATE_FAILED` endpoints and returned by `GET /model-endpoint`.

- **Schema + migration**: adds a nullable `Text` column `status_reason` to `hosted_model_inference.endpoints` with a correct Alembic migration chained to the previous revision.
- **Capture sites**: `live_endpoint_builder_service` records `str(error)` (whitespace-collapsed, 500-char capped) on the generic build-failure path and a static message on image-build failure; `live_model_endpoint_service` records a static message on infra-delete failure.
- **Clearing**: setting `status_reason=""` in `update_model_endpoint_record` is converted to SQL `NULL` so the field is cleared when an endpoint returns to `READY`; the semantics differ from every other nullable parameter in that signature (`None` = leave unchanged, `""` = clear).

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge with the understanding that raw exception messages from infrastructure operations will become visible to endpoint owners via the GET API; review the str(error) handling before exposing to external users.

The data flow is clean and the migration is correctly chained. However, the build-failure path passes str(error) from a broad exception handler directly into a user-visible API field. Exceptions from Kubernetes, AWS, or database layers can contain connection strings, internal IPs, or resource names that should not be surfaced in a public API response. The image-build and delete-failure paths use static strings (safe), but the generic catch-all path is the one most likely to fire in practice.

model-engine/model_engine_server/infra/services/live_endpoint_builder_service.py — the generic exception handler that serialises str(error) into status_reason
</details>

<details open><summary><h3>Security Review</h3></summary>

- **Information disclosure via `str(error)`** (`live_endpoint_builder_service.py`): The broad `except Exception` block passes `str(error)` directly as `status_reason`. This can surface internal infrastructure details — Kubernetes resource names, internal IP addresses, AWS ARNs, database connection strings — to API consumers through the public `GET /model-endpoint` response. Sanitization only normalises whitespace and caps length; no content filtering is applied.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| model-engine/model_engine_server/infra/services/live_endpoint_builder_service.py | Captures status_reason at UPDATE_FAILED and READY sites; raw str(error) may expose sensitive infrastructure internals to API consumers |
| model-engine/model_engine_server/infra/repositories/db_model_endpoint_record_repository.py | Adds status_reason to create/update paths with a non-obvious empty-string sentinel for clearing; logic is correct but the API contract is easy to misuse |
| model-engine/model_engine_server/db/migrations/alembic/versions/2026_06_16_1200-c4d5e6f7a8b9_add_status_reason_column.py | Correct nullable Text column addition with matching down_revision pointing to the prior migration |
| model-engine/model_engine_server/common/dtos/model_endpoints.py | Adds optional status_reason field to GetModelEndpointV1Response with clear description |
| model-engine/model_engine_server/domain/entities/model_endpoint_entity.py | Adds nullable status_reason field to ModelEndpointRecord entity with correct default |
| model-engine/model_engine_server/domain/use_cases/model_endpoint_use_cases.py | Threads status_reason from the entity record into the API response DTO |
| model-engine/model_engine_server/infra/repositories/model_endpoint_record_repository.py | Adds status_reason parameter to the abstract repository interface with docstring updates |
| model-engine/model_engine_server/db/models/hosted_model_inference.py | Adds nullable Text status_reason column to the Endpoint ORM model and __init__ signature |
| model-engine/model_engine_server/infra/services/live_model_endpoint_service.py | Sets a static status_reason for the infra-delete failure case; safe message with no dynamic content |
| model-engine/tests/unit/domain/test_model_endpoint_use_cases.py | Adds a focused test verifying status_reason flows through from the entity to the API response |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Builder as LiveEndpointBuilderService
    participant Repo as DbModelEndpointRecordRepository
    participant DB as PostgreSQL (endpoints)
    participant API as GET /model-endpoint

    Builder->>Repo: "update_model_endpoint_record(status=READY, status_reason="")"
    Repo->>DB: "UPDATE SET status_reason=NULL"
    Note over DB: status_reason cleared on success

    Builder->>Repo: "update_model_endpoint_record(status=UPDATE_FAILED, status_reason=sanitized_error)"
    Repo->>DB: "UPDATE SET status_reason='CUDA out of memory…'"
    Note over DB: reason persisted on failure

    API->>DB: "SELECT * FROM endpoints WHERE id=?"
    DB-->>API: "{status: UPDATE_FAILED, status_reason: 'CUDA out of memory…'}"
    API-->>API: "GetModelEndpointV1Response{status_reason: '…'}"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Builder as LiveEndpointBuilderService
    participant Repo as DbModelEndpointRecordRepository
    participant DB as PostgreSQL (endpoints)
    participant API as GET /model-endpoint

    Builder->>Repo: "update_model_endpoint_record(status=READY, status_reason="")"
    Repo->>DB: "UPDATE SET status_reason=NULL"
    Note over DB: status_reason cleared on success

    Builder->>Repo: "update_model_endpoint_record(status=UPDATE_FAILED, status_reason=sanitized_error)"
    Repo->>DB: "UPDATE SET status_reason='CUDA out of memory…'"
    Note over DB: reason persisted on failure

    API->>DB: "SELECT * FROM endpoints WHERE id=?"
    DB-->>API: "{status: UPDATE_FAILED, status_reason: 'CUDA out of memory…'}"
    API-->>API: "GetModelEndpointV1Response{status_reason: '…'}"
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Amodel-engine%2Fmodel_engine_server%2Finfra%2Fservices%2Flive_endpoint_builder_service.py%3A367-368%0A**Unfiltered%20%60str%28error%29%60%20may%20leak%20sensitive%20infrastructure%20details**%0A%0AThe%20broad%20%60except%20Exception%60%20block%20catches%20all%20errors%20from%20infrastructure%20operations%20%28Kubernetes%20API%20calls%2C%20AWS%20SDK%20calls%2C%20database%20operations%2C%20etc.%29.%20Passing%20%60str%28error%29%60%20directly%20as%20%60status_reason%60%20can%20expose%20internal%20connection%20strings%2C%20internal%20IP%20addresses%2C%20resource%20names%2C%20or%20database%20schema%20details%20to%20API%20consumers%20via%20the%20public%20%60GET%20%2Fmodel-endpoint%60%20response.%20The%20%60_sanitize_status_reason%60%20helper%20only%20collapses%20whitespace%20and%20caps%20length%20%E2%80%94%20it%20performs%20no%20content%20filtering.%20Consider%20catching%20specific%20known%20exception%20types%20and%20mapping%20them%20to%20safe%2C%20user-facing%20messages%2C%20or%20stripping%20exception%20types%20from%20a%20known-internal%20class%20hierarchy%20before%20persisting%20the%20message.%0A%0A%23%23%23%20Issue%202%20of%202%0Amodel-engine%2Fmodel_engine_server%2Finfra%2Frepositories%2Fdb_model_endpoint_record_repository.py%3A342-346%0A**Empty-string-as-sentinel%20is%20a%20non-obvious%20API%20contract**%0A%0AThe%20update%20method%20uses%20%60None%60%20to%20mean%20%22leave%20the%20existing%20value%20unchanged%22%20and%20%60%22%22%60%20to%20mean%20%22clear%20to%20NULL%22.%20This%20is%20documented%20in%20a%20comment%20but%20differs%20from%20every%20other%20nullable%20parameter%20in%20the%20same%20method%20signature%20%28e.g.%2C%20%60status%60%2C%20%60destination%60%2C%20%60metadata%60%29%20where%20%60None%60%20always%20means%20%22do%20not%20update%22.%20A%20future%20caller%20who%20passes%20%60status_reason%3DNone%60%20intending%20to%20clear%20the%20field%20will%20silently%20leave%20a%20stale%20failure%20reason.%20Consider%20using%20a%20dedicated%20sentinel%20%28e.g.%2C%20a%20module-level%20%60CLEAR%20%3D%20object%28%29%60%29%20or%20a%20separate%20%60clear_status_reason%3A%20bool%20%3D%20False%60%20parameter%20to%20make%20the%20intent%20explicit.%0A%0A&pr=839&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Amodel-engine%2Fmodel_engine_server%2Finfra%2Fservices%2Flive_endpoint_builder_service.py%3A367-368%0A**Unfiltered%20%60str%28error%29%60%20may%20leak%20sensitive%20infrastructure%20details**%0A%0AThe%20broad%20%60except%20Exception%60%20block%20catches%20all%20errors%20from%20infrastructure%20operations%20%28Kubernetes%20API%20calls%2C%20AWS%20SDK%20calls%2C%20database%20operations%2C%20etc.%29.%20Passing%20%60str%28error%29%60%20directly%20as%20%60status_reason%60%20can%20expose%20internal%20connection%20strings%2C%20internal%20IP%20addresses%2C%20resource%20names%2C%20or%20database%20schema%20details%20to%20API%20consumers%20via%20the%20public%20%60GET%20%2Fmodel-endpoint%60%20response.%20The%20%60_sanitize_status_reason%60%20helper%20only%20collapses%20whitespace%20and%20caps%20length%20%E2%80%94%20it%20performs%20no%20content%20filtering.%20Consider%20catching%20specific%20known%20exception%20types%20and%20mapping%20them%20to%20safe%2C%20user-facing%20messages%2C%20or%20stripping%20exception%20types%20from%20a%20known-internal%20class%20hierarchy%20before%20persisting%20the%20message.%0A%0A%23%23%23%20Issue%202%20of%202%0Amodel-engine%2Fmodel_engine_server%2Finfra%2Frepositories%2Fdb_model_endpoint_record_repository.py%3A342-346%0A**Empty-string-as-sentinel%20is%20a%20non-obvious%20API%20contract**%0A%0AThe%20update%20method%20uses%20%60None%60%20to%20mean%20%22leave%20the%20existing%20value%20unchanged%22%20and%20%60%22%22%60%20to%20mean%20%22clear%20to%20NULL%22.%20This%20is%20documented%20in%20a%20comment%20but%20differs%20from%20every%20other%20nullable%20parameter%20in%20the%20same%20method%20signature%20%28e.g.%2C%20%60status%60%2C%20%60destination%60%2C%20%60metadata%60%29%20where%20%60None%60%20always%20means%20%22do%20not%20update%22.%20A%20future%20caller%20who%20passes%20%60status_reason%3DNone%60%20intending%20to%20clear%20the%20field%20will%20silently%20leave%20a%20stale%20failure%20reason.%20Consider%20using%20a%20dedicated%20sentinel%20%28e.g.%2C%20a%20module-level%20%60CLEAR%20%3D%20object%28%29%60%29%20or%20a%20separate%20%60clear_status_reason%3A%20bool%20%3D%20False%60%20parameter%20to%20make%20the%20intent%20explicit.%0A%0A&repo=scaleapi%2Fllm-engine&pr=839&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fllm-engine%22%20on%20the%20existing%20branch%20%22dhruv%2Fendpoint-status-reason%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dhruv%2Fendpoint-status-reason%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Amodel-engine%2Fmodel_engine_server%2Finfra%2Fservices%2Flive_endpoint_builder_service.py%3A367-368%0A**Unfiltered%20%60str%28error%29%60%20may%20leak%20sensitive%20infrastructure%20details**%0A%0AThe%20broad%20%60except%20Exception%60%20block%20catches%20all%20errors%20from%20infrastructure%20operations%20%28Kubernetes%20API%20calls%2C%20AWS%20SDK%20calls%2C%20database%20operations%2C%20etc.%29.%20Passing%20%60str%28error%29%60%20directly%20as%20%60status_reason%60%20can%20expose%20internal%20connection%20strings%2C%20internal%20IP%20addresses%2C%20resource%20names%2C%20or%20database%20schema%20details%20to%20API%20consumers%20via%20the%20public%20%60GET%20%2Fmodel-endpoint%60%20response.%20The%20%60_sanitize_status_reason%60%20helper%20only%20collapses%20whitespace%20and%20caps%20length%20%E2%80%94%20it%20performs%20no%20content%20filtering.%20Consider%20catching%20specific%20known%20exception%20types%20and%20mapping%20them%20to%20safe%2C%20user-facing%20messages%2C%20or%20stripping%20exception%20types%20from%20a%20known-internal%20class%20hierarchy%20before%20persisting%20the%20message.%0A%0A%23%23%23%20Issue%202%20of%202%0Amodel-engine%2Fmodel_engine_server%2Finfra%2Frepositories%2Fdb_model_endpoint_record_repository.py%3A342-346%0A**Empty-string-as-sentinel%20is%20a%20non-obvious%20API%20contract**%0A%0AThe%20update%20method%20uses%20%60None%60%20to%20mean%20%22leave%20the%20existing%20value%20unchanged%22%20and%20%60%22%22%60%20to%20mean%20%22clear%20to%20NULL%22.%20This%20is%20documented%20in%20a%20comment%20but%20differs%20from%20every%20other%20nullable%20parameter%20in%20the%20same%20method%20signature%20%28e.g.%2C%20%60status%60%2C%20%60destination%60%2C%20%60metadata%60%29%20where%20%60None%60%20always%20means%20%22do%20not%20update%22.%20A%20future%20caller%20who%20passes%20%60status_reason%3DNone%60%20intending%20to%20clear%20the%20field%20will%20silently%20leave%20a%20stale%20failure%20reason.%20Consider%20using%20a%20dedicated%20sentinel%20%28e.g.%2C%20a%20module-level%20%60CLEAR%20%3D%20object%28%29%60%29%20or%20a%20separate%20%60clear_status_reason%3A%20bool%20%3D%20False%60%20parameter%20to%20make%20the%20intent%20explicit.%0A%0A&repo=scaleapi%2Fllm-engine&pr=839&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
model-engine/model_engine_server/infra/services/live_endpoint_builder_service.py:367-368
**Unfiltered `str(error)` may leak sensitive infrastructure details**

The broad `except Exception` block catches all errors from infrastructure operations (Kubernetes API calls, AWS SDK calls, database operations, etc.). Passing `str(error)` directly as `status_reason` can expose internal connection strings, internal IP addresses, resource names, or database schema details to API consumers via the public `GET /model-endpoint` response. The `_sanitize_status_reason` helper only collapses whitespace and caps length — it performs no content filtering. Consider catching specific known exception types and mapping them to safe, user-facing messages, or stripping exception types from a known-internal class hierarchy before persisting the message.

### Issue 2 of 2
model-engine/model_engine_server/infra/repositories/db_model_endpoint_record_repository.py:342-346
**Empty-string-as-sentinel is a non-obvious API contract**

The update method uses `None` to mean "leave the existing value unchanged" and `""` to mean "clear to NULL". This is documented in a comment but differs from every other nullable parameter in the same method signature (e.g., `status`, `destination`, `metadata`) where `None` always means "do not update". A future caller who passes `status_reason=None` intending to clear the field will silently leave a stale failure reason. Consider using a dedicated sentinel (e.g., a module-level `CLEAR = object()`) or a separate `clear_status_reason: bool = False` parameter to make the intent explicit.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: record and expose status\_reason on..."](https://github.com/scaleapi/llm-engine/commit/cdb9f50b5ea52955fbe22bd4805ea7ecc2fc3ab2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38573766)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->