### PR TITLE
feat(forwarding): instrument forwarder→vLLM hop with per-request timing (MLI-7224)

### DIFF
--- a/model-engine/model_engine_server/inference/domain/gateways/inference_monitoring_metrics_gateway.py
+++ b/model-engine/model_engine_server/inference/domain/gateways/inference_monitoring_metrics_gateway.py
@@ -10,6 +10,7 @@ inference to avoid importing stuff in user code that we don't need.)
 """
 
 from abc import ABC, abstractmethod
+from typing import List
 
 
 class InferenceMonitoringMetricsGateway(ABC):
@@ -48,5 +49,18 @@ class InferenceMonitoringMetricsGateway(ABC):
 
         Args:
             queue_name: The name of the Celery queue
+        """
+        pass
+
+    @abstractmethod
+    def emit_timing_metric(self, metric_name: str, value_ms: float, tags: List[str]):
+        """
+        Emit a latency/timing distribution metric (e.g. the per-request overhead the
+        forwarder sidecar adds on top of the vLLM round-trip).
+
+        Args:
+            metric_name: The fully-qualified metric name (e.g. scale_launch.forwarder.overhead_ms)
+            value_ms: The latency value in milliseconds
+            tags: Low-cardinality "key:value" tag strings (request_id is NOT a tag)
         """
         pass

--- a/model-engine/model_engine_server/inference/forwarding/forwarding.py
+++ b/model-engine/model_engine_server/inference/forwarding/forwarding.py
@@ -2,8 +2,9 @@ import ast
 import json
 import os
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
+from time import perf_counter
 from typing import Any, AsyncGenerator, Dict, Iterable, List, Optional, Sequence, Tuple
 
 import aiohttp
@@ -17,6 +18,9 @@ from model_engine_server.common.aiohttp_sse_client import EventSource
 from model_engine_server.core.loggers import logger_name, make_logger
 from model_engine_server.core.tracing import get_tracing_gateway
 from model_engine_server.inference.common import get_endpoint_config
+from model_engine_server.inference.domain.gateways.inference_monitoring_metrics_gateway import (
+    InferenceMonitoringMetricsGateway,
+)
 from model_engine_server.inference.infra.gateways.datadog_inference_monitoring_metrics_gateway import (
     DatadogInferenceMonitoringMetricsGateway,
 )
@@ -41,6 +45,44 @@ KEY_SERIALIZE_RESULTS_AS_STRING: str = "serialize_results_as_string"
 ENV_SERIALIZE_RESULTS_AS_STRING: str = "SERIALIZE_RESULTS_AS_STRING"
 
 DEFAULT_PORT: int = 5005
+
+# Forwarder timing metrics (milliseconds). The forwarder sidecar sits in front of the
+# vLLM/user process; these quantify the per-request overhead it adds on top of the vLLM
+# round-trip. Correlation is provided by the auto-injected dd.trace_id in logs, not by these
+# metrics (request_id is never a metric tag in this codebase).
+FORWARDER_METRIC_PREFIX: str = "scale_launch.forwarder"
+FORWARDER_OVERHEAD_METRIC: str = f"{FORWARDER_METRIC_PREFIX}.overhead_ms"
+FORWARDER_TOTAL_METRIC: str = f"{FORWARDER_METRIC_PREFIX}.total_ms"
+FORWARDER_VLLM_ROUNDTRIP_METRIC: str = f"{FORWARDER_METRIC_PREFIX}.vllm_roundtrip_ms"
+FORWARDER_TTFT_METRIC: str = f"{FORWARDER_METRIC_PREFIX}.ttft_ms"
+FORWARDER_VLLM_TTFT_METRIC: str = f"{FORWARDER_METRIC_PREFIX}.vllm_ttft_ms"
+
+
+def _build_forwarder_metric_tags(
+    request_type: str, route: str, endpoint_name: Optional[str]
+) -> List[str]:
+    """Low-cardinality metric tags, computed once per forwarder at load time."""
+    tags = [f"request_type:{request_type}", f"route:{route}"]
+    if endpoint_name:
+        tags.append(f"endpoint_name:{endpoint_name}")
+    return tags
+
+
+def _emit_forwarder_timing(
+    monitoring_metrics_gateway: Optional[InferenceMonitoringMetricsGateway],
+    tags: List[str],
+    metrics_ms: Dict[str, float],
+) -> None:
+    """Emit forwarder timing metrics. Never raises into the request hot path."""
+    if monitoring_metrics_gateway is None:
+        return
+    try:
+        for metric_name, value_ms in metrics_ms.items():
+            monitoring_metrics_gateway.emit_timing_metric(
+                metric_name=metric_name, value_ms=value_ms, tags=tags
+            )
+    except Exception:
+        logger.exception("Failed to emit forwarder timing metrics")
 
 
 class ModelEngineSerializationMixin:
