### PR TITLE
feat(api): surface user-facing domain exception messages + error_type in middleware

### DIFF
--- a/model-engine/model_engine_server/api/app.py
+++ b/model-engine/model_engine_server/api/app.py
@@ -31,10 +31,63 @@ from model_engine_server.core.loggers import (
     make_logger,
 )
 from model_engine_server.core.tracing import get_tracing_gateway
+from model_engine_server.domain.exceptions import (
+    DomainException,
+    ExistingEndpointOperationInProgressException,
+    ObjectAlreadyExistsException,
+    ObjectHasInvalidValueException,
+    ObjectNoLongerAvailableException,
+    ObjectNotAuthorizedException,
+    ObjectNotFoundException,
+    TooManyRequestsException,
+)
 from starlette.middleware import Middleware
 from starlette.middleware.base import BaseHTTPMiddleware
 
 logger = make_logger(logger_name())
+
+# Status codes for domain (business-logic) exceptions that reach the middleware without
+# a per-route handler. These are user-facing 4xx errors whose messages are safe to
+# surface (they are authored in-code, not raw infra/AWS/k8s errors). Domain exceptions
+# NOT listed here fall through to the generic 500 — they are treated as internal failures
+# whose messages may carry sensitive detail, so only the exception type is exposed.
+_DOMAIN_EXCEPTION_STATUS_CODES = {
+    ObjectAlreadyExistsException: 400,
+    ObjectNotFoundException: 404,
+    ObjectNotAuthorizedException: 403,
+    ObjectHasInvalidValueException: 400,
+    ObjectNoLongerAvailableException: 410,
+    ExistingEndpointOperationInProgressException: 409,
+    TooManyRequestsException: 429,
+}
+
+
+def _internal_error_response(e: Exception) -> JSONResponse:
+    """Generic 500 for unanticipated/internal errors.
+
+    Logs the full detail (message + traceback) server-side and returns a generic
+    message plus the exception class name — never the message or traceback, which can
+    leak internal details — so callers get a safe hint to pair with the request id.
+    """
+    tb_str = traceback.format_exception(e)
+    request_id = LoggerTagManager.get(LoggerTagKey.REQUEST_ID)
+    timestamp = datetime.now(pytz.timezone("US/Pacific")).strftime("%Y-%m-%d %H:%M:%S %Z")
+    structured_log = {
+        "error": str(e),
+        "request_id": str(request_id),
+        "traceback": "".join(tb_str),
+    }
+    logger.error("Unhandled exception: %s", structured_log)
+    return JSONResponse(
+        status_code=500,
+        content={
+            "error": "Internal error occurred. Our team has been notified.",
+            "error_type": type(e).__name__,
+            "timestamp": timestamp,
+            "request_id": request_id,
+        },
+    )
+
 
 # Allows us to make the Uvicorn worker concurrency in model_engine_server/api/worker.py very high
 MAX_CONCURRENCY = 500
@@ -69,28 +122,33 @@ class CustomMiddleware(BaseHTTPMiddleware):
                     "timestamp": timestamp,
                 },
             )
-        except Exception as e:
-            tb_str = traceback.format_exception(e)
-            request_id = LoggerTagManager.get(LoggerTagKey.REQUEST_ID)
+        except DomainException as e:
+            # A domain exception reached the middleware without a per-route handler.
+            # For known user-facing (4xx) types, surface the message and the right status
+            # so callers get an actionable error instead of an opaque 500. Unknown domain
+            # exceptions are treated as internal and get the generic 500 (their messages
+            # may carry sensitive detail), exposing only the exception type.
+            status_code = next(
+                (
+                    code
+                    for cls, code in _DOMAIN_EXCEPTION_STATUS_CODES.items()
+                    if isinstance(e, cls)
+                ),
+                None,
+            )
+            if status_code is None:
+                return _internal_error_response(e)
             timestamp = datetime.now(pytz.timezone("US/Pacific")).strftime("%Y-%m-%d %H:%M:%S %Z")
