### PR TITLE
[MLI-7222] test(api): parametrize cloud backend selection by cloud_provider

### DIFF
--- a/model-engine/tests/unit/api/test_dependencies.py
+++ b/model-engine/tests/unit/api/test_dependencies.py
@@ -4,16 +4,41 @@ import pytest
 from model_engine_server.api.dependencies import _get_external_interfaces
 from model_engine_server.common.config import HostedModelInferenceServiceConfig
 from model_engine_server.infra.gateways import (
+    ABSFileStorageGateway,
+    ABSFilesystemGateway,
+    ABSLLMArtifactGateway,
+    ASBInferenceAutoscalingMetricsGateway,
     GCSFileStorageGateway,
     GCSFilesystemGateway,
     GCSLLMArtifactGateway,
+    RedisInferenceAutoscalingMetricsGateway,
+    S3FilesystemGateway,
+    S3LLMArtifactGateway,
+)
+from model_engine_server.infra.gateways.resources.asb_queue_endpoint_resource_delegate import (
+    ASBQueueEndpointResourceDelegate,
 )
 from model_engine_server.infra.gateways.resources.gcp_pubsub_queue_endpoint_resource_delegate import (
     GcpPubSubQueueEndpointResourceDelegate,
 )
+from model_engine_server.infra.gateways.resources.onprem_queue_endpoint_resource_delegate import (
+    OnPremQueueEndpointResourceDelegate,
+)
+from model_engine_server.infra.gateways.resources.sqs_queue_endpoint_resource_delegate import (
+    SQSQueueEndpointResourceDelegate,
+)
+from model_engine_server.infra.gateways.s3_file_storage_gateway import S3FileStorageGateway
 from model_engine_server.infra.repositories import (
+    ABSFileLLMFineTuneEventsRepository,
+    ABSFileLLMFineTuneRepository,
+    ACRDockerRepository,
+    ECRDockerRepository,
     GARDockerRepository,
     GCSFileLLMFineTuneEventsRepository,
+    GCSFileLLMFineTuneRepository,
+    OnPremDockerRepository,
+    S3FileLLMFineTuneEventsRepository,
+    S3FileLLMFineTuneRepository,
 )
 
 
@@ -86,9 +111,85 @@ def test_default_task_queue_selection_when_celery_broker_type_redis_disabled():
         assert external_interfaces.inference_task_queue_gateway == sqs_gateway
 
 
