### PR TITLE
fix: make Datadog env tag per-cluster (DD_ENV) instead of build-time context

### DIFF
--- a/charts/model-engine/Chart.yaml
+++ b/charts/model-engine/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.6
+version: 0.2.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/model-engine/templates/_helpers.tpl
+++ b/charts/model-engine/templates/_helpers.tpl
@@ -95,7 +95,7 @@ owner: ${OWNER}
 env: {{- .Values.context | printf " %s" }}
 managed-by: {{- include "modelEngine.fullname" . | printf " %s\n" -}}
 use_scale_launch_endpoint_network_policy: "true"
-tags.datadoghq.com/env: ${DD_ENV}
+tags.datadoghq.com/env: "${DD_ENV}"
 tags.datadoghq.com/version: ${GIT_TAG}
 {{- if .Values.azure }}
 azure.workload.identity/use: "true"

--- a/charts/model-engine/templates/_helpers.tpl
+++ b/charts/model-engine/templates/_helpers.tpl
@@ -95,7 +95,7 @@ owner: ${OWNER}
 env: {{- .Values.context | printf " %s" }}
 managed-by: {{- include "modelEngine.fullname" . | printf " %s\n" -}}
 use_scale_launch_endpoint_network_policy: "true"
-tags.datadoghq.com/env: {{- .Values.context | printf " %s" }}
+tags.datadoghq.com/env: ${DD_ENV}
 tags.datadoghq.com/version: ${GIT_TAG}
 {{- if .Values.azure }}
 azure.workload.identity/use: "true"

--- a/charts/model-engine/templates/_helpers.tpl
+++ b/charts/model-engine/templates/_helpers.tpl
@@ -51,7 +51,7 @@ Create chart name and version as used by the chart label.
 team: infra
 app.kubernetes.io/version: {{ .Values.tag }}
 tags.datadoghq.com/version: {{ .Values.tag }}
-tags.datadoghq.com/env: {{ .Values.context }}
+tags.datadoghq.com/env: {{ .Values.datadog.env | default .Values.context }}
 env: {{ .Values.context }}
 {{- if .Values.azure }}
 azure.workload.identity/use: "true"
@@ -159,7 +159,7 @@ env:
   - name: DD_SERVICE
     value: "${ENDPOINT_NAME}"
   - name: DD_ENV
-    value: {{ .Values.context }}
+    value: "${DD_ENV}"
   - name: DD_VERSION
     value: "${GIT_TAG}"
   - name: DD_AGENT_HOST
@@ -223,7 +223,7 @@ env:
   - name: DD_SERVICE
     value: "${ENDPOINT_NAME}"
   - name: DD_ENV
-    value: {{ .Values.context }}
+    value: "${DD_ENV}"
   - name: DD_VERSION
     value: "${GIT_TAG}"
   - name: DD_AGENT_HOST
@@ -296,8 +296,8 @@ env:
     value: "{{ .Values.dd_trace_enabled }}"
   - name: DD_REMOTE_CONFIGURATION_ENABLED
     value: "false"
-  - name: DD_ENV
-    value: {{ .Values.context }}
+  {{- /* DD_ENV is set in the serviceEnvGitTag* wrappers: a Helm value for control-plane
+         pods, and the ${DD_ENV} runtime substitution for python-rendered endpoints. */}}
   - name: DD_AGENT_HOST
     valueFrom:
       fieldRef:
@@ -421,6 +421,8 @@ env:
 
 {{- define "modelEngine.serviceEnvGitTagFromHelmVar" }}
 {{- include "modelEngine.serviceEnvBase" . }}
+  - name: DD_ENV
+    value: {{ .Values.datadog.env | default .Values.context }}
   - name: DD_VERSION
     value: {{ .Values.tag }}
   - name: GIT_TAG
@@ -432,6 +434,8 @@ env:
 
 {{- define "modelEngine.serviceEnvGitTagFromPythonReplace" }}
 {{- include "modelEngine.serviceEnvBase" . }}
+  - name: DD_ENV
+    value: "${DD_ENV}"
   - name: DD_VERSION
     value: "${GIT_TAG}"
   - name: GIT_TAG

--- a/charts/model-engine/templates/celery_autoscaler_stateful_set.yaml
+++ b/charts/model-engine/templates/celery_autoscaler_stateful_set.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.celery_autoscaler.enabled }}
 {{- if not .Values.serviceIdentifier }}
 {{- $app := include "modelEngine.celeryautoscalername" . }}
-{{- $env := .Values.context }}
+{{- $env := .Values.datadog.env | default .Values.context }}
 {{- $tag := .Values.tag }}
 {{- $message_broker := .Values.celeryBrokerType }}
 {{- $num_shards := .Values.celery_autoscaler.num_shards }}

--- a/charts/model-engine/templates/service_template_config_map.yaml
+++ b/charts/model-engine/templates/service_template_config_map.yaml
@@ -3,7 +3,6 @@
 {{- $forwarder_repository := .Values.image.forwarderRepository -}}
 {{- $triton_repository := .Values.triton.image.repository -}}
 {{- $triton_tag := .Values.triton.image.tag -}}
-{{- $env := .Values.context -}}
 {{- $service_template_labels := include "modelEngine.serviceTemplateLabels" . }}
 {{- $job_template_labels := include "modelEngine.jobTemplateLabels" . }}
 {{- $service_env := include "modelEngine.serviceEnvGitTagFromPythonReplace" . }}
@@ -1084,7 +1083,7 @@ data:
             sidecar.istio.io/inject: "false"
             version: v1
           annotations:
-            ad.datadoghq.com/main.logs: '[{"source": "python", "service": "${RESOURCE_NAME}", "tags": ["env:{{ $env }}", "launch_job_id:${JOB_ID}"]}]'
+            ad.datadoghq.com/main.logs: '[{"source": "python", "service": "${RESOURCE_NAME}", "tags": ["env:${DD_ENV}", "launch_job_id:${JOB_ID}"]}]'
             cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
         spec:
           restartPolicy: Never
@@ -1193,7 +1192,7 @@ data:
             sidecar.istio.io/inject: "false"
             version: v1
           annotations:
-            ad.datadoghq.com/main.logs: '[{"source": "python", "service": "${RESOURCE_NAME}", "tags": ["env:{{ $env }}", "launch_job_id:${JOB_ID}"]}]'
+            ad.datadoghq.com/main.logs: '[{"source": "python", "service": "${RESOURCE_NAME}", "tags": ["env:${DD_ENV}", "launch_job_id:${JOB_ID}"]}]'
             cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
         spec:
           restartPolicy: Never

--- a/charts/model-engine/values.yaml
+++ b/charts/model-engine/values.yaml
@@ -1,4 +1,12 @@
 dd_trace_enabled: true
+
+# datadog [optional] configures Datadog tagging for model-engine pods.
+datadog:
+  # env [optional] sets the Datadog `env` tag (DD_ENV + tags.datadoghq.com/env) on both
+  # control-plane pods and launched inference endpoints. Falls back to `context` when empty.
+  # Set per-cluster (e.g. "sgp-dev") so pods report the cluster's real environment.
+  env: ""
+
 spellbook:
   enabled: false
 

--- a/charts/model-engine/values_sample.yaml
+++ b/charts/model-engine/values_sample.yaml
@@ -363,6 +363,7 @@ celeryBrokerType: sqs
 
 datadog:
   enabled: false
+  # env: ""  # Datadog `env` tag (DD_ENV + tags.datadoghq.com/env); set per-cluster (e.g. "sgp-dev"). Falls back to `context` when empty.
 
 recommendedHardware:
   byGpuMemoryGb:

--- a/model-engine/model_engine_server/common/env_vars.py
+++ b/model-engine/model_engine_server/common/env_vars.py
@@ -12,6 +12,7 @@ from model_engine_server.core.loggers import logger_name, make_logger
 
 __all__: Sequence[str] = (
     "CIRCLECI",
+    "DD_ENV",
     "GIT_TAG",
     "LAUNCH_SERVICE_TEMPLATE_CONFIG_MAP_PATH",
     "LAUNCH_SERVICE_TEMPLATE_FOLDER",
@@ -96,3 +97,9 @@ if LOCAL:
 GIT_TAG: str = os.environ.get("GIT_TAG", "GIT_TAG_NOT_FOUND")
 if GIT_TAG == "GIT_TAG_NOT_FOUND" and "pytest" not in sys.modules:
     raise ValueError("GIT_TAG environment variable must be set")
+
+# DD_ENV is the Datadog `env` tag. It is propagated to launched inference endpoints (via the
+# ${DD_ENV} template substitution) so they report the same per-cluster environment as the
+# gateway, instead of the build-time `context`. Defaults to infra_config().env when the
+# DD_ENV environment variable is not set on the gateway (e.g. local/CI).
+DD_ENV: str = os.environ.get("DD_ENV") or infra_config().env

--- a/model-engine/model_engine_server/common/env_vars.py
+++ b/model-engine/model_engine_server/common/env_vars.py
@@ -98,8 +98,10 @@ GIT_TAG: str = os.environ.get("GIT_TAG", "GIT_TAG_NOT_FOUND")
 if GIT_TAG == "GIT_TAG_NOT_FOUND" and "pytest" not in sys.modules:
     raise ValueError("GIT_TAG environment variable must be set")
 
-# DD_ENV is the Datadog `env` tag. It is propagated to launched inference endpoints (via the
+# DD_ENV is the Datadog `env` tag, propagated to launched inference endpoints (via the
 # ${DD_ENV} template substitution) so they report the same per-cluster environment as the
-# gateway, instead of the build-time `context`. Defaults to infra_config().env when the
-# DD_ENV environment variable is not set on the gateway (e.g. local/CI).
+# gateway instead of the build-time `context`. Falls back to infra_config().env when the
+# DD_ENV environment variable is unset OR empty -- the `or` is intentional (an empty env tag
+# is meaningless to Datadog). In cluster deploys the chart always sets DD_ENV
+# (datadog.env | default .context), so the fallback only matters for local/CI.
 DD_ENV: str = os.environ.get("DD_ENV") or infra_config().env

--- a/model-engine/model_engine_server/infra/gateways/datadog_monitoring_metrics_gateway.py
+++ b/model-engine/model_engine_server/infra/gateways/datadog_monitoring_metrics_gateway.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 
 from datadog import statsd
 from model_engine_server.common.dtos.llms import TokenUsage
-from model_engine_server.core.config import infra_config
+from model_engine_server.common.env_vars import DD_ENV
 from model_engine_server.domain.gateways.monitoring_metrics_gateway import (
     MetricMetadata,
     MonitoringMetricsGateway,
@@ -23,7 +23,7 @@ def get_model_tags(model_name: Optional[str]) -> List[str]:
 class DatadogMonitoringMetricsGateway(MonitoringMetricsGateway):
     def __init__(self, prefix: str = "model_engine"):
         self.prefix = prefix
-        self.tags = [f"env:{infra_config().env}"]
+        self.tags = [f"env:{DD_ENV}"]
 
     def emit_attempted_build_metric(self):
         statsd.increment("scale_launch.service_builder.attempt", tags=self.tags)

--- a/model-engine/model_engine_server/infra/gateways/datadog_monitoring_metrics_gateway.py
+++ b/model-engine/model_engine_server/infra/gateways/datadog_monitoring_metrics_gateway.py
@@ -56,9 +56,8 @@ class DatadogMonitoringMetricsGateway(MonitoringMetricsGateway):
         statsd.increment("scale_launch.database_cache.miss", tags=self.tags)
 
     def _format_call_tags(self, metadata: MetricMetadata) -> List[str]:
-        tags = self.tags
-        tags.extend(get_model_tags(metadata.model_name))
-        return tags
+        # Copy self.tags; extending it in place would leak per-call tags across emissions.
+        return [*self.tags, *get_model_tags(metadata.model_name)]
 
     def emit_route_call_metric(self, route: str, metadata: MetricMetadata):
         statsd.increment(f"{self.prefix}.{route}.call", tags=self._format_call_tags(metadata))
@@ -87,6 +86,6 @@ class DatadogMonitoringMetricsGateway(MonitoringMetricsGateway):
             statsd.distribution(inter_token_latency, token_usage.inter_token_latency, tags=tags)
 
     def emit_http_call_error_metrics(self, endpoint_name: str, error_code: int):
-        tags = self.tags
-        tags.extend([f"endpoint_name:{endpoint_name}", f"error_code:{error_code}"])
+        # Copy self.tags; extending it in place would leak per-call tags across emissions.
+        tags = [*self.tags, f"endpoint_name:{endpoint_name}", f"error_code:{error_code}"]
         statsd.increment(f"{self.prefix}.upstream_sync_error", tags=tags)

--- a/model-engine/model_engine_server/infra/gateways/resources/k8s_endpoint_resource_delegate.py
+++ b/model-engine/model_engine_server/infra/gateways/resources/k8s_endpoint_resource_delegate.py
@@ -21,6 +21,7 @@ from model_engine_server.common.config import hmi_config
 from model_engine_server.common.dtos.resource_manager import CreateOrUpdateResourcesRequest
 from model_engine_server.common.env_vars import (
     CIRCLECI,
+    DD_ENV,
     LAUNCH_SERVICE_TEMPLATE_CONFIG_MAP_PATH,
     LAUNCH_SERVICE_TEMPLATE_FOLDER,
     MODEL_CACHE_MOUNT_PATH,
@@ -277,6 +278,10 @@ def load_k8s_yaml(key: str, substitution_kwargs: ResourceArguments) -> Dict[str,
     # K8s/container error at deploy time, rather than a KeyError deep
     # inside the service-builder celery task.
     filtered_kwargs = {k: v for k, v in substitution_kwargs.items() if v is not None}
+    # Inject the Datadog env tag for every launched resource (endpoints, batch jobs, etc.)
+    # so any ${DD_ENV} in labels / env vars / log configs resolves to the gateway's
+    # per-cluster env (set via the chart's datadog.env). setdefault lets a caller override.
+    filtered_kwargs.setdefault("DD_ENV", DD_ENV)
     yaml_str = Template(template_str).safe_substitute(**filtered_kwargs)
     try:
         yaml_obj = yaml.safe_load(yaml_str)

--- a/model-engine/model_engine_server/infra/gateways/resources/k8s_resource_types.py
+++ b/model-engine/model_engine_server/infra/gateways/resources/k8s_resource_types.py
@@ -6,12 +6,7 @@ from typing import Any, Dict, List, Optional, Sequence, TypedDict, Union
 from model_engine_server.common.config import hmi_config
 from model_engine_server.common.dtos.model_endpoints import BrokerName, BrokerType
 from model_engine_server.common.dtos.resource_manager import CreateOrUpdateResourcesRequest
-from model_engine_server.common.env_vars import (
-    CIRCLECI,
-    DD_ENV,
-    GIT_TAG,
-    MODEL_CACHE_PVC_SUFFIX,
-)
+from model_engine_server.common.env_vars import CIRCLECI, GIT_TAG, MODEL_CACHE_PVC_SUFFIX
 from model_engine_server.common.resource_limits import (
     FORWARDER_CPU_USAGE,
     FORWARDER_MEMORY_USAGE,
@@ -115,7 +110,6 @@ class _BaseDeploymentArguments(_BaseEndpointArguments):
     IMAGE: str
     IMAGE_HASH: str
     DD_TRACE_ENABLED: str
-    DD_ENV: str
     CPUS: str
     MEMORY: str
     STORAGE_DICT: DictStrStr
@@ -673,7 +667,6 @@ def get_endpoint_resource_arguments_from_request(
             IMAGE=request.image,
             IMAGE_HASH=image_hash,
             DD_TRACE_ENABLED=str(dd_trace_enabled),
-            DD_ENV=DD_ENV,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
             STORAGE_DICT=storage_dict,
@@ -728,7 +721,6 @@ def get_endpoint_resource_arguments_from_request(
             IMAGE=request.image,
             IMAGE_HASH=image_hash,
             DD_TRACE_ENABLED=str(dd_trace_enabled),
-            DD_ENV=DD_ENV,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
             STORAGE_DICT=storage_dict,
@@ -785,7 +777,6 @@ def get_endpoint_resource_arguments_from_request(
             IMAGE=request.image,
             IMAGE_HASH=image_hash,
             DD_TRACE_ENABLED=str(dd_trace_enabled),
-            DD_ENV=DD_ENV,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
             STORAGE_DICT=storage_dict,
@@ -839,7 +830,6 @@ def get_endpoint_resource_arguments_from_request(
             IMAGE=request.image,
             IMAGE_HASH=image_hash,
             DD_TRACE_ENABLED=str(dd_trace_enabled),
-            DD_ENV=DD_ENV,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
             STORAGE_DICT=storage_dict,
@@ -895,7 +885,6 @@ def get_endpoint_resource_arguments_from_request(
             IMAGE=request.image,
             IMAGE_HASH=image_hash,
             DD_TRACE_ENABLED=str(dd_trace_enabled),
-            DD_ENV=DD_ENV,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
             STORAGE_DICT=storage_dict,
@@ -945,7 +934,6 @@ def get_endpoint_resource_arguments_from_request(
             IMAGE=request.image,
             IMAGE_HASH=image_hash,
             DD_TRACE_ENABLED=str(dd_trace_enabled),
-            DD_ENV=DD_ENV,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
             STORAGE_DICT=storage_dict,
@@ -997,7 +985,6 @@ def get_endpoint_resource_arguments_from_request(
             IMAGE=request.image,
             IMAGE_HASH=image_hash,
             DD_TRACE_ENABLED=str(dd_trace_enabled),
-            DD_ENV=DD_ENV,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
             STORAGE_DICT=storage_dict,
@@ -1060,7 +1047,6 @@ def get_endpoint_resource_arguments_from_request(
             IMAGE=request.image,
             IMAGE_HASH=image_hash,
             DD_TRACE_ENABLED=str(dd_trace_enabled),
-            DD_ENV=DD_ENV,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
             STORAGE_DICT=storage_dict,
@@ -1125,7 +1111,6 @@ def get_endpoint_resource_arguments_from_request(
             IMAGE=request.image,
             IMAGE_HASH=image_hash,
             DD_TRACE_ENABLED=str(dd_trace_enabled),
-            DD_ENV=DD_ENV,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
             STORAGE_DICT=storage_dict,
@@ -1183,7 +1168,6 @@ def get_endpoint_resource_arguments_from_request(
             IMAGE=request.image,
             IMAGE_HASH=image_hash,
             DD_TRACE_ENABLED=str(dd_trace_enabled),
-            DD_ENV=DD_ENV,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
             STORAGE_DICT=storage_dict,
@@ -1246,7 +1230,6 @@ def get_endpoint_resource_arguments_from_request(
             IMAGE=request.image,
             IMAGE_HASH=image_hash,
             DD_TRACE_ENABLED=str(dd_trace_enabled),
-            DD_ENV=DD_ENV,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
             STORAGE_DICT=storage_dict,

--- a/model-engine/model_engine_server/infra/gateways/resources/k8s_resource_types.py
+++ b/model-engine/model_engine_server/infra/gateways/resources/k8s_resource_types.py
@@ -6,7 +6,12 @@ from typing import Any, Dict, List, Optional, Sequence, TypedDict, Union
 from model_engine_server.common.config import hmi_config
 from model_engine_server.common.dtos.model_endpoints import BrokerName, BrokerType
 from model_engine_server.common.dtos.resource_manager import CreateOrUpdateResourcesRequest
-from model_engine_server.common.env_vars import CIRCLECI, GIT_TAG, MODEL_CACHE_PVC_SUFFIX
+from model_engine_server.common.env_vars import (
+    CIRCLECI,
+    DD_ENV,
+    GIT_TAG,
+    MODEL_CACHE_PVC_SUFFIX,
+)
 from model_engine_server.common.resource_limits import (
     FORWARDER_CPU_USAGE,
     FORWARDER_MEMORY_USAGE,
@@ -110,6 +115,7 @@ class _BaseDeploymentArguments(_BaseEndpointArguments):
     IMAGE: str
     IMAGE_HASH: str
     DD_TRACE_ENABLED: str
+    DD_ENV: str
     CPUS: str
     MEMORY: str
     STORAGE_DICT: DictStrStr
@@ -667,6 +673,7 @@ def get_endpoint_resource_arguments_from_request(
             IMAGE=request.image,
             IMAGE_HASH=image_hash,
             DD_TRACE_ENABLED=str(dd_trace_enabled),
+            DD_ENV=DD_ENV,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
             STORAGE_DICT=storage_dict,
@@ -721,6 +728,7 @@ def get_endpoint_resource_arguments_from_request(
             IMAGE=request.image,
             IMAGE_HASH=image_hash,
             DD_TRACE_ENABLED=str(dd_trace_enabled),
+            DD_ENV=DD_ENV,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
             STORAGE_DICT=storage_dict,
@@ -777,6 +785,7 @@ def get_endpoint_resource_arguments_from_request(
             IMAGE=request.image,
             IMAGE_HASH=image_hash,
             DD_TRACE_ENABLED=str(dd_trace_enabled),
+            DD_ENV=DD_ENV,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
             STORAGE_DICT=storage_dict,
@@ -830,6 +839,7 @@ def get_endpoint_resource_arguments_from_request(
             IMAGE=request.image,
             IMAGE_HASH=image_hash,
             DD_TRACE_ENABLED=str(dd_trace_enabled),
+            DD_ENV=DD_ENV,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
             STORAGE_DICT=storage_dict,
@@ -885,6 +895,7 @@ def get_endpoint_resource_arguments_from_request(
             IMAGE=request.image,
             IMAGE_HASH=image_hash,
             DD_TRACE_ENABLED=str(dd_trace_enabled),
+            DD_ENV=DD_ENV,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
             STORAGE_DICT=storage_dict,
@@ -934,6 +945,7 @@ def get_endpoint_resource_arguments_from_request(
             IMAGE=request.image,
             IMAGE_HASH=image_hash,
             DD_TRACE_ENABLED=str(dd_trace_enabled),
+            DD_ENV=DD_ENV,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
             STORAGE_DICT=storage_dict,
@@ -985,6 +997,7 @@ def get_endpoint_resource_arguments_from_request(
             IMAGE=request.image,
             IMAGE_HASH=image_hash,
             DD_TRACE_ENABLED=str(dd_trace_enabled),
+            DD_ENV=DD_ENV,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
             STORAGE_DICT=storage_dict,
@@ -1047,6 +1060,7 @@ def get_endpoint_resource_arguments_from_request(
             IMAGE=request.image,
             IMAGE_HASH=image_hash,
             DD_TRACE_ENABLED=str(dd_trace_enabled),
+            DD_ENV=DD_ENV,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
             STORAGE_DICT=storage_dict,
@@ -1111,6 +1125,7 @@ def get_endpoint_resource_arguments_from_request(
             IMAGE=request.image,
             IMAGE_HASH=image_hash,
             DD_TRACE_ENABLED=str(dd_trace_enabled),
+            DD_ENV=DD_ENV,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
             STORAGE_DICT=storage_dict,
@@ -1168,6 +1183,7 @@ def get_endpoint_resource_arguments_from_request(
             IMAGE=request.image,
             IMAGE_HASH=image_hash,
             DD_TRACE_ENABLED=str(dd_trace_enabled),
+            DD_ENV=DD_ENV,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
             STORAGE_DICT=storage_dict,
@@ -1230,6 +1246,7 @@ def get_endpoint_resource_arguments_from_request(
             IMAGE=request.image,
             IMAGE_HASH=image_hash,
             DD_TRACE_ENABLED=str(dd_trace_enabled),
+            DD_ENV=DD_ENV,
             CPUS=str(build_endpoint_request.cpus),
             MEMORY=str(build_endpoint_request.memory),
             STORAGE_DICT=storage_dict,

--- a/model-engine/model_engine_server/infra/gateways/resources/templates/service_template_config_map_circleci.yaml
+++ b/model-engine/model_engine_server/infra/gateways/resources/templates/service_template_config_map_circleci.yaml
@@ -12,7 +12,7 @@ metadata:
     tags.datadoghq.com/env: circleci
     env: circleci
     product: model-engine
-    helm.sh/chart: model-engine-0.2.4
+    helm.sh/chart: model-engine-0.2.7
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
@@ -33,7 +33,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: circleci
+        tags.datadoghq.com/env: ${DD_ENV}
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -68,7 +68,7 @@ data:
             env: circleci
             managed-by: model-engine
             use_scale_launch_endpoint_network_policy: "true"
-            tags.datadoghq.com/env: circleci
+            tags.datadoghq.com/env: ${DD_ENV}
             tags.datadoghq.com/version: ${GIT_TAG}
             tags.datadoghq.com/service: ${ENDPOINT_NAME}
             endpoint_id: ${ENDPOINT_ID}
@@ -135,7 +135,7 @@ data:
                 - name: DD_SERVICE
                   value: "${ENDPOINT_NAME}"
                 - name: DD_ENV
-                  value: circleci
+                  value: "${DD_ENV}"
                 - name: DD_VERSION
                   value: "${GIT_TAG}"
                 - name: DD_AGENT_HOST
@@ -306,7 +306,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: circleci
+        tags.datadoghq.com/env: ${DD_ENV}
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -341,7 +341,7 @@ data:
             env: circleci
             managed-by: model-engine
             use_scale_launch_endpoint_network_policy: "true"
-            tags.datadoghq.com/env: circleci
+            tags.datadoghq.com/env: ${DD_ENV}
             tags.datadoghq.com/version: ${GIT_TAG}
             tags.datadoghq.com/service: ${ENDPOINT_NAME}
             endpoint_id: ${ENDPOINT_ID}
@@ -408,7 +408,7 @@ data:
                 - name: DD_SERVICE
                   value: "${ENDPOINT_NAME}"
                 - name: DD_ENV
-                  value: circleci
+                  value: "${DD_ENV}"
                 - name: DD_VERSION
                   value: "${GIT_TAG}"
                 - name: DD_AGENT_HOST
@@ -533,7 +533,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: circleci
+        tags.datadoghq.com/env: ${DD_ENV}
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -561,7 +561,7 @@ data:
             env: circleci
             managed-by: model-engine
             use_scale_launch_endpoint_network_policy: "true"
-            tags.datadoghq.com/env: circleci
+            tags.datadoghq.com/env: ${DD_ENV}
             tags.datadoghq.com/version: ${GIT_TAG}
             tags.datadoghq.com/service: ${ENDPOINT_NAME}
             endpoint_id: ${ENDPOINT_ID}
@@ -630,7 +630,7 @@ data:
                 - name: DD_SERVICE
                   value: "${ENDPOINT_NAME}"
                 - name: DD_ENV
-                  value: circleci
+                  value: "${DD_ENV}"
                 - name: DD_VERSION
                   value: "${GIT_TAG}"
                 - name: DD_AGENT_HOST
@@ -807,7 +807,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: circleci
+        tags.datadoghq.com/env: ${DD_ENV}
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -835,7 +835,7 @@ data:
             env: circleci
             managed-by: model-engine
             use_scale_launch_endpoint_network_policy: "true"
-            tags.datadoghq.com/env: circleci
+            tags.datadoghq.com/env: ${DD_ENV}
             tags.datadoghq.com/version: ${GIT_TAG}
             tags.datadoghq.com/service: ${ENDPOINT_NAME}
             endpoint_id: ${ENDPOINT_ID}
@@ -904,7 +904,7 @@ data:
                 - name: DD_SERVICE
                   value: "${ENDPOINT_NAME}"
                 - name: DD_ENV
-                  value: circleci
+                  value: "${DD_ENV}"
                 - name: DD_VERSION
                   value: "${GIT_TAG}"
                 - name: DD_AGENT_HOST
@@ -1035,7 +1035,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: circleci
+        tags.datadoghq.com/env: ${DD_ENV}
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -1063,7 +1063,7 @@ data:
             env: circleci
             managed-by: model-engine
             use_scale_launch_endpoint_network_policy: "true"
-            tags.datadoghq.com/env: circleci
+            tags.datadoghq.com/env: ${DD_ENV}
             tags.datadoghq.com/version: ${GIT_TAG}
             tags.datadoghq.com/service: ${ENDPOINT_NAME}
             endpoint_id: ${ENDPOINT_ID}
@@ -1140,7 +1140,7 @@ data:
                 - name: DD_SERVICE
                   value: "${ENDPOINT_NAME}"
                 - name: DD_ENV
-                  value: circleci
+                  value: "${DD_ENV}"
                 - name: DD_VERSION
                   value: "${GIT_TAG}"
                 - name: DD_AGENT_HOST
@@ -1271,7 +1271,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: circleci
+        tags.datadoghq.com/env: ${DD_ENV}
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -1306,7 +1306,7 @@ data:
             env: circleci
             managed-by: model-engine
             use_scale_launch_endpoint_network_policy: "true"
-            tags.datadoghq.com/env: circleci
+            tags.datadoghq.com/env: ${DD_ENV}
             tags.datadoghq.com/version: ${GIT_TAG}
             tags.datadoghq.com/service: ${ENDPOINT_NAME}
             endpoint_id: ${ENDPOINT_ID}
@@ -1379,7 +1379,7 @@ data:
                 - name: DD_SERVICE
                   value: "${ENDPOINT_NAME}"
                 - name: DD_ENV
-                  value: circleci
+                  value: "${DD_ENV}"
                 - name: DD_VERSION
                   value: "${GIT_TAG}"
                 - name: DD_AGENT_HOST
@@ -1552,7 +1552,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: circleci
+        tags.datadoghq.com/env: ${DD_ENV}
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -1587,7 +1587,7 @@ data:
             env: circleci
             managed-by: model-engine
             use_scale_launch_endpoint_network_policy: "true"
-            tags.datadoghq.com/env: circleci
+            tags.datadoghq.com/env: ${DD_ENV}
             tags.datadoghq.com/version: ${GIT_TAG}
             tags.datadoghq.com/service: ${ENDPOINT_NAME}
             endpoint_id: ${ENDPOINT_ID}
@@ -1660,7 +1660,7 @@ data:
                 - name: DD_SERVICE
                   value: "${ENDPOINT_NAME}"
                 - name: DD_ENV
-                  value: circleci
+                  value: "${DD_ENV}"
                 - name: DD_VERSION
                   value: "${GIT_TAG}"
                 - name: DD_AGENT_HOST
@@ -1787,7 +1787,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: circleci
+        tags.datadoghq.com/env: ${DD_ENV}
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -1815,7 +1815,7 @@ data:
             env: circleci
             managed-by: model-engine
             use_scale_launch_endpoint_network_policy: "true"
-            tags.datadoghq.com/env: circleci
+            tags.datadoghq.com/env: ${DD_ENV}
             tags.datadoghq.com/version: ${GIT_TAG}
             tags.datadoghq.com/service: ${ENDPOINT_NAME}
             endpoint_id: ${ENDPOINT_ID}
@@ -1890,7 +1890,7 @@ data:
                 - name: DD_SERVICE
                   value: "${ENDPOINT_NAME}"
                 - name: DD_ENV
-                  value: circleci
+                  value: "${DD_ENV}"
                 - name: DD_VERSION
                   value: "${GIT_TAG}"
                 - name: DD_AGENT_HOST
@@ -2069,7 +2069,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: circleci
+        tags.datadoghq.com/env: ${DD_ENV}
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -2097,7 +2097,7 @@ data:
             env: circleci
             managed-by: model-engine
             use_scale_launch_endpoint_network_policy: "true"
-            tags.datadoghq.com/env: circleci
+            tags.datadoghq.com/env: ${DD_ENV}
             tags.datadoghq.com/version: ${GIT_TAG}
             tags.datadoghq.com/service: ${ENDPOINT_NAME}
             endpoint_id: ${ENDPOINT_ID}
@@ -2172,7 +2172,7 @@ data:
                 - name: DD_SERVICE
                   value: "${ENDPOINT_NAME}"
                 - name: DD_ENV
-                  value: circleci
+                  value: "${DD_ENV}"
                 - name: DD_VERSION
                   value: "${GIT_TAG}"
                 - name: DD_AGENT_HOST
@@ -2305,7 +2305,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: circleci
+        tags.datadoghq.com/env: ${DD_ENV}
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -2333,7 +2333,7 @@ data:
             env: circleci
             managed-by: model-engine
             use_scale_launch_endpoint_network_policy: "true"
-            tags.datadoghq.com/env: circleci
+            tags.datadoghq.com/env: ${DD_ENV}
             tags.datadoghq.com/version: ${GIT_TAG}
             tags.datadoghq.com/service: ${ENDPOINT_NAME}
             endpoint_id: ${ENDPOINT_ID}
@@ -2416,7 +2416,7 @@ data:
                 - name: DD_SERVICE
                   value: "${ENDPOINT_NAME}"
                 - name: DD_ENV
-                  value: circleci
+                  value: "${DD_ENV}"
                 - name: DD_VERSION
                   value: "${GIT_TAG}"
                 - name: DD_AGENT_HOST
@@ -2549,7 +2549,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: circleci
+        tags.datadoghq.com/env: ${DD_ENV}
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -2571,7 +2571,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: circleci
+        tags.datadoghq.com/env: ${DD_ENV}
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -2593,7 +2593,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: circleci
+        tags.datadoghq.com/env: ${DD_ENV}
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -2619,7 +2619,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: circleci
+        tags.datadoghq.com/env: ${DD_ENV}
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -2637,7 +2637,7 @@ data:
             metric:
               name: request-concurrency-average
             target:
-              type: Value
+              type: AverageValue
               averageValue: ${CONCURRENCY}
   keda-scaled-object.yaml: |-
     apiVersion: keda.sh/v1alpha1
@@ -2654,7 +2654,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: circleci
+        tags.datadoghq.com/env: ${DD_ENV}
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -2701,7 +2701,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: circleci
+        tags.datadoghq.com/env: ${DD_ENV}
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -2724,7 +2724,7 @@ data:
               env: circleci
               managed-by: model-engine
               use_scale_launch_endpoint_network_policy: "true"
-              tags.datadoghq.com/env: circleci
+              tags.datadoghq.com/env: ${DD_ENV}
               tags.datadoghq.com/version: ${GIT_TAG}
               tags.datadoghq.com/service: ${ENDPOINT_NAME}
               endpoint_id: ${ENDPOINT_ID}
@@ -2797,6 +2797,8 @@ data:
                   - "forwarder.sync.routes=${FORWARDER_SYNC_ROUTES}"
                   - --set
                   - "forwarder.stream.routes=${FORWARDER_STREAM_ROUTES}"
+                  - --set
+                  - "max_concurrency=${FORWARDER_MAX_CONCURRENCY}"
                 env:
                   - name: DD_TRACE_ENABLED
                     value: "${DD_TRACE_ENABLED}"
@@ -2805,7 +2807,7 @@ data:
                   - name: DD_SERVICE
                     value: "${ENDPOINT_NAME}"
                   - name: DD_ENV
-                    value: circleci
+                    value: "${DD_ENV}"
                   - name: DD_VERSION
                     value: "${GIT_TAG}"
                   - name: DD_AGENT_HOST
@@ -2929,7 +2931,7 @@ data:
               env: circleci
               managed-by: model-engine
               use_scale_launch_endpoint_network_policy: "true"
-              tags.datadoghq.com/env: circleci
+              tags.datadoghq.com/env: ${DD_ENV}
               tags.datadoghq.com/version: ${GIT_TAG}
               tags.datadoghq.com/service: ${ENDPOINT_NAME}
               endpoint_id: ${ENDPOINT_ID}
@@ -3038,7 +3040,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: circleci
+        tags.datadoghq.com/env: ${DD_ENV}
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -3068,7 +3070,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: circleci
+        tags.datadoghq.com/env: ${DD_ENV}
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -3099,7 +3101,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: circleci
+        tags.datadoghq.com/env: ${DD_ENV}
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -3130,7 +3132,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: circleci
+        tags.datadoghq.com/env: ${DD_ENV}
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -3155,7 +3157,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: circleci
+        tags.datadoghq.com/env: ${DD_ENV}
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -3183,7 +3185,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: circleci
+        tags.datadoghq.com/env: ${DD_ENV}
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -3222,7 +3224,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: circleci
+        tags.datadoghq.com/env: ${DD_ENV}
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -3246,7 +3248,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: circleci
+        tags.datadoghq.com/env: ${DD_ENV}
         tags.datadoghq.com/version: ${GIT_TAG}
         launch_job_id: ${JOB_ID}
         tags.datadoghq.com/request_id: ${REQUEST_ID}
@@ -3268,7 +3270,7 @@ data:
             env: circleci
             managed-by: model-engine
             use_scale_launch_endpoint_network_policy: "true"
-            tags.datadoghq.com/env: circleci
+            tags.datadoghq.com/env: ${DD_ENV}
             tags.datadoghq.com/version: ${GIT_TAG}
             launch_job_id: ${JOB_ID}
             tags.datadoghq.com/request_id: ${REQUEST_ID}
@@ -3278,7 +3280,7 @@ data:
             sidecar.istio.io/inject: "false"
             version: v1
           annotations:
-            ad.datadoghq.com/main.logs: '[{"source": "python", "service": "${RESOURCE_NAME}", "tags": ["env:circleci", "launch_job_id:${JOB_ID}"]}]'
+            ad.datadoghq.com/main.logs: '[{"source": "python", "service": "${RESOURCE_NAME}", "tags": ["env:${DD_ENV}", "launch_job_id:${JOB_ID}"]}]'
             cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
         spec:
           restartPolicy: Never
@@ -3311,8 +3313,6 @@ data:
                   value: "true"
                 - name: DD_REMOTE_CONFIGURATION_ENABLED
                   value: "false"
-                - name: DD_ENV
-                  value: circleci
                 - name: DD_AGENT_HOST
                   valueFrom:
                     fieldRef:
@@ -3352,6 +3352,8 @@ data:
                   value: "600"
                 - name: CIRCLECI
                   value: "true"
+                - name: DD_ENV
+                  value: ${DD_ENV}
                 - name: DD_VERSION
                   value: ${GIT_TAG}
                 - name: GIT_TAG
@@ -3406,7 +3408,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: circleci
+        tags.datadoghq.com/env: ${DD_ENV}
         tags.datadoghq.com/version: ${GIT_TAG}
         launch_job_id: ${JOB_ID}
         tags.datadoghq.com/request_id: ${REQUEST_ID}
@@ -3431,7 +3433,7 @@ data:
             env: circleci
             managed-by: model-engine
             use_scale_launch_endpoint_network_policy: "true"
-            tags.datadoghq.com/env: circleci
+            tags.datadoghq.com/env: ${DD_ENV}
             tags.datadoghq.com/version: ${GIT_TAG}
             launch_job_id: ${JOB_ID}
             tags.datadoghq.com/request_id: ${REQUEST_ID}
@@ -3441,7 +3443,7 @@ data:
             sidecar.istio.io/inject: "false"
             version: v1
           annotations:
-            ad.datadoghq.com/main.logs: '[{"source": "python", "service": "${RESOURCE_NAME}", "tags": ["env:circleci", "launch_job_id:${JOB_ID}"]}]'
+            ad.datadoghq.com/main.logs: '[{"source": "python", "service": "${RESOURCE_NAME}", "tags": ["env:${DD_ENV}", "launch_job_id:${JOB_ID}"]}]'
             cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
         spec:
           restartPolicy: Never
@@ -3473,8 +3475,6 @@ data:
                   value: "true"
                 - name: DD_REMOTE_CONFIGURATION_ENABLED
                   value: "false"
-                - name: DD_ENV
-                  value: circleci
                 - name: DD_AGENT_HOST
                   valueFrom:
                     fieldRef:
@@ -3514,6 +3514,8 @@ data:
                   value: "600"
                 - name: CIRCLECI
                   value: "true"
+                - name: DD_ENV
+                  value: ${DD_ENV}
                 - name: DD_VERSION
                   value: ${GIT_TAG}
                 - name: GIT_TAG
@@ -3586,7 +3588,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: circleci
+        tags.datadoghq.com/env: ${DD_ENV}
         tags.datadoghq.com/version: ${GIT_TAG}
         launch_job_id: ${JOB_ID}
         tags.datadoghq.com/request_id: ${REQUEST_ID}
@@ -3611,7 +3613,7 @@ data:
             env: circleci
             managed-by: model-engine
             use_scale_launch_endpoint_network_policy: "true"
-            tags.datadoghq.com/env: circleci
+            tags.datadoghq.com/env: ${DD_ENV}
             tags.datadoghq.com/version: ${GIT_TAG}
             launch_job_id: ${JOB_ID}
             tags.datadoghq.com/request_id: ${REQUEST_ID}
@@ -3621,7 +3623,7 @@ data:
             sidecar.istio.io/inject: "false"
             version: v1
           annotations:
-            ad.datadoghq.com/main.logs: '[{"source": "python", "service": "${RESOURCE_NAME}", "tags": ["env:circleci", "launch_job_id:${JOB_ID}"]}]'
+            ad.datadoghq.com/main.logs: '[{"source": "python", "service": "${RESOURCE_NAME}", "tags": ["env:${DD_ENV}", "launch_job_id:${JOB_ID}"]}]'
             cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
         spec:
           restartPolicy: Never
@@ -3659,8 +3661,6 @@ data:
                   value: "true"
                 - name: DD_REMOTE_CONFIGURATION_ENABLED
                   value: "false"
-                - name: DD_ENV
-                  value: circleci
                 - name: DD_AGENT_HOST
                   valueFrom:
                     fieldRef:
@@ -3700,6 +3700,8 @@ data:
                   value: "600"
                 - name: CIRCLECI
                   value: "true"
+                - name: DD_ENV
+                  value: ${DD_ENV}
                 - name: DD_VERSION
                   value: ${GIT_TAG}
                 - name: GIT_TAG

--- a/model-engine/model_engine_server/infra/gateways/resources/templates/service_template_config_map_circleci.yaml
+++ b/model-engine/model_engine_server/infra/gateways/resources/templates/service_template_config_map_circleci.yaml
@@ -33,7 +33,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: ${DD_ENV}
+        tags.datadoghq.com/env: "${DD_ENV}"
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -68,7 +68,7 @@ data:
             env: circleci
             managed-by: model-engine
             use_scale_launch_endpoint_network_policy: "true"
-            tags.datadoghq.com/env: ${DD_ENV}
+            tags.datadoghq.com/env: "${DD_ENV}"
             tags.datadoghq.com/version: ${GIT_TAG}
             tags.datadoghq.com/service: ${ENDPOINT_NAME}
             endpoint_id: ${ENDPOINT_ID}
@@ -306,7 +306,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: ${DD_ENV}
+        tags.datadoghq.com/env: "${DD_ENV}"
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -341,7 +341,7 @@ data:
             env: circleci
             managed-by: model-engine
             use_scale_launch_endpoint_network_policy: "true"
-            tags.datadoghq.com/env: ${DD_ENV}
+            tags.datadoghq.com/env: "${DD_ENV}"
             tags.datadoghq.com/version: ${GIT_TAG}
             tags.datadoghq.com/service: ${ENDPOINT_NAME}
             endpoint_id: ${ENDPOINT_ID}
@@ -533,7 +533,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: ${DD_ENV}
+        tags.datadoghq.com/env: "${DD_ENV}"
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -561,7 +561,7 @@ data:
             env: circleci
             managed-by: model-engine
             use_scale_launch_endpoint_network_policy: "true"
-            tags.datadoghq.com/env: ${DD_ENV}
+            tags.datadoghq.com/env: "${DD_ENV}"
             tags.datadoghq.com/version: ${GIT_TAG}
             tags.datadoghq.com/service: ${ENDPOINT_NAME}
             endpoint_id: ${ENDPOINT_ID}
@@ -807,7 +807,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: ${DD_ENV}
+        tags.datadoghq.com/env: "${DD_ENV}"
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -835,7 +835,7 @@ data:
             env: circleci
             managed-by: model-engine
             use_scale_launch_endpoint_network_policy: "true"
-            tags.datadoghq.com/env: ${DD_ENV}
+            tags.datadoghq.com/env: "${DD_ENV}"
             tags.datadoghq.com/version: ${GIT_TAG}
             tags.datadoghq.com/service: ${ENDPOINT_NAME}
             endpoint_id: ${ENDPOINT_ID}
@@ -1035,7 +1035,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: ${DD_ENV}
+        tags.datadoghq.com/env: "${DD_ENV}"
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -1063,7 +1063,7 @@ data:
             env: circleci
             managed-by: model-engine
             use_scale_launch_endpoint_network_policy: "true"
-            tags.datadoghq.com/env: ${DD_ENV}
+            tags.datadoghq.com/env: "${DD_ENV}"
             tags.datadoghq.com/version: ${GIT_TAG}
             tags.datadoghq.com/service: ${ENDPOINT_NAME}
             endpoint_id: ${ENDPOINT_ID}
@@ -1271,7 +1271,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: ${DD_ENV}
+        tags.datadoghq.com/env: "${DD_ENV}"
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -1306,7 +1306,7 @@ data:
             env: circleci
             managed-by: model-engine
             use_scale_launch_endpoint_network_policy: "true"
-            tags.datadoghq.com/env: ${DD_ENV}
+            tags.datadoghq.com/env: "${DD_ENV}"
             tags.datadoghq.com/version: ${GIT_TAG}
             tags.datadoghq.com/service: ${ENDPOINT_NAME}
             endpoint_id: ${ENDPOINT_ID}
@@ -1552,7 +1552,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: ${DD_ENV}
+        tags.datadoghq.com/env: "${DD_ENV}"
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -1587,7 +1587,7 @@ data:
             env: circleci
             managed-by: model-engine
             use_scale_launch_endpoint_network_policy: "true"
-            tags.datadoghq.com/env: ${DD_ENV}
+            tags.datadoghq.com/env: "${DD_ENV}"
             tags.datadoghq.com/version: ${GIT_TAG}
             tags.datadoghq.com/service: ${ENDPOINT_NAME}
             endpoint_id: ${ENDPOINT_ID}
@@ -1787,7 +1787,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: ${DD_ENV}
+        tags.datadoghq.com/env: "${DD_ENV}"
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -1815,7 +1815,7 @@ data:
             env: circleci
             managed-by: model-engine
             use_scale_launch_endpoint_network_policy: "true"
-            tags.datadoghq.com/env: ${DD_ENV}
+            tags.datadoghq.com/env: "${DD_ENV}"
             tags.datadoghq.com/version: ${GIT_TAG}
             tags.datadoghq.com/service: ${ENDPOINT_NAME}
             endpoint_id: ${ENDPOINT_ID}
@@ -2069,7 +2069,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: ${DD_ENV}
+        tags.datadoghq.com/env: "${DD_ENV}"
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -2097,7 +2097,7 @@ data:
             env: circleci
             managed-by: model-engine
             use_scale_launch_endpoint_network_policy: "true"
-            tags.datadoghq.com/env: ${DD_ENV}
+            tags.datadoghq.com/env: "${DD_ENV}"
             tags.datadoghq.com/version: ${GIT_TAG}
             tags.datadoghq.com/service: ${ENDPOINT_NAME}
             endpoint_id: ${ENDPOINT_ID}
@@ -2305,7 +2305,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: ${DD_ENV}
+        tags.datadoghq.com/env: "${DD_ENV}"
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -2333,7 +2333,7 @@ data:
             env: circleci
             managed-by: model-engine
             use_scale_launch_endpoint_network_policy: "true"
-            tags.datadoghq.com/env: ${DD_ENV}
+            tags.datadoghq.com/env: "${DD_ENV}"
             tags.datadoghq.com/version: ${GIT_TAG}
             tags.datadoghq.com/service: ${ENDPOINT_NAME}
             endpoint_id: ${ENDPOINT_ID}
@@ -2549,7 +2549,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: ${DD_ENV}
+        tags.datadoghq.com/env: "${DD_ENV}"
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -2571,7 +2571,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: ${DD_ENV}
+        tags.datadoghq.com/env: "${DD_ENV}"
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -2593,7 +2593,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: ${DD_ENV}
+        tags.datadoghq.com/env: "${DD_ENV}"
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -2619,7 +2619,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: ${DD_ENV}
+        tags.datadoghq.com/env: "${DD_ENV}"
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -2654,7 +2654,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: ${DD_ENV}
+        tags.datadoghq.com/env: "${DD_ENV}"
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -2701,7 +2701,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: ${DD_ENV}
+        tags.datadoghq.com/env: "${DD_ENV}"
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -2724,7 +2724,7 @@ data:
               env: circleci
               managed-by: model-engine
               use_scale_launch_endpoint_network_policy: "true"
-              tags.datadoghq.com/env: ${DD_ENV}
+              tags.datadoghq.com/env: "${DD_ENV}"
               tags.datadoghq.com/version: ${GIT_TAG}
               tags.datadoghq.com/service: ${ENDPOINT_NAME}
               endpoint_id: ${ENDPOINT_ID}
@@ -2931,7 +2931,7 @@ data:
               env: circleci
               managed-by: model-engine
               use_scale_launch_endpoint_network_policy: "true"
-              tags.datadoghq.com/env: ${DD_ENV}
+              tags.datadoghq.com/env: "${DD_ENV}"
               tags.datadoghq.com/version: ${GIT_TAG}
               tags.datadoghq.com/service: ${ENDPOINT_NAME}
               endpoint_id: ${ENDPOINT_ID}
@@ -3040,7 +3040,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: ${DD_ENV}
+        tags.datadoghq.com/env: "${DD_ENV}"
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -3070,7 +3070,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: ${DD_ENV}
+        tags.datadoghq.com/env: "${DD_ENV}"
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -3101,7 +3101,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: ${DD_ENV}
+        tags.datadoghq.com/env: "${DD_ENV}"
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -3132,7 +3132,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: ${DD_ENV}
+        tags.datadoghq.com/env: "${DD_ENV}"
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -3157,7 +3157,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: ${DD_ENV}
+        tags.datadoghq.com/env: "${DD_ENV}"
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -3185,7 +3185,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: ${DD_ENV}
+        tags.datadoghq.com/env: "${DD_ENV}"
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -3224,7 +3224,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: ${DD_ENV}
+        tags.datadoghq.com/env: "${DD_ENV}"
         tags.datadoghq.com/version: ${GIT_TAG}
         tags.datadoghq.com/service: ${ENDPOINT_NAME}
         endpoint_id: ${ENDPOINT_ID}
@@ -3248,7 +3248,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: ${DD_ENV}
+        tags.datadoghq.com/env: "${DD_ENV}"
         tags.datadoghq.com/version: ${GIT_TAG}
         launch_job_id: ${JOB_ID}
         tags.datadoghq.com/request_id: ${REQUEST_ID}
@@ -3270,7 +3270,7 @@ data:
             env: circleci
             managed-by: model-engine
             use_scale_launch_endpoint_network_policy: "true"
-            tags.datadoghq.com/env: ${DD_ENV}
+            tags.datadoghq.com/env: "${DD_ENV}"
             tags.datadoghq.com/version: ${GIT_TAG}
             launch_job_id: ${JOB_ID}
             tags.datadoghq.com/request_id: ${REQUEST_ID}
@@ -3408,7 +3408,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: ${DD_ENV}
+        tags.datadoghq.com/env: "${DD_ENV}"
         tags.datadoghq.com/version: ${GIT_TAG}
         launch_job_id: ${JOB_ID}
         tags.datadoghq.com/request_id: ${REQUEST_ID}
@@ -3433,7 +3433,7 @@ data:
             env: circleci
             managed-by: model-engine
             use_scale_launch_endpoint_network_policy: "true"
-            tags.datadoghq.com/env: ${DD_ENV}
+            tags.datadoghq.com/env: "${DD_ENV}"
             tags.datadoghq.com/version: ${GIT_TAG}
             launch_job_id: ${JOB_ID}
             tags.datadoghq.com/request_id: ${REQUEST_ID}
@@ -3588,7 +3588,7 @@ data:
         env: circleci
         managed-by: model-engine
         use_scale_launch_endpoint_network_policy: "true"
-        tags.datadoghq.com/env: ${DD_ENV}
+        tags.datadoghq.com/env: "${DD_ENV}"
         tags.datadoghq.com/version: ${GIT_TAG}
         launch_job_id: ${JOB_ID}
         tags.datadoghq.com/request_id: ${REQUEST_ID}
@@ -3613,7 +3613,7 @@ data:
             env: circleci
             managed-by: model-engine
             use_scale_launch_endpoint_network_policy: "true"
-            tags.datadoghq.com/env: ${DD_ENV}
+            tags.datadoghq.com/env: "${DD_ENV}"
             tags.datadoghq.com/version: ${GIT_TAG}
             launch_job_id: ${JOB_ID}
             tags.datadoghq.com/request_id: ${REQUEST_ID}


### PR DESCRIPTION
## Problem

model-engine's Datadog `env` tag is derived from the build-time Helm value `.Values.context`, so every deployment reports the same `env` (e.g. `production`) regardless of which cluster/environment it actually runs in. This affects three surfaces, all keyed off the single overloaded `context`:

1. **Control-plane pods** (gateway, builder, cacher, celery autoscaler) — `DD_ENV` and the `tags.datadoghq.com/env` label both come straight from `.Values.context`.
2. **Runtime-launched inference endpoints / batch jobs** — `DD_ENV` and `tags.datadoghq.com/env` are baked into the rendered `service_template_config_map` from `.Values.context` at `helm template` time, so they're frozen in the image and identical for every cluster (unlike the neighboring `DD_SERVICE`/`DD_VERSION`, which are already `${...}` runtime-substituted).
3. **Gateway custom metrics** — `DatadogMonitoringMetricsGateway` tags every metric with `env:{infra_config().env}`, and the chart wires the infra config's `env` from `.Values.context` too (`service_config_map.yaml`), so these are build-time-static as well.

## Approach

Introduce a dedicated, optional `datadog.env` value, decoupled from `context` (which is overloaded — it also selects the `service_template_config_map` variant, drives a `context == "circleci"` conditional, sets non-DD labels, and seeds the infra config's `env`, so it must not be repurposed). The fix mirrors the existing `GIT_TAG`/`DD_VERSION` split:

- **Control-plane** → `DD_ENV` / env label = `{{ .Values.datadog.env | default .Values.context }}` (Helm value, backwards-compatible: falls back to `context` when unset).
- **Launched resources** → templates emit the literal `${DD_ENV}`, resolved **centrally at endpoint-creation time** in `load_k8s_yaml` via a single `filtered_kwargs.setdefault("DD_ENV", DD_ENV)`. The value is sourced from the gateway/builder's own `DD_ENV` env var (which the chart sets to `datadog.env | default context`), so launched pods inherit the gateway's per-cluster env. This one hook covers endpoints, batch jobs, cron jobs, image-cache, LWS, and all auxiliary resources (service/virtual-service/destination-rule/hpa/keda/vpa/pdb) without threading `DD_ENV` through every argument class.
- **Gateway custom metrics** → tag with the same `DD_ENV`, so metrics, traces, and labels all report a consistent per-cluster env.

## Changes

**Chart (`charts/model-engine`)**
- `values.yaml`: add optional `datadog.env` (default `""`).
- `_helpers.tpl`:
  - `baseLabels` (control-plane object labels): `tags.datadoghq.com/env` → `datadog.env | default context`.
  - `baseTemplateLabels` (launched service + job templates): `tags.datadoghq.com/env` → `${DD_ENV}`.
  - `serviceEnvBase`: remove the hardcoded `DD_ENV` (moved into the wrappers, like `GIT_TAG`).
  - `serviceEnvGitTagFromHelmVar` (control-plane): add `DD_ENV` = `datadog.env | default context`.
  - `serviceEnvGitTagFromPythonReplace` (endpoints): add `DD_ENV` = `${DD_ENV}`.
  - `baseServiceTemplateEnv` / `baseForwarderTemplateEnv` (legacy endpoint paths): `DD_ENV` → `${DD_ENV}`.
- `service_template_config_map.yaml`: `ad.datadoghq.com/main.logs` job annotation `env:{{ $env }}` → `env:${DD_ENV}`; drop the now-unused `$env`.
- `celery_autoscaler_stateful_set.yaml`: `$env` (drives both the `DD_ENV` env var and the env label) → `datadog.env | default context`.
- `Chart.yaml`: `0.2.6` → `0.2.7`.

**Server (`model-engine`)**
- `common/env_vars.py`: add exported `DD_ENV` = `os.environ.get("DD_ENV") or infra_config().env` (falls back to the infra config env locally/CI where the env var isn't set).
- `infra/gateways/resources/k8s_endpoint_resource_delegate.py`: in `load_k8s_yaml`, `filtered_kwargs.setdefault("DD_ENV", DD_ENV)` before `safe_substitute` — the single central injection that resolves `${DD_ENV}` for every launched resource. (`setdefault` lets a caller override.)
- `infra/gateways/datadog_monitoring_metrics_gateway.py`:
  - `self.tags` env tag: `infra_config().env` → `DD_ENV`, so gateway custom metrics report the same per-cluster env as traces/labels.
  - **Drive-by bug fix:** `_format_call_tags` and `emit_http_call_error_metrics` previously did `tags = self.tags; tags.extend(...)`, mutating `self.tags` **in place** — leaking per-call `model_name`/`endpoint_name`/`error_code` tags across every subsequent emission and growing the list unboundedly. Now build a fresh list (`[*self.tags, ...]`).

**Generated fallback**
- `infra/gateways/resources/templates/service_template_config_map_circleci.yaml`: regenerated via `just autogen-templates`. Picks up the `${DD_ENV}` substitutions, plus pre-existing chart-source drift the stale fallback was missing (the `type: AverageValue` HPA change and the 7th `max_concurrency=${FORWARDER_MAX_CONCURRENCY}` `--set` arg, both from #836), and the `helm.sh/chart` stamp (0.2.4 → 0.2.7).

## Validation

- `helm template` across `values_sample` (datadog.env unset → falls back to `context`), `--set datadog.env=sgp-dev`, and `values_circleci`: control-plane `DD_ENV`/labels resolve to the Helm value; the launched-resource ConfigMap keeps the literal `${DD_ENV}` for Python substitution. No `<no value>` / unrendered `{{ }}`.
- The regenerated circleci fallback is byte-identical to `helm template --show-only` (modulo the autogen header + cosmetic trailing whitespace).
- `${DD_ENV}` resolves at endpoint creation via `load_k8s_yaml`. Existing `test_k8s_endpoint_resource_delegate.py` tests render the real chart and assert `tags.datadoghq.com/env == "circleci"` — DD_ENV resolves to `infra_config().env` → `circleci` under CI (env var unset), so they remain green. The metrics-gateway tests assert only that statsd is called, not tag values, so the env-source swap and tag-copy refactor don't break them.
- Did **not** run the full `model-engine` suite locally (heavy service deps) — CI should confirm.

## Known limitations / rollout notes

- **Monitor migration:** once an operator sets `datadog.env`, the gateway's custom metrics (`model_engine.*` / `scale_launch.*`) move from `env:<context>` to `env:<datadog.env>`. Dashboards/monitors filtering on the old `env` value must be updated. (No-op while `datadog.env` is unset — both equal `context`. The infra config's `env` field, used for DB/celery routing, is intentionally still keyed off `context`.)
- **Rollout skew:** the launched-resource ConfigMap is a Helm pre-upgrade hook, so its new `${DD_ENV}` data can be synced into still-running *old* builder pods before they roll. An old builder (without the central `setdefault`) would leave the literal `${DD_ENV}` in a label, and the endpoint/HPA/service create would be rejected by the API server (`${DD_ENV}` is an invalid label value). Loud, infrequent, and self-heals once the new builder is Ready — but expect a brief window during upgrade where endpoint creates may fail.
- **Downstream:** consumers that bake the rendered `service_template_config_map_<env>.yaml` into an image (e.g. model-engine-internal's `just autogen-templates` + image build) should regenerate; the rendered `DD_ENV` line becomes a runtime placeholder. This is not the production read path (the chart-mounted ConfigMap is), so it mainly matters for local/CI.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the forwarder worker path and Firehose logging client behavior. The main changes are:

- Adds an opt-in gevent worker pool for the Celery forwarder.
- Adds prefork-only worker recycling through `CELERY_WORKER_MAX_TASKS_PER_CHILD`.
- Caches the Firehose client and refreshes it before assumed-role credentials expire.
- Adds Firehose connection pool sizing for shared gevent use.
- Adds unit and local integration tests for the new worker-pool and Firehose paths.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking correctness or security issues were identified in the reviewed changes.

The changes are focused, covered by targeted validation, and no accepted review findings remain.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared the baseline rendering of Datadog environment handling against the current head to verify how --set datadog.env and unset values affect the rendered service templates and Helm outputs.
- Reviewed tag handling by comparing base and head tag initialization and formatting behavior, confirming that the head uses an env:dd-env-runtime tag and does not mutate internal self.tags, with per-call route/error tags and metrics emitted accordingly.

<a href="https://app.greptile.com/trex/runs/12808867/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `charts/model-engine/templates/service_template_config_map.yaml`, line 1127 ([link](https://github.com/scaleapi/llm-engine/blob/76ad47c1124a62eafb8a13c32ccdc0a857f5a948/charts/model-engine/templates/service_template_config_map.yaml#L1127)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Preserve DD_ENV quotes**

   The batch-job env vars are parsed through `fromYaml` and re-emitted with `toYaml`, which drops the quotes around `${DD_ENV}` in the rendered ConfigMap. `load_k8s_yaml` substitutes before `yaml.safe_load`, so a valid cluster env like `123`, `true`, or `null` becomes a YAML int, bool, or null for `env.value`. Kubernetes then rejects the Job because env var values must be strings. This path needs to keep `DD_ENV` explicitly quoted after the `toYaml` round trip.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: targeted script using the real chart helper and batch-job template path](https://app.greptile.com/trex/artifacts/2e25af3f-d0c0-4206-b6a9-2976fb764fe5)**

   - Contains supporting evidence from the run (text/x-python; charset=utf-8).

   **[Repro: command output showing unquoted DD\_ENV substitution parses to non-string types](https://app.greptile.com/trex/artifacts/29277fc4-95ea-4c57-9f67-a6755faa5fdc)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/12701673/artifacts?artifact=2e25af3f-d0c0-4206-b6a9-2976fb764fe5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: charts/model-engine/templates/service_template_config_map.yaml
   Line: 1127

   Comment:
   **Preserve DD_ENV quotes**

   The batch-job env vars are parsed through `fromYaml` and re-emitted with `toYaml`, which drops the quotes around `${DD_ENV}` in the rendered ConfigMap. `load_k8s_yaml` substitutes before `yaml.safe_load`, so a valid cluster env like `123`, `true`, or `null` becomes a YAML int, bool, or null for `env.value`. Kubernetes then rejects the Job because env var values must be strings. This path needs to keep `DD_ENV` explicitly quoted after the `toYaml` round trip.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20charts%2Fmodel-engine%2Ftemplates%2Fservice_template_config_map.yaml%0ALine%3A%201127%0A%0AComment%3A%0A**Preserve%20DD_ENV%20quotes**%0A%0AThe%20batch-job%20env%20vars%20are%20parsed%20through%20%60fromYaml%60%20and%20re-emitted%20with%20%60toYaml%60%2C%20which%20drops%20the%20quotes%20around%20%60%24%7BDD_ENV%7D%60%20in%20the%20rendered%20ConfigMap.%20%60load_k8s_yaml%60%20substitutes%20before%20%60yaml.safe_load%60%2C%20so%20a%20valid%20cluster%20env%20like%20%60123%60%2C%20%60true%60%2C%20or%20%60null%60%20becomes%20a%20YAML%20int%2C%20bool%2C%20or%20null%20for%20%60env.value%60.%20Kubernetes%20then%20rejects%20the%20Job%20because%20env%20var%20values%20must%20be%20strings.%20This%20path%20needs%20to%20keep%20%60DD_ENV%60%20explicitly%20quoted%20after%20the%20%60toYaml%60%20round%20trip.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=849&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20charts%2Fmodel-engine%2Ftemplates%2Fservice_template_config_map.yaml%0ALine%3A%201127%0A%0AComment%3A%0A**Preserve%20DD_ENV%20quotes**%0A%0AThe%20batch-job%20env%20vars%20are%20parsed%20through%20%60fromYaml%60%20and%20re-emitted%20with%20%60toYaml%60%2C%20which%20drops%20the%20quotes%20around%20%60%24%7BDD_ENV%7D%60%20in%20the%20rendered%20ConfigMap.%20%60load_k8s_yaml%60%20substitutes%20before%20%60yaml.safe_load%60%2C%20so%20a%20valid%20cluster%20env%20like%20%60123%60%2C%20%60true%60%2C%20or%20%60null%60%20becomes%20a%20YAML%20int%2C%20bool%2C%20or%20null%20for%20%60env.value%60.%20Kubernetes%20then%20rejects%20the%20Job%20because%20env%20var%20values%20must%20be%20strings.%20This%20path%20needs%20to%20keep%20%60DD_ENV%60%20explicitly%20quoted%20after%20the%20%60toYaml%60%20round%20trip.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fllm-engine&pr=849&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fllm-engine%22%20on%20the%20existing%20branch%20%22sayakmaity%2Fmodel-engine-dd-env-per-cluster%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22sayakmaity%2Fmodel-engine-dd-env-per-cluster%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20charts%2Fmodel-engine%2Ftemplates%2Fservice_template_config_map.yaml%0ALine%3A%201127%0A%0AComment%3A%0A**Preserve%20DD_ENV%20quotes**%0A%0AThe%20batch-job%20env%20vars%20are%20parsed%20through%20%60fromYaml%60%20and%20re-emitted%20with%20%60toYaml%60%2C%20which%20drops%20the%20quotes%20around%20%60%24%7BDD_ENV%7D%60%20in%20the%20rendered%20ConfigMap.%20%60load_k8s_yaml%60%20substitutes%20before%20%60yaml.safe_load%60%2C%20so%20a%20valid%20cluster%20env%20like%20%60123%60%2C%20%60true%60%2C%20or%20%60null%60%20becomes%20a%20YAML%20int%2C%20bool%2C%20or%20null%20for%20%60env.value%60.%20Kubernetes%20then%20rejects%20the%20Job%20because%20env%20var%20values%20must%20be%20strings.%20This%20path%20needs%20to%20keep%20%60DD_ENV%60%20explicitly%20quoted%20after%20the%20%60toYaml%60%20round%20trip.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fllm-engine&pr=849&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into sayakmaity/mode..."](https://github.com/scaleapi/llm-engine/commit/281b5ff1edc583dfbddce7a92a368c988cb44e19) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40648361)</sub>

<!-- /greptile_comment -->