-            structured_log = {
-                "error": str(e),
-                "request_id": str(request_id),
-                "traceback": "".join(tb_str),
-            }
-            logger.error("Unhandled exception: %s", structured_log)
             return JSONResponse(
-                status_code=500,
+                status_code=status_code,
                 content={
-                    "error": "Internal error occurred. Our team has been notified.",
-                    # Surface only the exception class name (never the message/traceback,
-                    # which can leak internal details) so callers and support get a hint
-                    # of what failed to pair with the request_id. Full detail is logged.
+                    "error": str(e) or type(e).__name__,
                     "error_type": type(e).__name__,
                     "timestamp": timestamp,
-                    "request_id": request_id,
                 },
             )
+        except Exception as e:
+            return _internal_error_response(e)
 
 
 app = FastAPI(

--- a/model-engine/model_engine_server/api/app.py
+++ b/model-engine/model_engine_server/api/app.py
@@ -83,6 +83,10 @@ class CustomMiddleware(BaseHTTPMiddleware):
                 status_code=500,
                 content={
                     "error": "Internal error occurred. Our team has been notified.",
+                    # Surface only the exception class name (never the message/traceback,
+                    # which can leak internal details) so callers and support get a hint
+                    # of what failed to pair with the request_id. Full detail is logged.
+                    "error_type": type(e).__name__,
                     "timestamp": timestamp,
                     "request_id": request_id,
                 },

--- a/model-engine/tests/unit/api/test_app.py
+++ b/model-engine/tests/unit/api/test_app.py
@@ -18,6 +18,27 @@ def test_healthcheck(simple_client: TestClient):
     assert response.status_code == 200
 
 
+def test_unhandled_exception_returns_generic_500_with_error_type(simple_client: TestClient):
+    # An unhandled exception that reaches the catch-all middleware should return the
+    # generic message plus the exception class name (not its message/traceback) so
+    # callers get a safe hint to pair with the request id.
+    app = simple_client.app
+
+    @app.get("/_test_raises")
+    async def _raises():  # pragma: no cover - body is the raise
+        raise KeyError("super-secret-internal-detail")
+
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.get("/_test_raises")
+
+    assert response.status_code == 500
+    body = response.json()
+    assert body["error"] == "Internal error occurred. Our team has been notified."
+    assert body["error_type"] == "KeyError"
+    # The raw exception message must not leak to the response.
+    assert "super-secret-internal-detail" not in response.text
+
+
 def test_rename_openapi_schemas_renames_discriminated_unions():
     """Test that discriminated union schemas are renamed correctly."""
     ugly_name = (

--- a/model-engine/tests/unit/api/test_app.py
+++ b/model-engine/tests/unit/api/test_app.py
@@ -19,9 +19,9 @@ def test_healthcheck(simple_client: TestClient):
 
 
 def test_unhandled_exception_returns_generic_500_with_error_type(simple_client: TestClient):
-    # An unhandled exception that reaches the catch-all middleware should return the
-    # generic message plus the exception class name (not its message/traceback) so
-    # callers get a safe hint to pair with the request id.
+    # A non-domain exception reaching the catch-all should return the generic message
+    # plus the exception class name (not its message/traceback) so callers get a safe
+    # hint to pair with the request id.
     app = simple_client.app
 
     @app.get("/_test_raises")
@@ -37,6 +37,47 @@ def test_unhandled_exception_returns_generic_500_with_error_type(simple_client: 
     assert body["error_type"] == "KeyError"
     # The raw exception message must not leak to the response.
     assert "super-secret-internal-detail" not in response.text
+
+
+def test_unhandled_domain_exception_surfaces_status_and_message(simple_client: TestClient):
+    # A known user-facing domain exception reaching the middleware (no per-route handler)
+    # should surface its message at the mapped status code.
+    from model_engine_server.domain.exceptions import ObjectNotFoundException
+
+    app = simple_client.app
+
+    @app.get("/_test_not_found")
+    async def _not_found():  # pragma: no cover - body is the raise
+        raise ObjectNotFoundException("model 'foo' was not found")
+
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.get("/_test_not_found")
+
+    assert response.status_code == 404
+    body = response.json()
+    assert body["error"] == "model 'foo' was not found"
+    assert body["error_type"] == "ObjectNotFoundException"
+
+
+def test_unmapped_domain_exception_falls_back_to_generic_500(simple_client: TestClient):
+    # A domain exception that isn't in the user-facing status map is treated as internal:
+    # generic 500, message not surfaced.
+    from model_engine_server.domain.exceptions import EndpointDeleteFailedException
+
+    app = simple_client.app
+
+    @app.get("/_test_internal_domain")
+    async def _internal_domain():  # pragma: no cover - body is the raise
+        raise EndpointDeleteFailedException("internal teardown detail")
+
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.get("/_test_internal_domain")
+
+    assert response.status_code == 500
+    body = response.json()
+    assert body["error"] == "Internal error occurred. Our team has been notified."
+    assert body["error_type"] == "EndpointDeleteFailedException"
+    assert "internal teardown detail" not in response.text
 
 
 def test_rename_openapi_schemas_renames_discriminated_unions():


### PR DESCRIPTION
## Summary

The global catch-all middleware (`CustomMiddleware` in `api/app.py`) returned a generic `"Internal error occurred. Our team has been notified."` + `request_id` for *any* unhandled exception. Downstream consumers (e.g. Scale's SGP, surfacing deploy/inference errors to users) had no actionable cause without grepping logs by `request_id`.

This makes the middleware return meaningful errors while staying safe about what it exposes:

1. **Known user-facing `DomainException`s** reaching the middleware without a per-route handler are mapped to their proper status + message:
   - `ObjectNotFoundException` → 404
   - `ObjectNotAuthorizedException` → 403
   - `ObjectAlreadyExistsException`, `ObjectHasInvalidValueException` → 400
   - `ObjectNoLongerAvailableException` → 410
   - `ExistingEndpointOperationInProgressException` → 409
   - `TooManyRequestsException` → 429
2. **Unmapped `DomainException`s** (e.g. `EndpointDeleteFailedException` and other infra-ish failures whose messages may carry internal detail) → generic 500, message **not** surfaced.
3. **Non-domain exceptions** → generic 500 with `error_type` (exception class name only — never the message/traceback), a safe hint to pair with `request_id`.

Full detail (message + traceback) is still logged server-side in all cases. Per-route handlers still take precedence — they raise `HTTPException`, caught by the first branch — so this only affects exceptions that would otherwise have become an opaque 500. A shared `_internal_error_response` helper backs both the unmapped-domain and catch-all paths.

## Safety rationale

`DomainException`s are authored in-code as user-facing business errors (per their docstrings). Only the explicitly-mapped 4xx types surface their message; everything else (including any not-yet-mapped domain exception) gets the generic 500, so raw infra/AWS/k8s error text never leaks.

## Test plan

- [x] Mapped domain exception (`ObjectNotFoundException`) → 404 with its message + `error_type`.
- [x] Unmapped domain exception (`EndpointDeleteFailedException`) → generic 500, message not leaked.
- [x] Non-domain exception (`KeyError`) → generic 500 with `error_type`, raw message not leaked.
- [x] black / ruff / isort clean on changed files.

## Context

Follow-up to the async-deploy `status_reason` work (#840). That PR surfaces causes for endpoint *build* failures; this addresses the separate sync middleware path that #840 doesn't touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the `CustomMiddleware` catch-all in `app.py` to return meaningful errors for known user-facing `DomainException`s instead of a blanket generic 500, while keeping unmapped domain and non-domain exceptions safely opaque.

- Adds `_DOMAIN_EXCEPTION_STATUS_CODES` dispatch map and a shared `_internal_error_response` helper; refactors the middleware to catch `DomainException` first, surface the message + `error_type` for the seven mapped 4xx types, and fall back to the generic 500 for everything else.
- Adds three unit tests covering the non-domain 500 path, a mapped 404, and an unmapped domain-exception 500, but does not test the 409 `ExistingEndpointOperationInProgressException` case where a message-drop bug is present.

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge after fixing the `ExistingEndpointOperationInProgressException` message-drop; the 409 response currently returns the class name instead of the intended conflict description.

The overall design is sound and the safety rationale is well-reasoned, but `ExistingEndpointOperationInProgressException.__init__` never calls `super().__init__(message)`, so `str(e)` is always empty and the fallback silently exposes only the class name in 409 responses — defeating the purpose of mapping that exception. The test suite does not cover this case, so the bug would ship undetected.

Both `app.py` (the middleware logic) and `domain/exceptions.py` (the `ExistingEndpointOperationInProgressException.__init__` definition) need attention before merging.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| model-engine/model_engine_server/api/app.py | Adds `_DOMAIN_EXCEPTION_STATUS_CODES` dispatch map and `_internal_error_response` helper; refactors `CustomMiddleware` to surface user-facing 4xx messages. One bug: `ExistingEndpointOperationInProgressException.__init__` stores the message only in `self.message` (no `super().__init__(message)` call), so `str(e)` is always `''` and the 409 body falls back to the class name. |
| model-engine/tests/unit/api/test_app.py | Adds three new middleware tests covering the non-domain 500 path, a mapped `ObjectNotFoundException` 404, and an unmapped `EndpointDeleteFailedException` 500. Does not cover the 409 `ExistingEndpointOperationInProgressException` case where the message-drop bug would be detectable. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Request enters CustomMiddleware] --> B[call_next — route handler]
    B -->|raises HTTPException| C[Return JSONResponse with e.status_code + e.detail]
    B -->|raises DomainException| D{In _DOMAIN_EXCEPTION_STATUS_CODES?}
    D -->|Yes — 4xx mapped| E[Return JSONResponse\nstatus=mapped code\nerror=str e\nerror_type=class name]
    D -->|No — unmapped| F[_internal_error_response\nLog full detail server-side\nReturn 500 generic message + error_type]
    B -->|raises any other Exception| F
    B -->|success| G[Return response normally]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Request enters CustomMiddleware] --> B[call_next — route handler]
    B -->|raises HTTPException| C[Return JSONResponse with e.status_code + e.detail]
    B -->|raises DomainException| D{In _DOMAIN_EXCEPTION_STATUS_CODES?}
    D -->|Yes — 4xx mapped| E[Return JSONResponse\nstatus=mapped code\nerror=str e\nerror_type=class name]
    D -->|No — unmapped| F[_internal_error_response\nLog full detail server-side\nReturn 500 generic message + error_type]
    B -->|raises any other Exception| F
    B -->|success| G[Return response normally]
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Amodel-engine%2Fmodel_engine_server%2Fapi%2Fapp.py%3A145%0A**%60ExistingEndpointOperationInProgressException%60%20message%20is%20silently%20dropped**%0A%0A%60ExistingEndpointOperationInProgressException.__init__%60%20stores%20the%20message%20in%20%60self.message%60%20but%20never%20calls%20%60super%28%29.__init__%28message%29%60%2C%20so%20%60self.args%60%20stays%20empty%20and%20%60str%28e%29%60%20returns%20%60''%60.%20The%20fallback%20%60str%28e%29%20or%20type%28e%29.__name__%60%20will%20always%20resolve%20to%20the%20class%20name%20%E2%80%94%20the%20409%20response%20will%20say%20%60%22ExistingEndpointOperationInProgressException%22%60%20instead%20of%20the%20actual%20conflict%20description.%20No%20test%20currently%20exercises%20this%20exception%20type%20so%20the%20bug%20is%20invisible%20in%20the%20test%20suite.%20A%20fix%20here%20or%20in%20the%20exception%20definition%20%28%60super%28%29.__init__%28message%29%60%29%20is%20needed%20to%20make%20the%20409%20surface%20the%20intended%20message.%0A%0A%23%23%23%20Issue%202%20of%203%0Amodel-engine%2Fmodel_engine_server%2Fapi%2Fapp.py%3A141-149%0A**No%20server-side%20logging%20for%20mapped%204xx%20domain%20exceptions**%0A%0AThe%20%60_internal_error_response%60%20path%20logs%20the%20full%20error%20%2B%20traceback%2C%20but%20mapped%20%60DomainException%60s%20%28404%2C%20403%2C%20409%2C%20etc.%29%20silently%20return%20a%20response%20with%20no%20log%20entry.%20When%20these%20exceptions%20escape%20a%20route%20handler%20and%20land%20in%20the%20middleware%20it's%20usually%20unexpected%3B%20without%20a%20log%20line%20there%20is%20no%20server-side%20record%20to%20correlate%20with%20downstream%20reports%20of%20404%2F403%20errors.%20Consider%20at%20least%20a%20%60logger.warning%60%20%28without%20the%20traceback%29%20to%20preserve%20observability%20for%20these%20cases.%0A%0A%23%23%23%20Issue%203%20of%203%0Amodel-engine%2Fmodel_engine_server%2Fapi%2Fapp.py%3A54-62%0A**Several%20clearly%20user-facing%20%60DomainException%60s%20are%20absent%20from%20the%20map**%0A%0A%60InvalidRequestException%60%2C%20%60TriggerNameAlreadyExistsException%60%2C%20%60LLMFineTuningQuotaReached%60%2C%20%60CronSyntaxException%60%2C%20%60EndpointUnsupportedRequestException%60%2C%20and%20%60EndpointResourceInvalidRequestException%60%20all%20describe%20user-input%20errors%20with%20authored%20messages%2C%20yet%20they%20fall%20through%20to%20the%20generic%20500%20path.%20If%20any%20of%20these%20escape%20a%20route%20handler%20they%20will%20silently%20look%20like%20server%20bugs%20to%20callers%20instead%20of%20returning%20an%20actionable%204xx.%20Worth%20confirming%20whether%20these%20are%20intentionally%20deferred%20or%20simply%20overlooked%20when%20assembling%20the%20initial%20map.%0A%0A&pr=841&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Amodel-engine%2Fmodel_engine_server%2Fapi%2Fapp.py%3A145%0A**%60ExistingEndpointOperationInProgressException%60%20message%20is%20silently%20dropped**%0A%0A%60ExistingEndpointOperationInProgressException.__init__%60%20stores%20the%20message%20in%20%60self.message%60%20but%20never%20calls%20%60super%28%29.__init__%28message%29%60%2C%20so%20%60self.args%60%20stays%20empty%20and%20%60str%28e%29%60%20returns%20%60''%60.%20The%20fallback%20%60str%28e%29%20or%20type%28e%29.__name__%60%20will%20always%20resolve%20to%20the%20class%20name%20%E2%80%94%20the%20409%20response%20will%20say%20%60%22ExistingEndpointOperationInProgressException%22%60%20instead%20of%20the%20actual%20conflict%20description.%20No%20test%20currently%20exercises%20this%20exception%20type%20so%20the%20bug%20is%20invisible%20in%20the%20test%20suite.%20A%20fix%20here%20or%20in%20the%20exception%20definition%20%28%60super%28%29.__init__%28message%29%60%29%20is%20needed%20to%20make%20the%20409%20surface%20the%20intended%20message.%0A%0A%23%23%23%20Issue%202%20of%203%0Amodel-engine%2Fmodel_engine_server%2Fapi%2Fapp.py%3A141-149%0A**No%20server-side%20logging%20for%20mapped%204xx%20domain%20exceptions**%0A%0AThe%20%60_internal_error_response%60%20path%20logs%20the%20full%20error%20%2B%20traceback%2C%20but%20mapped%20%60DomainException%60s%20%28404%2C%20403%2C%20409%2C%20etc.%29%20silently%20return%20a%20response%20with%20no%20log%20entry.%20When%20these%20exceptions%20escape%20a%20route%20handler%20and%20land%20in%20the%20middleware%20it's%20usually%20unexpected%3B%20without%20a%20log%20line%20there%20is%20no%20server-side%20record%20to%20correlate%20with%20downstream%20reports%20of%20404%2F403%20errors.%20Consider%20at%20least%20a%20%60logger.warning%60%20%28without%20the%20traceback%29%20to%20preserve%20observability%20for%20these%20cases.%0A%0A%23%23%23%20Issue%203%20of%203%0Amodel-engine%2Fmodel_engine_server%2Fapi%2Fapp.py%3A54-62%0A**Several%20clearly%20user-facing%20%60DomainException%60s%20are%20absent%20from%20the%20map**%0A%0A%60InvalidRequestException%60%2C%20%60TriggerNameAlreadyExistsException%60%2C%20%60LLMFineTuningQuotaReached%60%2C%20%60CronSyntaxException%60%2C%20%60EndpointUnsupportedRequestException%60%2C%20and%20%60EndpointResourceInvalidRequestException%60%20all%20describe%20user-input%20errors%20with%20authored%20messages%2C%20yet%20they%20fall%20through%20to%20the%20generic%20500%20path.%20If%20any%20of%20these%20escape%20a%20route%20handler%20they%20will%20silently%20look%20like%20server%20bugs%20to%20callers%20instead%20of%20returning%20an%20actionable%204xx.%20Worth%20confirming%20whether%20these%20are%20intentionally%20deferred%20or%20simply%20overlooked%20when%20assembling%20the%20initial%20map.%0A%0A&repo=scaleapi%2Fllm-engine&pr=841&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fllm-engine%22%20on%20the%20existing%20branch%20%22dhruv%2Fapp-catchall-error-detail%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dhruv%2Fapp-catchall-error-detail%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Amodel-engine%2Fmodel_engine_server%2Fapi%2Fapp.py%3A145%0A**%60ExistingEndpointOperationInProgressException%60%20message%20is%20silently%20dropped**%0A%0A%60ExistingEndpointOperationInProgressException.__init__%60%20stores%20the%20message%20in%20%60self.message%60%20but%20never%20calls%20%60super%28%29.__init__%28message%29%60%2C%20so%20%60self.args%60%20stays%20empty%20and%20%60str%28e%29%60%20returns%20%60''%60.%20The%20fallback%20%60str%28e%29%20or%20type%28e%29.__name__%60%20will%20always%20resolve%20to%20the%20class%20name%20%E2%80%94%20the%20409%20response%20will%20say%20%60%22ExistingEndpointOperationInProgressException%22%60%20instead%20of%20the%20actual%20conflict%20description.%20No%20test%20currently%20exercises%20this%20exception%20type%20so%20the%20bug%20is%20invisible%20in%20the%20test%20suite.%20A%20fix%20here%20or%20in%20the%20exception%20definition%20%28%60super%28%29.__init__%28message%29%60%29%20is%20needed%20to%20make%20the%20409%20surface%20the%20intended%20message.%0A%0A%23%23%23%20Issue%202%20of%203%0Amodel-engine%2Fmodel_engine_server%2Fapi%2Fapp.py%3A141-149%0A**No%20server-side%20logging%20for%20mapped%204xx%20domain%20exceptions**%0A%0AThe%20%60_internal_error_response%60%20path%20logs%20the%20full%20error%20%2B%20traceback%2C%20but%20mapped%20%60DomainException%60s%20%28404%2C%20403%2C%20409%2C%20etc.%29%20silently%20return%20a%20response%20with%20no%20log%20entry.%20When%20these%20exceptions%20escape%20a%20route%20handler%20and%20land%20in%20the%20middleware%20it's%20usually%20unexpected%3B%20without%20a%20log%20line%20there%20is%20no%20server-side%20record%20to%20correlate%20with%20downstream%20reports%20of%20404%2F403%20errors.%20Consider%20at%20least%20a%20%60logger.warning%60%20%28without%20the%20traceback%29%20to%20preserve%20observability%20for%20these%20cases.%0A%0A%23%23%23%20Issue%203%20of%203%0Amodel-engine%2Fmodel_engine_server%2Fapi%2Fapp.py%3A54-62%0A**Several%20clearly%20user-facing%20%60DomainException%60s%20are%20absent%20from%20the%20map**%0A%0A%60InvalidRequestException%60%2C%20%60TriggerNameAlreadyExistsException%60%2C%20%60LLMFineTuningQuotaReached%60%2C%20%60CronSyntaxException%60%2C%20%60EndpointUnsupportedRequestException%60%2C%20and%20%60EndpointResourceInvalidRequestException%60%20all%20describe%20user-input%20errors%20with%20authored%20messages%2C%20yet%20they%20fall%20through%20to%20the%20generic%20500%20path.%20If%20any%20of%20these%20escape%20a%20route%20handler%20they%20will%20silently%20look%20like%20server%20bugs%20to%20callers%20instead%20of%20returning%20an%20actionable%204xx.%20Worth%20confirming%20whether%20these%20are%20intentionally%20deferred%20or%20simply%20overlooked%20when%20assembling%20the%20initial%20map.%0A%0A&repo=scaleapi%2Fllm-engine&pr=841&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
model-engine/model_engine_server/api/app.py:145
**`ExistingEndpointOperationInProgressException` message is silently dropped**

`ExistingEndpointOperationInProgressException.__init__` stores the message in `self.message` but never calls `super().__init__(message)`, so `self.args` stays empty and `str(e)` returns `''`. The fallback `str(e) or type(e).__name__` will always resolve to the class name — the 409 response will say `"ExistingEndpointOperationInProgressException"` instead of the actual conflict description. No test currently exercises this exception type so the bug is invisible in the test suite. A fix here or in the exception definition (`super().__init__(message)`) is needed to make the 409 surface the intended message.

### Issue 2 of 3
model-engine/model_engine_server/api/app.py:141-149
**No server-side logging for mapped 4xx domain exceptions**

The `_internal_error_response` path logs the full error + traceback, but mapped `DomainException`s (404, 403, 409, etc.) silently return a response with no log entry. When these exceptions escape a route handler and land in the middleware it's usually unexpected; without a log line there is no server-side record to correlate with downstream reports of 404/403 errors. Consider at least a `logger.warning` (without the traceback) to preserve observability for these cases.

### Issue 3 of 3
model-engine/model_engine_server/api/app.py:54-62
**Several clearly user-facing `DomainException`s are absent from the map**

`InvalidRequestException`, `TriggerNameAlreadyExistsException`, `LLMFineTuningQuotaReached`, `CronSyntaxException`, `EndpointUnsupportedRequestException`, and `EndpointResourceInvalidRequestException` all describe user-input errors with authored messages, yet they fall through to the generic 500 path. If any of these escape a route handler they will silently look like server bugs to callers instead of returning an actionable 4xx. Worth confirming whether these are intentionally deferred or simply overlooked when assembling the initial map.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(api): surface user-facing domain ex..."](https://github.com/scaleapi/llm-engine/commit/a17825eea8c578f6a9b4e7a3805d3f1ac2a7d15a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39127972)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->