-def test_gcp_provider_selects_gcp_implementations():
-    """Test that cloud_provider='gcp' wires the correct GCP implementations."""
+# Expected concrete backend class per cloud_provider. docker_repository is keyed on
+# registry_type (not cloud_provider): aws/azure/gcp drive it via a realistic prefix, onprem
+# via docker_registry_type since no prefix infers "onprem".
+_PROVIDER_CASES = [
+    pytest.param(
+        "aws",
+        "000000000000.dkr.ecr.us-east-1.amazonaws.com/my-repo",
+        None,
+        {
+            "queue_delegate": SQSQueueEndpointResourceDelegate,
+            "filesystem_gateway": S3FilesystemGateway,
+            "llm_artifact_gateway": S3LLMArtifactGateway,
+            "file_storage_gateway": S3FileStorageGateway,
+            "docker_repository": ECRDockerRepository,
+            "llm_fine_tune_repository": S3FileLLMFineTuneRepository,
+            "llm_fine_tune_events_repository": S3FileLLMFineTuneEventsRepository,
+            "inference_autoscaling_metrics_gateway": RedisInferenceAutoscalingMetricsGateway,
+        },
+        id="aws",
+    ),
+    pytest.param(
+        "azure",
+        "myregistry.azurecr.io/my-repo",
+        None,
+        {
+            "queue_delegate": ASBQueueEndpointResourceDelegate,
+            "filesystem_gateway": ABSFilesystemGateway,
+            "llm_artifact_gateway": ABSLLMArtifactGateway,
+            "file_storage_gateway": ABSFileStorageGateway,
+            "docker_repository": ACRDockerRepository,
+            "llm_fine_tune_repository": ABSFileLLMFineTuneRepository,
+            "llm_fine_tune_events_repository": ABSFileLLMFineTuneEventsRepository,
+            "inference_autoscaling_metrics_gateway": ASBInferenceAutoscalingMetricsGateway,
+        },
+        id="azure",
+    ),
+    pytest.param(
+        "gcp",
+        "us-docker.pkg.dev/my-project/my-repo",
+        None,
+        {
+            "queue_delegate": GcpPubSubQueueEndpointResourceDelegate,
+            "filesystem_gateway": GCSFilesystemGateway,
+            "llm_artifact_gateway": GCSLLMArtifactGateway,
+            "file_storage_gateway": GCSFileStorageGateway,
+            "docker_repository": GARDockerRepository,
+            "llm_fine_tune_repository": GCSFileLLMFineTuneRepository,
+            "llm_fine_tune_events_repository": GCSFileLLMFineTuneEventsRepository,
+            "inference_autoscaling_metrics_gateway": RedisInferenceAutoscalingMetricsGateway,
+        },
+        id="gcp",
+    ),
+    pytest.param(
+        "onprem",
+        "registry.internal/my-repo",
+        "onprem",
+        {
+            "queue_delegate": OnPremQueueEndpointResourceDelegate,
+            "filesystem_gateway": S3FilesystemGateway,
+            "llm_artifact_gateway": S3LLMArtifactGateway,
+            "file_storage_gateway": S3FileStorageGateway,
+            "docker_repository": OnPremDockerRepository,
+            "llm_fine_tune_repository": S3FileLLMFineTuneRepository,
+            "llm_fine_tune_events_repository": S3FileLLMFineTuneEventsRepository,
+            "inference_autoscaling_metrics_gateway": RedisInferenceAutoscalingMetricsGateway,
+        },
+        id="onprem",
+    ),
+]
 
+
+@pytest.mark.parametrize(
+    "cloud_provider, docker_repo_prefix, docker_registry_type, expected",
+    _PROVIDER_CASES,
+)
+def test_cloud_provider_selects_expected_backends(
+    cloud_provider, docker_repo_prefix, docker_registry_type, expected
+):
+    """Pin the concrete backend class selected for each cloud_provider."""
     with (
         patch("model_engine_server.api.dependencies.infra_config") as mock_config,
         patch("model_engine_server.api.dependencies.CIRCLECI", False),
@@ -96,30 +197,34 @@ def test_gcp_provider_selects_gcp_implementations():
         patch("model_engine_server.api.dependencies.get_tracing_gateway"),
         patch("model_engine_server.api.dependencies.aioredis"),
         patch("model_engine_server.api.dependencies.get_or_create_aioredis_pool"),
-        patch("model_engine_server.api.dependencies.ASBInferenceAutoscalingMetricsGateway"),
         patch("model_engine_server.api.dependencies.get_monitoring_metrics_gateway"),
     ):
         mock_config_instance = MagicMock()
-        mock_config_instance.cloud_provider = "gcp"
+        mock_config_instance.cloud_provider = cloud_provider
+        mock_config_instance.docker_repo_prefix = docker_repo_prefix
+        mock_config_instance.docker_registry_type = docker_registry_type
         mock_config_instance.celery_broker_type_redis = None
-        mock_config_instance.docker_repo_prefix = "us-docker.pkg.dev/my-project/my-repo"
-        mock_config_instance.docker_registry_type = None
+        mock_config_instance.gcp_project_id = "test-project"
         mock_config.return_value = mock_config_instance
 
-        mock_session = MagicMock()
-        external_interfaces = _get_external_interfaces(read_only=False, session=mock_session)
+        ei = _get_external_interfaces(read_only=False, session=MagicMock())
 