@@ -169,8 +211,12 @@ class Forwarder(ModelEngineSerializationMixin):
     # We do this to avoid having to put this data in any sync response and only do it for async responses
     forward_http_status_in_body: bool
     post_inference_hooks_handler: Optional[PostInferenceHooksHandler] = None
+    monitoring_metrics_gateway: Optional[InferenceMonitoringMetricsGateway] = None
+    # Precomputed low-cardinality metric tags (request_type, route, endpoint_name); see load().
+    metric_tags: List[str] = field(default_factory=list)
 
     async def forward(self, json_payload: Any, trace_config: Optional[str] = None) -> Any:
+        t0 = perf_counter()
         json_payload, using_serialize_results_as_string = self.unwrap_json_payload(json_payload)
         json_payload_repr = json_payload.keys() if hasattr(json_payload, "keys") else json_payload
 
@@ -181,6 +227,7 @@ class Forwarder(ModelEngineSerializationMixin):
                 headers = {"Content-Type": "application/json"}
                 if trace_config and tracing_gateway:
                     headers.update(tracing_gateway.encode_trace_headers())
+                t_vllm_start = perf_counter()
                 response_raw = await aioclient.post(
                     self.predict_endpoint,
                     json=json_payload,
@@ -189,6 +236,7 @@ class Forwarder(ModelEngineSerializationMixin):
                 response = await response_raw.json(
                     content_type=None
                 )  # [Bug] upstream service doesn't always have the content type header set which causes aiohttp to error
+                vllm_roundtrip_ms = (perf_counter() - t_vllm_start) * 1000.0
 
         except Exception:
             logger.exception(
@@ -219,6 +267,28 @@ class Forwarder(ModelEngineSerializationMixin):
                 response,
                 response_raw.status,
             )
+
+        total_ms = (perf_counter() - t0) * 1000.0
+        forwarder_overhead_ms = total_ms - vllm_roundtrip_ms
+        # dd.trace_id is auto-injected into this log record, providing request correlation.
+        logger.info(
+            "forwarder sync request timing",
+            extra={
+                "request_type": "sync",
+                "forwarder_total_ms": total_ms,
+                "vllm_roundtrip_ms": vllm_roundtrip_ms,
+                "forwarder_overhead_ms": forwarder_overhead_ms,
+            },
+        )
+        _emit_forwarder_timing(
+            self.monitoring_metrics_gateway,
+            self.metric_tags,
+            {
+                FORWARDER_TOTAL_METRIC: total_ms,
+                FORWARDER_VLLM_ROUNDTRIP_METRIC: vllm_roundtrip_ms,
+                FORWARDER_OVERHEAD_METRIC: forwarder_overhead_ms,
+            },
+        )
 
         if self.forward_http_status:
             return JSONResponse(content=response, status_code=response_raw.status)
@@ -376,8 +446,11 @@ class LoadForwarder:
         else:
             serialize_results_as_string = self.serialize_results_as_string
 
+        monitoring_metrics_gateway = DatadogInferenceMonitoringMetricsGateway()
+        endpoint_name: Optional[str] = None
         try:
             endpoint_config = get_endpoint_config()
+            endpoint_name = endpoint_config.endpoint_name
             handler = PostInferenceHooksHandler(
                 endpoint_name=endpoint_config.endpoint_name,
                 bundle_name=endpoint_config.bundle_name,
@@ -387,7 +460,7 @@ class LoadForwarder:
                 billing_tags=endpoint_config.billing_tags,
                 default_callback_url=endpoint_config.default_callback_url,
                 default_callback_auth=endpoint_config.default_callback_auth,
-                monitoring_metrics_gateway=DatadogInferenceMonitoringMetricsGateway(),
+                monitoring_metrics_gateway=monitoring_metrics_gateway,
                 endpoint_id=endpoint_config.endpoint_id,
                 endpoint_type=endpoint_config.endpoint_type,
                 bundle_id=endpoint_config.bundle_id,
@@ -405,6 +478,8 @@ class LoadForwarder:
             wrap_response=self.wrap_response,
             forward_http_status=self.forward_http_status,
             forward_http_status_in_body=self.forward_http_status_in_body,
+            monitoring_metrics_gateway=monitoring_metrics_gateway,
+            metric_tags=_build_forwarder_metric_tags("sync", self.predict_route, endpoint_name),
         )
 
 
@@ -428,8 +503,38 @@ class StreamingForwarder(ModelEngineSerializationMixin):
     model_engine_unwrap: bool
     serialize_results_as_string: bool
     post_inference_hooks_handler: Optional[PostInferenceHooksHandler] = None  # unused for now
+    monitoring_metrics_gateway: Optional[InferenceMonitoringMetricsGateway] = None
+    # Precomputed low-cardinality metric tags (request_type, route, endpoint_name); see load().
+    metric_tags: List[str] = field(default_factory=list)
 
-    async def forward(self, json_payload: Any) -> AsyncGenerator[Any, None]:  # pragma: no cover
+    def _emit_ttft_timing(self, t0: float, t_vllm_start: float) -> None:
+        """Emit time-to-first-token timing, called when the first event arrives."""
+        now = perf_counter()
+        forwarder_ttft_ms = (now - t0) * 1000.0
+        vllm_ttft_ms = (now - t_vllm_start) * 1000.0
+        forwarder_overhead_ms = forwarder_ttft_ms - vllm_ttft_ms
+        # dd.trace_id is auto-injected into this log record for correlation.
+        logger.info(
+            "forwarder stream request timing",
+            extra={
+                "request_type": "stream",
+                "forwarder_ttft_ms": forwarder_ttft_ms,
+                "vllm_ttft_ms": vllm_ttft_ms,
+                "forwarder_overhead_ms": forwarder_overhead_ms,
+            },
+        )
+        _emit_forwarder_timing(
+            self.monitoring_metrics_gateway,
+            self.metric_tags,
+            {
+                FORWARDER_TTFT_METRIC: forwarder_ttft_ms,
+                FORWARDER_VLLM_TTFT_METRIC: vllm_ttft_ms,
+                FORWARDER_OVERHEAD_METRIC: forwarder_overhead_ms,
+            },
+        )
+
+    async def forward(self, json_payload: Any) -> AsyncGenerator[Any, None]:
+        t0 = perf_counter()
         json_payload, using_serialize_results_as_string = self.unwrap_json_payload(json_payload)
         json_payload_repr = json_payload.keys() if hasattr(json_payload, "keys") else json_payload
 
@@ -438,6 +543,7 @@ class StreamingForwarder(ModelEngineSerializationMixin):
         try:
             response: aiohttp.ClientResponse
             async with aiohttp.ClientSession(json_serialize=_serialize_json) as aioclient:
+                t_vllm_start = perf_counter()
                 response = await aioclient.post(
                     self.predict_endpoint,
                     json=json_payload,
@@ -450,7 +556,11 @@ class StreamingForwarder(ModelEngineSerializationMixin):
                     )  # [Bug] upstream service doesn't always have the content type header set which causes aiohttp to error
 
                 async with EventSource(response=response) as event_source:
+                    ttft_recorded = False
                     async for event in event_source:
+                        if not ttft_recorded:
+                            ttft_recorded = True
+                            self._emit_ttft_timing(t0, t_vllm_start)
                         yield self.get_response_payload_stream(
                             using_serialize_results_as_string, event.data
                         )
@@ -598,8 +708,11 @@ class LoadStreamingForwarder:
         else:
             serialize_results_as_string = self.serialize_results_as_string
 
+        monitoring_metrics_gateway = DatadogInferenceMonitoringMetricsGateway()
+        endpoint_name: Optional[str] = None
         try:
             endpoint_config = get_endpoint_config()
+            endpoint_name = endpoint_config.endpoint_name
             handler = PostInferenceHooksHandler(
                 endpoint_name=endpoint_config.endpoint_name,
                 bundle_name=endpoint_config.bundle_name,
@@ -609,7 +722,7 @@ class LoadStreamingForwarder:
                 billing_tags=endpoint_config.billing_tags,
                 default_callback_url=endpoint_config.default_callback_url,
                 default_callback_auth=endpoint_config.default_callback_auth,
-                monitoring_metrics_gateway=DatadogInferenceMonitoringMetricsGateway(),
+                monitoring_metrics_gateway=monitoring_metrics_gateway,
                 endpoint_id=endpoint_config.endpoint_id,
                 endpoint_type=endpoint_config.endpoint_type,
                 bundle_id=endpoint_config.bundle_id,
@@ -624,6 +737,8 @@ class LoadStreamingForwarder:
             model_engine_unwrap=self.model_engine_unwrap,
             serialize_results_as_string=serialize_results_as_string,
             post_inference_hooks_handler=handler,
+            monitoring_metrics_gateway=monitoring_metrics_gateway,
+            metric_tags=_build_forwarder_metric_tags("stream", self.predict_route, endpoint_name),
         )
 
 

--- a/model-engine/model_engine_server/inference/forwarding/forwarding.py
+++ b/model-engine/model_engine_server/inference/forwarding/forwarding.py
@@ -507,11 +507,10 @@ class StreamingForwarder(ModelEngineSerializationMixin):
     # Precomputed low-cardinality metric tags (request_type, route, endpoint_name); see load().
     metric_tags: List[str] = field(default_factory=list)
 
-    def _emit_ttft_timing(self, t0: float, t_vllm_start: float) -> None:
+    def _emit_ttft_timing(self, t0: float, t_vllm_start: float, t_first_event: float) -> None:
         """Emit time-to-first-token timing, called when the first event arrives."""
-        now = perf_counter()
-        forwarder_ttft_ms = (now - t0) * 1000.0
-        vllm_ttft_ms = (now - t_vllm_start) * 1000.0
+        forwarder_ttft_ms = (t_first_event - t0) * 1000.0
+        vllm_ttft_ms = (t_first_event - t_vllm_start) * 1000.0
         forwarder_overhead_ms = forwarder_ttft_ms - vllm_ttft_ms
         # dd.trace_id is auto-injected into this log record for correlation.
         logger.info(
@@ -560,7 +559,7 @@ class StreamingForwarder(ModelEngineSerializationMixin):
                     async for event in event_source:
                         if not ttft_recorded:
                             ttft_recorded = True
-                            self._emit_ttft_timing(t0, t_vllm_start)
+                            self._emit_ttft_timing(t0, t_vllm_start, perf_counter())
                         yield self.get_response_payload_stream(
                             using_serialize_results_as_string, event.data
                         )

--- a/model-engine/model_engine_server/inference/infra/gateways/datadog_inference_monitoring_metrics_gateway.py
+++ b/model-engine/model_engine_server/inference/infra/gateways/datadog_inference_monitoring_metrics_gateway.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from datadog import statsd
 from model_engine_server.inference.domain.gateways.inference_monitoring_metrics_gateway import (
     InferenceMonitoringMetricsGateway,
@@ -18,6 +20,9 @@ class DatadogInferenceMonitoringMetricsGateway(InferenceMonitoringMetricsGateway
 
     def emit_async_task_stuck_metric(self, queue_name: str):
         statsd.increment("scale_launch.async_task.stuck.count", tags=[f"queue_name:{queue_name}"])
+
+    def emit_timing_metric(self, metric_name: str, value_ms: float, tags: List[str]):
+        statsd.distribution(metric_name, value_ms, tags=tags)
 
     def emit_batch_completions_metric(
         self,

--- a/model-engine/tests/unit/inference/test_forwarding.py
+++ b/model-engine/tests/unit/inference/test_forwarding.py
@@ -1,16 +1,25 @@
 import json
 from dataclasses import dataclass
-from typing import Mapping
+from typing import List, Mapping, Tuple
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from aioresponses import aioresponses
 from fastapi import HTTPException
 from fastapi.responses import JSONResponse
 from model_engine_server.core.utils.env import environment
 from model_engine_server.domain.entities import ModelEndpointConfig
+from model_engine_server.inference.domain.gateways.inference_monitoring_metrics_gateway import (
+    InferenceMonitoringMetricsGateway,
+)
 from model_engine_server.inference.forwarding.forwarding import (
     ENV_SERIALIZE_RESULTS_AS_STRING,
+    FORWARDER_OVERHEAD_METRIC,
+    FORWARDER_TOTAL_METRIC,
+    FORWARDER_TTFT_METRIC,
+    FORWARDER_VLLM_ROUNDTRIP_METRIC,
+    FORWARDER_VLLM_TTFT_METRIC,
     KEY_SERIALIZE_RESULTS_AS_STRING,
     Forwarder,
     LoadForwarder,
@@ -582,6 +591,25 @@ def test_streaming_forwarder_loader():
     _check_streaming(response)
 
 
+@pytest.mark.asyncio
+async def test_streaming_forward_relays_chunks():
+    """Async StreamingForwarder.forward() relays each upstream SSE chunk unchanged."""
+    endpoint = "http://localhost:5005/stream"
+    fwd = StreamingForwarder(
+        endpoint,
+        model_engine_unwrap=False,
+        serialize_results_as_string=False,
+        post_inference_hooks_handler=None,
+    )
+    sse_body = f"data: {json.dumps(PAYLOAD)}\n\ndata: {PAYLOAD_END}\n\n"
+    with aioresponses() as aio_mock:
+        aio_mock.post(
+            endpoint, status=200, body=sse_body, headers={"content-type": "text/event-stream"}
+        )
+        chunks = [chunk async for chunk in fwd.forward(dict(PAYLOAD))]
+    assert chunks == [{"result": PAYLOAD}, {"result": PAYLOAD_END}]
+
+
 # Passthrough forwarder tests
 @pytest.mark.asyncio
 async def test_passthrough_forwarder():
@@ -704,3 +732,179 @@ def test_load_passthrough_forwarder_validation():
     # Test empty healthcheck route
     with pytest.raises(ValueError, match="healthcheck route must be non-empty"):
         LoadPassthroughForwarder(healthcheck_route="").load(None, None)  # type: ignore
+
+
+# ---- Forwarder timing instrumentation ----
+
+
+class FakeInferenceMonitoringMetricsGateway(InferenceMonitoringMetricsGateway):
+    """Records emitted timing metrics so tests can assert on them."""
+
+    def __init__(self):
+        self.timing_calls: List[Tuple[str, float, List[str]]] = []
+
+    def emit_attempted_post_inference_hook(self, hook: str):
+        pass
+
+    def emit_successful_post_inference_hook(self, hook: str):
+        pass
+
+    def emit_async_task_received_metric(self, queue_name: str):
+        pass
+
+    def emit_async_task_stuck_metric(self, queue_name: str):
+        pass
+
+    def emit_timing_metric(self, metric_name: str, value_ms: float, tags: List[str]):
+        self.timing_calls.append((metric_name, value_ms, tags))
+
+    def by_name(self) -> Mapping[str, Tuple[float, List[str]]]:
+        return {name: (value_ms, tags) for name, value_ms, tags in self.timing_calls}
+
+
+SYNC_ROUTE = "/v1/chat/completions"
+SYNC_ENDPOINT = f"http://localhost:5005{SYNC_ROUTE}"
+SYNC_TAGS = ["request_type:sync", f"route:{SYNC_ROUTE}", "endpoint_name:test-endpoint"]
+STREAM_TAGS = ["request_type:stream", f"route:{SYNC_ROUTE}", "endpoint_name:test-endpoint"]
+
+
+@pytest.mark.asyncio
+async def test_forward_emits_sync_timing_metrics():
+    metrics_gateway = FakeInferenceMonitoringMetricsGateway()
+    fwd = Forwarder(
+        SYNC_ENDPOINT,
+        model_engine_unwrap=False,
+        serialize_results_as_string=False,
+        post_inference_hooks_handler=None,
+        wrap_response=True,
+        forward_http_status=False,
+        forward_http_status_in_body=False,
+        monitoring_metrics_gateway=metrics_gateway,
+        metric_tags=SYNC_TAGS,
+    )
+
+    # Scripted clock: t0=0, t_vllm_start=1, vllm end=3, total end=5 (seconds).
+    # roundtrip brackets only the post+json (1->3); total brackets entry->exit (0->5).
+    with (
+        aioresponses() as aio_mock,
+        mock.patch(
+            "model_engine_server.inference.forwarding.forwarding.perf_counter",
+            side_effect=[0.0, 1.0, 3.0, 5.0],
+        ),
+    ):
+        aio_mock.post(SYNC_ENDPOINT, status=200, payload=dict(PAYLOAD))
+        response = await fwd.forward(dict(PAYLOAD))
+
+    assert response == {"result": PAYLOAD}  # happy-path response unchanged
+
+    emitted = metrics_gateway.by_name()
+    assert emitted[FORWARDER_TOTAL_METRIC][0] == 5000.0
+    assert emitted[FORWARDER_VLLM_ROUNDTRIP_METRIC][0] == 2000.0
+    assert emitted[FORWARDER_OVERHEAD_METRIC][0] == 3000.0
+    # overhead == total - roundtrip
+    assert (
+        emitted[FORWARDER_OVERHEAD_METRIC][0]
+        == emitted[FORWARDER_TOTAL_METRIC][0] - emitted[FORWARDER_VLLM_ROUNDTRIP_METRIC][0]
+    )
+    assert emitted[FORWARDER_OVERHEAD_METRIC][1] == SYNC_TAGS
+
+
+@pytest.mark.asyncio
+async def test_forward_emits_streaming_ttft_metrics():
+    metrics_gateway = FakeInferenceMonitoringMetricsGateway()
+    fwd = StreamingForwarder(
+        SYNC_ENDPOINT,
+        model_engine_unwrap=False,
+        serialize_results_as_string=False,
+        post_inference_hooks_handler=None,
+        monitoring_metrics_gateway=metrics_gateway,
+        metric_tags=STREAM_TAGS,
+    )
+
+    sse_body = 'data: {"hello": "world"}\n\ndata: [DONE]\n\n'
+    # Scripted clock: t0=0, t_vllm_start=1, first-event=4 (seconds).
+    with (
+        aioresponses() as aio_mock,
+        mock.patch(
+            "model_engine_server.inference.forwarding.forwarding.perf_counter",
+            side_effect=[0.0, 1.0, 4.0],
+        ),
+    ):
+        aio_mock.post(
+            SYNC_ENDPOINT,
+            status=200,
+            body=sse_body,
+            headers={"content-type": "text/event-stream"},
+        )
+        chunks = [chunk async for chunk in fwd.forward(dict(PAYLOAD))]
+
+    assert len(chunks) == 2  # sanity: stream was driven (contents asserted elsewhere)
+
+    emitted = metrics_gateway.by_name()
+    assert emitted[FORWARDER_TTFT_METRIC][0] == 4000.0
+    assert emitted[FORWARDER_VLLM_TTFT_METRIC][0] == 3000.0
+    assert emitted[FORWARDER_OVERHEAD_METRIC][0] == 1000.0
+    # overhead == forwarder_ttft - vllm_ttft
+    assert (
+        emitted[FORWARDER_OVERHEAD_METRIC][0]
+        == emitted[FORWARDER_TTFT_METRIC][0] - emitted[FORWARDER_VLLM_TTFT_METRIC][0]
+    )
+    assert emitted[FORWARDER_OVERHEAD_METRIC][1] == STREAM_TAGS
+
+
+@pytest.mark.asyncio
+async def test_forward_without_metrics_gateway_is_noop():
+    """A forwarder with no metrics gateway must still serve the happy path."""
+    fwd = Forwarder(
+        SYNC_ENDPOINT,
+        model_engine_unwrap=False,
+        serialize_results_as_string=False,
+        post_inference_hooks_handler=None,
+        wrap_response=True,
+        forward_http_status=False,
+        forward_http_status_in_body=False,
+        monitoring_metrics_gateway=None,
+    )
+    with aioresponses() as aio_mock:
+        aio_mock.post(SYNC_ENDPOINT, status=200, payload=dict(PAYLOAD))
+        response = await fwd.forward(dict(PAYLOAD))
+    assert response == {"result": PAYLOAD}
+
+
+@mock.patch("requests.post", mocked_post)
+@mock.patch("requests.get", mocked_get)
+@mock.patch(
+    "model_engine_server.inference.forwarding.forwarding.get_endpoint_config",
+    mocked_get_endpoint_config,
+)
+def test_loaders_set_metrics_gateway_and_tags():
+    fwd = LoadForwarder().load(None, None)  # type: ignore
+    assert fwd.monitoring_metrics_gateway is not None
+    assert fwd.metric_tags == [
+        "request_type:sync",
+        "route:/predict",
+        "endpoint_name:test_endpoint_name",
+    ]
+
+    stream_fwd = LoadStreamingForwarder().load(None, None)  # type: ignore
+    assert stream_fwd.monitoring_metrics_gateway is not None
+    assert stream_fwd.metric_tags == [
+        "request_type:stream",
+        "route:/predict",
+        "endpoint_name:test_endpoint_name",
+    ]
+
+
+@mock.patch("requests.post", mocked_post)
+@mock.patch("requests.get", mocked_get)
+@mock.patch(
+    "model_engine_server.inference.forwarding.forwarding.get_endpoint_config",
+    side_effect=RuntimeError("no endpoint config"),
+)
+def test_loader_survives_endpoint_config_failure(_mock_config):
+    # Even when endpoint config (and thus the hooks handler) fails, the forwarder still gets a
+    # metrics gateway; tags degrade to omit endpoint_name.
+    fwd = LoadForwarder().load(None, None)  # type: ignore
+    assert fwd.monitoring_metrics_gateway is not None
+    assert fwd.post_inference_hooks_handler is None
+    assert fwd.metric_tags == ["request_type:sync", "route:/predict"]


### PR DESCRIPTION
## What
Instruments the async `Forwarder.forward()` and `StreamingForwarder.forward()` methods to quantify the per-request overhead the forwarder sidecar adds on top of the vLLM round-trip.

## Changes
- Add `emit_timing_metric(metric_name, value_ms, tags)` to the inference monitoring gateway interface and its Datadog impl (`statsd.distribution`).
- Sync path emits `total_ms`, `vllm_roundtrip_ms`, `overhead_ms` (= total − roundtrip).
- Streaming path emits `ttft_ms`, `vllm_ttft_ms`, `overhead_ms` at first-event.
- Same timings logged as structured fields, correlated via the auto-injected `dd.trace_id`.
- Metrics prefixed `scale_launch.forwarder.*`; tags `request_type`, `route`, `endpoint_name` (no `env`, DD_ENV handles it). Tags computed once at `load()` time.
- Gateway is constructed before the `get_endpoint_config()` try block so the forwarder keeps emitting even when endpoint config is unavailable.

## Tests
- Unit tests drive both `forward()` methods with `aioresponses` and a scripted `perf_counter`, asserting each field is emitted with expected values and tags.
- Happy-path response/stream verified unchanged; no-gateway path is a no-op.

Units are milliseconds (documented deviation from the codebase's seconds convention, justified by single-digit-ms overhead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR instruments the `Forwarder` and `StreamingForwarder` sidecars to quantify per-request overhead relative to the vLLM round-trip, emitting `statsd.distribution` metrics and structured log fields correlated via `dd.trace_id`.

- Adds `emit_timing_metric` to the `InferenceMonitoringMetricsGateway` interface and its Datadog implementation; tags (`request_type`, `route`, `endpoint_name`) are computed once at `load()` time and the gateway is constructed before the `get_endpoint_config()` try-block so instrumentation survives config failures.
- Sync path records `total_ms`, `vllm_roundtrip_ms`, and `overhead_ms`; streaming path records `ttft_ms`, `vllm_ttft_ms`, and `overhead_ms` at first-event arrival.
- Unit tests cover both paths with a scripted `perf_counter`, assert metric values and tags, verify the no-gateway no-op, and confirm loader resilience when endpoint config is unavailable.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The instrumentation is well-isolated behind try/except and no-op guards, so the hot request path cannot be broken by metric emission failures. The one concern is the `endpoint_name` metric tag, which is user-defined and grows unboundedly across all historical deployments — worth verifying with the platform team before this ships to production.

The timing logic, exception handling, and test coverage are solid. The `endpoint_name` tag accumulates one unique Datadog timeseries per ever-created endpoint name, which can compound costs at scale and violates the team's high-cardinality tag policy. That warrants a #platform-help check before merging.

model-engine/model_engine_server/inference/forwarding/forwarding.py — the `_build_forwarder_metric_tags` helper and its callers in `LoadForwarder.load()` and `LoadStreamingForwarder.load()` where `endpoint_name` is added as a tag.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| model-engine/model_engine_server/inference/forwarding/forwarding.py | Adds per-request timing instrumentation to sync and streaming forwarders; `endpoint_name` metric tag is potentially high-cardinality (unbounded unique values across all historical deployments). |
| model-engine/model_engine_server/inference/domain/gateways/inference_monitoring_metrics_gateway.py | Adds `emit_timing_metric(metric_name, value_ms, tags)` abstract method to the gateway interface; minimal, correct change. |
| model-engine/model_engine_server/inference/infra/gateways/datadog_inference_monitoring_metrics_gateway.py | Implements `emit_timing_metric` via `statsd.distribution`; correct and consistent with other metric methods. |
| model-engine/tests/unit/inference/test_forwarding.py | Adds comprehensive timing tests with scripted `perf_counter` mocking; happy path, tag assertions, no-gateway no-op, and loader survival tests all look correct. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Client
    participant F as Forwarder/StreamingForwarder
    participant V as vLLM

    C->>F: forward(json_payload)
    Note over F: t0 = perf_counter()

    F->>F: unwrap_json_payload()
    Note over F: t_vllm_start = perf_counter()

    F->>V: POST predict_endpoint
    V-->>F: response (sync) / SSE stream (streaming)
    Note over F: vllm_roundtrip_ms = (now - t_vllm_start) × 1000

    alt Streaming: first event
        Note over F: _emit_ttft_timing(t0, t_vllm_start, perf_counter())
        F->>F: emit ttft_ms, vllm_ttft_ms, overhead_ms
    end

    F->>F: get_response_payload / wrap response
    Note over F: total_ms = (now - t0) × 1000
    F->>F: _emit_forwarder_timing(total_ms, vllm_roundtrip_ms, overhead_ms)
    F->>F: logger.info(timing fields + dd.trace_id)
    F->>F: statsd.distribution × N metrics

    F-->>C: response / async generator
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Client
    participant F as Forwarder/StreamingForwarder
    participant V as vLLM

    C->>F: forward(json_payload)
    Note over F: t0 = perf_counter()

    F->>F: unwrap_json_payload()
    Note over F: t_vllm_start = perf_counter()

    F->>V: POST predict_endpoint
    V-->>F: response (sync) / SSE stream (streaming)
    Note over F: vllm_roundtrip_ms = (now - t_vllm_start) × 1000

    alt Streaming: first event
        Note over F: _emit_ttft_timing(t0, t_vllm_start, perf_counter())
        F->>F: emit ttft_ms, vllm_ttft_ms, overhead_ms
    end

    F->>F: get_response_payload / wrap response
    Note over F: total_ms = (now - t0) × 1000
    F->>F: _emit_forwarder_timing(total_ms, vllm_roundtrip_ms, overhead_ms)
    F->>F: logger.info(timing fields + dd.trace_id)
    F->>F: statsd.distribution × N metrics

    F-->>C: response / async generator
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(forwarding): sample TTFT timestamp a..."](https://github.com/scaleapi/llm-engine/commit/edb0cf896b01c66aff2b9fc97f9bd259d4418b0e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39201096)</sub>

**Context used:**

- Rule used - # Datadog High-Cardinality Tag Guard

**What:** Pr... ([source](https://app.greptile.com/scale-ai/-/custom-context?memory=3995666a-dc2a-4909-84bd-93d7ab0f3c6a))

<!-- /greptile_comment -->