### PR TITLE
fix(fips): upgrade base image to Python 3.11 for numpy compatibility

### DIFF
--- a/model-engine/Dockerfile.fips
+++ b/model-engine/Dockerfile.fips
@@ -1,4 +1,4 @@
-FROM cgr.dev/scale.com/python-fips:3.10.20-r7-dev
+FROM cgr.dev/scale.com/python-fips:3.11-dev
 WORKDIR /workspace
 USER root
 
@@ -17,7 +17,7 @@ RUN apk update && apk add \
             jq \
             gcc \
             glibc-dev \
-            python-3.10-dev \
+            python-3.11-dev \
             libffi-dev \
             openssl-dev \
             build-base \


### PR DESCRIPTION
## Summary

- Upgrades `Dockerfile.fips` base image from Python 3.10 FIPS to Python 3.11 FIPS
- numpy>=2.3.0 dropped Python 3.10 support; numpy 2.4.4 (latest, required by Trivy remediation GFD-2481) requires Python >=3.11
- Updates all in-file Python version pins (`python-3.10-dev` apk package → `python-3.11-dev`) to 3.11

## Context

This is the llm-engine half of GFD-2481 (Trivy App Vulnerability Remediation). The Harbor replication policy for `scale.com/python-fips` 3.11 images is being added in a parallel MR. This PR upgrades the Dockerfile to consume that new image.

## Test plan

- [ ] CI pipeline builds successfully with the new base image
- [ ] No Python 3.10-specific import errors at container startup
- [ ] numpy 2.4.4 (or latest) installs cleanly
- [ ] Trivy scan shows no remaining Python 3.10 CVEs in base image layer

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Updates `model-engine/Dockerfile.fips` to use the Python 3.11 FIPS base image.
- Updates the apk development headers from `python-3.10-dev` to `python-3.11-dev`.
- Leaves the existing FIPS dependency installation flow unchanged.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Merge appears safe based on the scoped Dockerfile-only change.

The change is limited to updating the FIPS Python base image and matching development header package pins, with no review comments identified.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- - Before-state: The base Dockerfile used Python 3.10 pins and attempted to install numpy\>=2.4.0, which failed with a No matching distribution error and exit code 1.
- - After-state: The head Dockerfile uses Python 3.11 pins and numpy installs successfully (numpy-2.4.6) with runtime 3.11.6 and exit code 0.
- - Both artifacts indicate the build/run could not run because docker was not found, so full image build/run was skipped.

<a href="https://app.greptile.com/trex/runs/12047724/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `model-engine/Dockerfile.fips`, line 40 ([link](https://github.com/scaleapi/llm-engine/blob/acef720b49e8dcaf01e1ea7104b34fb38f1f360e/model-engine/Dockerfile.fips#L40)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Update test dependency** This image now builds on Python 3.11, but it still installs `requirements-test.txt`, which pins `coverage==5.5`. That coverage release predates Python 3.11 support and has no `cp311` wheel, so this Docker build can fail while building the old C extension from source before it reaches the app requirements. Please bump the pinned coverage version in `requirements-test.txt` to a Python 3.11-compatible release, or stop installing test dependencies in this image if they are not needed.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: model-engine/Dockerfile.fips
   Line: 40

   Comment:
   **Update test dependency** This image now builds on Python 3.11, but it still installs `requirements-test.txt`, which pins `coverage==5.5`. That coverage release predates Python 3.11 support and has no `cp311` wheel, so this Docker build can fail while building the old C extension from source before it reaches the app requirements. Please bump the pinned coverage version in `requirements-test.txt` to a Python 3.11-compatible release, or stop installing test dependencies in this image if they are not needed.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20model-engine%2FDockerfile.fips%0ALine%3A%2040%0A%0AComment%3A%0A**Update%20test%20dependency**%20This%20image%20now%20builds%20on%20Python%203.11%2C%20but%20it%20still%20installs%20%60requirements-test.txt%60%2C%20which%20pins%20%60coverage%3D%3D5.5%60.%20That%20coverage%20release%20predates%20Python%203.11%20support%20and%20has%20no%20%60cp311%60%20wheel%2C%20so%20this%20Docker%20build%20can%20fail%20while%20building%20the%20old%20C%20extension%20from%20source%20before%20it%20reaches%20the%20app%20requirements.%20Please%20bump%20the%20pinned%20coverage%20version%20in%20%60requirements-test.txt%60%20to%20a%20Python%203.11-compatible%20release%2C%20or%20stop%20installing%20test%20dependencies%20in%20this%20image%20if%20they%20are%20not%20needed.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=847&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20model-engine%2FDockerfile.fips%0ALine%3A%2040%0A%0AComment%3A%0A**Update%20test%20dependency**%20This%20image%20now%20builds%20on%20Python%203.11%2C%20but%20it%20still%20installs%20%60requirements-test.txt%60%2C%20which%20pins%20%60coverage%3D%3D5.5%60.%20That%20coverage%20release%20predates%20Python%203.11%20support%20and%20has%20no%20%60cp311%60%20wheel%2C%20so%20this%20Docker%20build%20can%20fail%20while%20building%20the%20old%20C%20extension%20from%20source%20before%20it%20reaches%20the%20app%20requirements.%20Please%20bump%20the%20pinned%20coverage%20version%20in%20%60requirements-test.txt%60%20to%20a%20Python%203.11-compatible%20release%2C%20or%20stop%20installing%20test%20dependencies%20in%20this%20image%20if%20they%20are%20not%20needed.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fllm-engine&pr=847&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fllm-engine%22%20on%20the%20existing%20branch%20%22pubsect%2FGFD-2481-dockerfile-fips-python311%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22pubsect%2FGFD-2481-dockerfile-fips-python311%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20model-engine%2FDockerfile.fips%0ALine%3A%2040%0A%0AComment%3A%0A**Update%20test%20dependency**%20This%20image%20now%20builds%20on%20Python%203.11%2C%20but%20it%20still%20installs%20%60requirements-test.txt%60%2C%20which%20pins%20%60coverage%3D%3D5.5%60.%20That%20coverage%20release%20predates%20Python%203.11%20support%20and%20has%20no%20%60cp311%60%20wheel%2C%20so%20this%20Docker%20build%20can%20fail%20while%20building%20the%20old%20C%20extension%20from%20source%20before%20it%20reaches%20the%20app%20requirements.%20Please%20bump%20the%20pinned%20coverage%20version%20in%20%60requirements-test.txt%60%20to%20a%20Python%203.11-compatible%20release%2C%20or%20stop%20installing%20test%20dependencies%20in%20this%20image%20if%20they%20are%20not%20needed.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fllm-engine&pr=847&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(fips): upgrade base image to Python ..."](https://github.com/scaleapi/llm-engine/commit/aa1b03e710cf6857ebe4286f9492b6066b2ef4e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39360781)</sub>

<!-- /greptile_comment -->