-        assert isinstance(external_interfaces.filesystem_gateway, GCSFilesystemGateway)
-        assert isinstance(external_interfaces.llm_artifact_gateway, GCSLLMArtifactGateway)
-        assert isinstance(external_interfaces.file_storage_gateway, GCSFileStorageGateway)
-        assert isinstance(external_interfaces.docker_repository, GARDockerRepository)
+        assert isinstance(ei.resource_gateway.queue_delegate, expected["queue_delegate"])
+        assert isinstance(ei.filesystem_gateway, expected["filesystem_gateway"])
+        assert isinstance(ei.llm_artifact_gateway, expected["llm_artifact_gateway"])
+        assert isinstance(ei.file_storage_gateway, expected["file_storage_gateway"])
+        assert isinstance(ei.docker_repository, expected["docker_repository"])
         assert isinstance(
-            external_interfaces.llm_fine_tune_events_repository,
-            GCSFileLLMFineTuneEventsRepository,
+            ei.llm_fine_tuning_service.llm_fine_tune_repository,
+            expected["llm_fine_tune_repository"],
         )
         assert isinstance(
-            external_interfaces.resource_gateway.queue_delegate,
-            GcpPubSubQueueEndpointResourceDelegate,
+            ei.llm_fine_tune_events_repository,
+            expected["llm_fine_tune_events_repository"],
+        )
+        assert isinstance(
+            ei.resource_gateway.inference_autoscaling_metrics_gateway,
+            expected["inference_autoscaling_metrics_gateway"],
         )
 
 


### PR DESCRIPTION
## Summary

Parametrized unit test pinning the concrete backend class selected for each `cloud_provider` (aws/azure/gcp/onprem) in the API dependency wiring. Replaces the single-provider `test_gcp_provider_selects_gcp_implementations`.

Test-only change.

Resolves [MLI-7222](https://linear.app/scale-epd/issue/MLI-7222).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the single-provider `test_gcp_provider_selects_gcp_implementations` test with a parametrized `test_cloud_provider_selects_expected_backends` that covers all four cloud backends (aws, azure, gcp, onprem) in one sweep. It also widens the assertion surface to include `llm_fine_tune_repository` and `inference_autoscaling_metrics_gateway`, both of which were unverified before.

- **Parametrization**: `_PROVIDER_CASES` drives four `pytest.param` entries; each pins the full set of concrete backend classes selected by `_get_external_interfaces` for that `cloud_provider`.
- **Broader assertions**: The new test adds `isinstance` checks for `llm_fine_tuning_service.llm_fine_tune_repository` and `resource_gateway.inference_autoscaling_metrics_gateway` that were absent from the previous GCP-only test.
- **Dropped unnecessary mock**: The old test patched `ASBInferenceAutoscalingMetricsGateway` even for GCP (where it is never instantiated). The new test omits that patch; for the azure case it correctly lets the real (no-`__init__`) class instantiate so that the `isinstance` assertion is meaningful.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Test-only change; no production code is modified and the new parametrized test correctly mirrors the wiring logic in dependencies.py for all four cloud backends.

Every expected class was cross-checked against the actual branch conditions in _get_external_interfaces. The docker registry inference (infer_registry_type) correctly maps the chosen prefixes to ecr/acr/gar, and the onprem case explicitly sets docker_registry_type to bypass prefix inference. Azure-specific classes (ABSFilesystemGateway, ASBInferenceAutoscalingMetricsGateway) have no __init__ that touches Azure SDKs, so dropping the ASBInferenceAutoscalingMetricsGateway mock is safe and makes the isinstance assertion meaningful. No logic gaps were found.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| model-engine/tests/unit/api/test_dependencies.py | Replaces the single-provider GCP test with a 4-provider parametrized test; imports, fixture data, and assertions all align correctly with the actual wiring logic in dependencies.py. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    CP[cloud_provider] --> AWS[aws]
    CP --> AZURE[azure]
    CP --> GCP[gcp]
    CP --> ONPREM[onprem]

    AWS --> AWS_Q[SQSQueueEndpointResourceDelegate]
    AWS --> AWS_FS[S3FilesystemGateway]
    AWS --> AWS_ART[S3LLMArtifactGateway]
    AWS --> AWS_FILE[S3FileStorageGateway]
    AWS --> AWS_DOCKER[ECRDockerRepository]
    AWS --> AWS_FT[S3FileLLMFineTuneRepository]
    AWS --> AWS_METRICS[RedisInferenceAutoscalingMetricsGateway]

    AZURE --> AZ_Q[ASBQueueEndpointResourceDelegate]
    AZURE --> AZ_FS[ABSFilesystemGateway]
    AZURE --> AZ_ART[ABSLLMArtifactGateway]
    AZURE --> AZ_FILE[ABSFileStorageGateway]
    AZURE --> AZ_DOCKER[ACRDockerRepository]
    AZURE --> AZ_FT[ABSFileLLMFineTuneRepository]
    AZURE --> AZ_METRICS[ASBInferenceAutoscalingMetricsGateway]

    GCP --> GCP_Q[GcpPubSubQueueEndpointResourceDelegate]
    GCP --> GCP_FS[GCSFilesystemGateway]
    GCP --> GCP_ART[GCSLLMArtifactGateway]
    GCP --> GCP_FILE[GCSFileStorageGateway]
    GCP --> GCP_DOCKER[GARDockerRepository]
    GCP --> GCP_FT[GCSFileLLMFineTuneRepository]
    GCP --> GCP_METRICS[RedisInferenceAutoscalingMetricsGateway]

    ONPREM --> OP_Q[OnPremQueueEndpointResourceDelegate]
    ONPREM --> OP_FS[S3FilesystemGateway]
    ONPREM --> OP_ART[S3LLMArtifactGateway]
    ONPREM --> OP_FILE[S3FileStorageGateway]
    ONPREM --> OP_DOCKER[OnPremDockerRepository]
    ONPREM --> OP_FT[S3FileLLMFineTuneRepository]
    ONPREM --> OP_METRICS[RedisInferenceAutoscalingMetricsGateway]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    CP[cloud_provider] --> AWS[aws]
    CP --> AZURE[azure]
    CP --> GCP[gcp]
    CP --> ONPREM[onprem]

    AWS --> AWS_Q[SQSQueueEndpointResourceDelegate]
    AWS --> AWS_FS[S3FilesystemGateway]
    AWS --> AWS_ART[S3LLMArtifactGateway]
    AWS --> AWS_FILE[S3FileStorageGateway]
    AWS --> AWS_DOCKER[ECRDockerRepository]
    AWS --> AWS_FT[S3FileLLMFineTuneRepository]
    AWS --> AWS_METRICS[RedisInferenceAutoscalingMetricsGateway]

    AZURE --> AZ_Q[ASBQueueEndpointResourceDelegate]
    AZURE --> AZ_FS[ABSFilesystemGateway]
    AZURE --> AZ_ART[ABSLLMArtifactGateway]
    AZURE --> AZ_FILE[ABSFileStorageGateway]
    AZURE --> AZ_DOCKER[ACRDockerRepository]
    AZURE --> AZ_FT[ABSFileLLMFineTuneRepository]
    AZURE --> AZ_METRICS[ASBInferenceAutoscalingMetricsGateway]

    GCP --> GCP_Q[GcpPubSubQueueEndpointResourceDelegate]
    GCP --> GCP_FS[GCSFilesystemGateway]
    GCP --> GCP_ART[GCSLLMArtifactGateway]
    GCP --> GCP_FILE[GCSFileStorageGateway]
    GCP --> GCP_DOCKER[GARDockerRepository]
    GCP --> GCP_FT[GCSFileLLMFineTuneRepository]
    GCP --> GCP_METRICS[RedisInferenceAutoscalingMetricsGateway]

    ONPREM --> OP_Q[OnPremQueueEndpointResourceDelegate]
    ONPREM --> OP_FS[S3FilesystemGateway]
    ONPREM --> OP_ART[S3LLMArtifactGateway]
    ONPREM --> OP_FILE[S3FileStorageGateway]
    ONPREM --> OP_DOCKER[OnPremDockerRepository]
    ONPREM --> OP_FT[S3FileLLMFineTuneRepository]
    ONPREM --> OP_METRICS[RedisInferenceAutoscalingMetricsGateway]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into lorenzonorcini/..."](https://github.com/scaleapi/llm-engine/commit/8b99fdcc39552cfe652192b645848721573b1779) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39362183)</sub>

<!-- /greptile_comment -->