### PR TITLE
fix(forwarder): cache Firehose client + add gevent worker pool (MLI-7328)

### DIFF
--- a/model-engine/model_engine_server/core/celery/s3.py
+++ b/model-engine/model_engine_server/core/celery/s3.py
@@ -52,8 +52,9 @@ class S3Backend(KeyValueStoreBackend):
 
         self.base_path = conf.get("s3_base_path", None)
 
-        # Keyed by threading.get_ident(), which is per-greenlet under gevent (not shared), so a
-        # bounded gevent pool reuses ids and caches one resource per worker slot. Safe, not a leak.
+        # Keyed by threading.get_ident() (id of the current greenlet under gevent). Celery spawns a
+        # greenlet per task, but CPython reuses the id() of GC'd greenlets, so the distinct-key set
+        # stays ~concurrency (measured flat at ~21 for concurrency 20 over 60k tasks), not per-task.
         self._s3_resource_per_thread = {}  # thread/greenlet identifier: s3 resource
         self._s3_resource_dict_lock = threading.Lock()  # might not be necessary but it's insurance
 

--- a/model-engine/model_engine_server/core/celery/s3.py
+++ b/model-engine/model_engine_server/core/celery/s3.py
@@ -53,8 +53,8 @@ class S3Backend(KeyValueStoreBackend):
         self.base_path = conf.get("s3_base_path", None)
 
         # Keyed by threading.get_ident() (id of the current greenlet under gevent). Celery spawns a
-        # greenlet per task, but CPython reuses the id() of GC'd greenlets, so the distinct-key set
-        # stays ~concurrency (measured flat at ~21 for concurrency 20 over 60k tasks), not per-task.
+        # greenlet per task, but CPython reuses the id() of GC'd greenlets, so the number of
+        # distinct keys tracks live concurrency, not total tasks (bounded, not a per-task leak).
         self._s3_resource_per_thread = {}  # thread/greenlet identifier: s3 resource
         self._s3_resource_dict_lock = threading.Lock()  # might not be necessary but it's insurance
 

--- a/model-engine/model_engine_server/core/celery/s3.py
+++ b/model-engine/model_engine_server/core/celery/s3.py
@@ -52,7 +52,9 @@ class S3Backend(KeyValueStoreBackend):
 
         self.base_path = conf.get("s3_base_path", None)
 
-        self._s3_resource_per_thread = {}  # thread identifier: s3 resource
+        # Keyed by threading.get_ident(), which is per-greenlet under gevent (not shared), so a
+        # bounded gevent pool reuses ids and caches one resource per worker slot. Safe, not a leak.
+        self._s3_resource_per_thread = {}  # thread/greenlet identifier: s3 resource
         self._s3_resource_dict_lock = threading.Lock()  # might not be necessary but it's insurance
 
     def _get_s3_object(self, key):

--- a/model-engine/model_engine_server/inference/forwarding/celery_forwarder.py
+++ b/model-engine/model_engine_server/inference/forwarding/celery_forwarder.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E402  (gevent monkey-patch must run before imports; see CELERY_WORKER_POOL block)
 # gevent worker pool (MLI-7328): IO-bound forwarder runs greenlets in one process instead of N
 # prefork processes (much less memory). Must monkey-patch BEFORE importing celery/boto3/requests
 # or they bind un-patched sockets and greenlets never yield. Import gevent before patch_all() so

--- a/model-engine/model_engine_server/inference/forwarding/celery_forwarder.py
+++ b/model-engine/model_engine_server/inference/forwarding/celery_forwarder.py
@@ -12,10 +12,6 @@ if CELERY_WORKER_POOL == "gevent":
     from gevent import monkey
 
     monkey.patch_all()
-elif CELERY_WORKER_POOL == "eventlet":
-    import eventlet
-
-    eventlet.monkey_patch()
 
 import argparse
 import json

--- a/model-engine/model_engine_server/inference/forwarding/celery_forwarder.py
+++ b/model-engine/model_engine_server/inference/forwarding/celery_forwarder.py
@@ -217,12 +217,23 @@ def start_celery_service(
         loglevel="INFO",
         optimization="fair",
     )
-    if CELERY_WORKER_POOL != "prefork":
+    if CELERY_WORKER_POOL == "gevent":
         worker_kwargs["pool"] = CELERY_WORKER_POOL
     else:
-        max_tasks_per_child = os.getenv("CELERY_WORKER_MAX_TASKS_PER_CHILD")
-        if max_tasks_per_child:
-            worker_kwargs["max_tasks_per_child"] = int(max_tasks_per_child)
+        # prefork-only recycling knob; ignore junk / non-positive values instead of crashing.
+        max_tasks_raw = os.getenv("CELERY_WORKER_MAX_TASKS_PER_CHILD")
+        if max_tasks_raw:
+            try:
+                max_tasks = int(max_tasks_raw)
+            except ValueError:
+                max_tasks = 0
+            if max_tasks > 0:
+                worker_kwargs["max_tasks_per_child"] = max_tasks
+            else:
+                logger.warning(
+                    "Ignoring invalid CELERY_WORKER_MAX_TASKS_PER_CHILD=%r (need a positive int)",
+                    max_tasks_raw,
+                )
     worker = app.Worker(**worker_kwargs)
     worker.start()
 

--- a/model-engine/model_engine_server/inference/forwarding/celery_forwarder.py
+++ b/model-engine/model_engine_server/inference/forwarding/celery_forwarder.py
@@ -7,6 +7,10 @@
 import os
 
 CELERY_WORKER_POOL = os.getenv("CELERY_WORKER_POOL", "prefork")
+if CELERY_WORKER_POOL not in ("prefork", "gevent"):
+    raise ValueError(
+        f"Unsupported CELERY_WORKER_POOL={CELERY_WORKER_POOL!r}; supported values: 'prefork', 'gevent'"
+    )
 if CELERY_WORKER_POOL == "gevent":
     import gevent  # noqa: F401  (import before patch_all so ddtrace patches gevent)
     from gevent import monkey

--- a/model-engine/model_engine_server/inference/forwarding/celery_forwarder.py
+++ b/model-engine/model_engine_server/inference/forwarding/celery_forwarder.py
@@ -1,3 +1,21 @@
+# gevent worker pool (MLI-7328): IO-bound forwarder runs greenlets in one process instead of N
+# prefork processes (much less memory). Must monkey-patch BEFORE importing celery/boto3/requests
+# or they bind un-patched sockets and greenlets never yield. Import gevent before patch_all() so
+# ddtrace installs TracedGreenlet (per-greenlet trace context). Run under ddtrace-run; its 4.x
+# module-cloning keeps this ordering safe. Guarded, so prefork is unaffected.
+import os
+
+CELERY_WORKER_POOL = os.getenv("CELERY_WORKER_POOL", "prefork")
+if CELERY_WORKER_POOL == "gevent":
+    import gevent  # noqa: F401  (import before patch_all so ddtrace patches gevent)
+    from gevent import monkey
+
+    monkey.patch_all()
+elif CELERY_WORKER_POOL == "eventlet":
+    import eventlet
+
+    eventlet.monkey_patch()
+
 import argparse
 import json
 from datetime import datetime, timedelta
@@ -187,18 +205,18 @@ def start_celery_service(
     queue: str,
     concurrency: int,
 ) -> None:
-    worker = app.Worker(
+    # Pool: prefork by default; CELERY_WORKER_POOL=gevent runs greenlets in one process
+    # (monkey-patched at module top). Under gevent there is no worker_max_tasks_per_child, so the
+    # firehose client-cache fix is what bounds per-task memory. Not pool="solo" (one task at a time).
+    worker_kwargs: Dict[str, Any] = dict(
         queues=[queue],
         concurrency=concurrency,
         loglevel="INFO",
         optimization="fair",
-        # Don't use pool="solo" so we can send multiple concurrent requests over
-        # Historically, pool="solo" argument fixes the known issues of celery and some of the libraries.
-        # Particularly asyncio and torchvision transformers. This isn't relevant since celery-forwarder
-        # is quite lightweight
-        # TODO: we should probably use eventlet or gevent for the pool, since
-        # the forwarder is nearly the most extreme example of IO bound.
     )
+    if CELERY_WORKER_POOL != "prefork":
+        worker_kwargs["pool"] = CELERY_WORKER_POOL
+    worker = app.Worker(**worker_kwargs)
     worker.start()
 
 

--- a/model-engine/model_engine_server/inference/forwarding/celery_forwarder.py
+++ b/model-engine/model_engine_server/inference/forwarding/celery_forwarder.py
@@ -207,8 +207,10 @@ def start_celery_service(
     concurrency: int,
 ) -> None:
     # Pool: prefork by default; CELERY_WORKER_POOL=gevent runs greenlets in one process
-    # (monkey-patched at module top). Under gevent there is no worker_max_tasks_per_child, so the
-    # firehose client-cache fix is what bounds per-task memory. Not pool="solo" (one task at a time).
+    # (monkey-patched at module top). The firehose client-cache fix bounds per-task memory on both
+    # pools. Prefork additionally honors CELERY_WORKER_MAX_TASKS_PER_CHILD (off unless set) to
+    # recycle each child after N tasks as defense-in-depth; gevent has no per-child recycling.
+    # Not pool="solo" (one task at a time).
     worker_kwargs: Dict[str, Any] = dict(
         queues=[queue],
         concurrency=concurrency,
@@ -217,6 +219,10 @@ def start_celery_service(
     )
     if CELERY_WORKER_POOL != "prefork":
         worker_kwargs["pool"] = CELERY_WORKER_POOL
+    else:
+        max_tasks_per_child = os.getenv("CELERY_WORKER_MAX_TASKS_PER_CHILD")
+        if max_tasks_per_child:
+            worker_kwargs["max_tasks_per_child"] = int(max_tasks_per_child)
     worker = app.Worker(**worker_kwargs)
     worker.start()
 

--- a/model-engine/model_engine_server/inference/forwarding/celery_forwarder.py
+++ b/model-engine/model_engine_server/inference/forwarding/celery_forwarder.py
@@ -1,10 +1,8 @@
 # ruff: noqa: E402  (gevent monkey-patch must run before imports; see CELERY_WORKER_POOL block)
-# gevent worker pool (MLI-7328): IO-bound forwarder runs greenlets in one process instead of N
-# prefork processes (much less memory). Must monkey-patch BEFORE importing celery/boto3/requests
-# or they bind un-patched sockets and greenlets never yield. Import gevent before patch_all() so
-# ddtrace installs TracedGreenlet (per-greenlet trace context). Launch as __main__ via python -m
-# (prod: ddtrace-run python -m ...); patching during a plain import under ddtrace-run deadlocks
-# the import lock. Guarded, so prefork is unaffected.
+# Opt-in gevent pool (MLI-7328): patch_all() must run before celery/boto3/requests are imported,
+# or their sockets bind un-patched and greenlets never yield. Import gevent first so ddtrace can
+# patch it. Launch as __main__ (prod: ddtrace-run python -m ...); a plain import under ddtrace-run
+# deadlocks the import lock. Guarded, so prefork is unaffected.
 import os
 
 CELERY_WORKER_POOL = os.getenv("CELERY_WORKER_POOL", "prefork")
@@ -207,11 +205,9 @@ def start_celery_service(
     queue: str,
     concurrency: int,
 ) -> None:
-    # Pool: prefork by default; CELERY_WORKER_POOL=gevent runs greenlets in one process
-    # (monkey-patched at module top). The firehose client-cache fix bounds per-task memory on both
-    # pools. Prefork additionally honors CELERY_WORKER_MAX_TASKS_PER_CHILD (off unless set) to
-    # recycle each child after N tasks as defense-in-depth; gevent has no per-child recycling.
-    # Not pool="solo" (one task at a time).
+    # Pool: prefork by default; CELERY_WORKER_POOL=gevent runs greenlets in one process.
+    # CELERY_WORKER_MAX_TASKS_PER_CHILD (prefork-only, off unless set) recycles each child after N
+    # tasks as defense-in-depth; gevent has no per-child recycling.
     worker_kwargs: Dict[str, Any] = dict(
         queues=[queue],
         concurrency=concurrency,
@@ -221,19 +217,17 @@ def start_celery_service(
     if CELERY_WORKER_POOL == "gevent":
         worker_kwargs["pool"] = CELERY_WORKER_POOL
     else:
-        # prefork-only recycling knob; ignore junk / non-positive values instead of crashing.
-        max_tasks_raw = os.getenv("CELERY_WORKER_MAX_TASKS_PER_CHILD")
-        if max_tasks_raw:
+        raw = os.getenv("CELERY_WORKER_MAX_TASKS_PER_CHILD")
+        if raw:
             try:
-                max_tasks = int(max_tasks_raw)
+                max_tasks = int(raw)
             except ValueError:
-                max_tasks = 0
-            if max_tasks > 0:
+                max_tasks = None
+            if max_tasks is not None and max_tasks > 0:
                 worker_kwargs["max_tasks_per_child"] = max_tasks
             else:
                 logger.warning(
-                    "Ignoring invalid CELERY_WORKER_MAX_TASKS_PER_CHILD=%r (need a positive int)",
-                    max_tasks_raw,
+                    "Ignoring CELERY_WORKER_MAX_TASKS_PER_CHILD=%r (need a positive int)", raw
                 )
     worker = app.Worker(**worker_kwargs)
     worker.start()

--- a/model-engine/model_engine_server/inference/forwarding/celery_forwarder.py
+++ b/model-engine/model_engine_server/inference/forwarding/celery_forwarder.py
@@ -2,8 +2,9 @@
 # gevent worker pool (MLI-7328): IO-bound forwarder runs greenlets in one process instead of N
 # prefork processes (much less memory). Must monkey-patch BEFORE importing celery/boto3/requests
 # or they bind un-patched sockets and greenlets never yield. Import gevent before patch_all() so
-# ddtrace installs TracedGreenlet (per-greenlet trace context). Run under ddtrace-run; its 4.x
-# module-cloning keeps this ordering safe. Guarded, so prefork is unaffected.
+# ddtrace installs TracedGreenlet (per-greenlet trace context). Launch as __main__ via python -m
+# (prod: ddtrace-run python -m ...); patching during a plain import under ddtrace-run deadlocks
+# the import lock. Guarded, so prefork is unaffected.
 import os
 
 CELERY_WORKER_POOL = os.getenv("CELERY_WORKER_POOL", "prefork")

--- a/model-engine/model_engine_server/inference/infra/gateways/firehose_streaming_storage_gateway.py
+++ b/model-engine/model_engine_server/inference/infra/gateways/firehose_streaming_storage_gateway.py
@@ -20,9 +20,8 @@ _CLIENT_REFRESH_LEEWAY = timedelta(minutes=10)
 
 
 def _firehose_max_pool_connections() -> int:
-    # Shared client reused across greenlets under gevent. Default is static; set
-    # FIREHOSE_CLIENT_MAX_POOL_CONNECTIONS >= worker concurrency to avoid pool contention.
-    # Bad / non-positive values fall back to the default rather than crash-loop the forwarder.
+    # Shared client pool size under gevent; set >= worker concurrency. Bad/non-positive values
+    # fall back to the default instead of crash-looping the forwarder.
     default = 50
     raw = os.getenv("FIREHOSE_CLIENT_MAX_POOL_CONNECTIONS", str(default))
     try:

--- a/model-engine/model_engine_server/inference/infra/gateways/firehose_streaming_storage_gateway.py
+++ b/model-engine/model_engine_server/inference/infra/gateways/firehose_streaming_storage_gateway.py
@@ -1,7 +1,12 @@
 import json
+import os
+import threading
 from typing import Any, Dict
 
 import boto3
+from botocore.config import Config
+from botocore.credentials import RefreshableCredentials
+from botocore.session import get_session
 from model_engine_server.core.config import infra_config
 from model_engine_server.core.loggers import logger_name, make_logger
 from model_engine_server.domain.exceptions import StreamPutException
@@ -11,38 +16,64 @@ from model_engine_server.inference.domain.gateways.streaming_storage_gateway imp
 
 logger = make_logger(logger_name())
 
+# Shared client is reused across greenlets under the gevent pool; size the pool to concurrency.
+_FIREHOSE_MAX_POOL_CONNECTIONS = int(os.getenv("FIREHOSE_CLIENT_MAX_POOL_CONNECTIONS", "50"))
+
 
 class FirehoseStreamingStorageGateway(StreamingStorageGateway):
-    """
-    A gateway that stores data through the AWS Kinesis Firehose streaming mechanism.
+    """Stores records via AWS Kinesis Firehose.
+
+    MLI-7328: client is built once and cached. It is called per task by the logging hook;
+    rebuilding per call (STS assume_role + new boto clients) leaked memory and OOM-killed the
+    forwarder. Do not revert to per-call construction. Assumed-role creds are temporary, so the
+    cache uses RefreshableCredentials to re-assume before expiry.
     """
 
     def __init__(self):
-        pass
+        self._client = None
+        # gevent: greenlets share this client and build() yields on assume_role; lock stops two
+        # greenlets both building. threading.Lock is greenlet-aware after monkey.patch_all().
+        self._lock = threading.Lock()
 
-    """
-    Creates a new firehose client.
+    def _make_refreshable_client(self):
+        # Firehose stream is cross-account, so we assume a role; RefreshableCredentials lets
+        # botocore re-assume before the temporary creds expire (no client rebuild needed).
+        region = infra_config().default_region
+        role_arn = infra_config().firehose_role_arn
 
-    Streams with Snowflake as a destination and the AWS profile live in different 
-    accounts. Firehose doesn't support resource-based policies, so we need to assume 
-    a new role to write to the stream.
-    """
+        def _refresh():
+            sts_client = boto3.Session(region_name=region).client("sts")
+            credentials = sts_client.assume_role(
+                RoleArn=role_arn,
+                RoleSessionName="AssumeMlLoggingRoleSession",
+            )["Credentials"]
+            return {
+                "access_key": credentials["AccessKeyId"],
+                "secret_key": credentials["SecretAccessKey"],
+                "token": credentials["SessionToken"],
+                "expiry_time": credentials["Expiration"].isoformat(),
+            }
+
+        creds = RefreshableCredentials.create_from_metadata(
+            metadata=_refresh(),
+            refresh_using=_refresh,
+            method="sts-assume-role",
+        )
+        botocore_session = get_session()
+        botocore_session._credentials = creds
+        return boto3.Session(botocore_session=botocore_session).client(
+            "firehose",
+            region_name=region,
+            config=Config(max_pool_connections=_FIREHOSE_MAX_POOL_CONNECTIONS),
+        )
 
     def _get_firehose_client(self):
-        sts_session = boto3.Session(region_name=infra_config().default_region)
-        sts_client = sts_session.client("sts")
-        assumed_role_object = sts_client.assume_role(
-            RoleArn=infra_config().firehose_role_arn,
-            RoleSessionName="AssumeMlLoggingRoleSession",
-        )
-        credentials = assumed_role_object["Credentials"]
-        session = boto3.Session(
-            aws_access_key_id=credentials["AccessKeyId"],
-            aws_secret_access_key=credentials["SecretAccessKey"],
-            aws_session_token=credentials["SessionToken"],
-        )
-        firehose_client = session.client("firehose", region_name=infra_config().default_region)
-        return firehose_client
+        # Double-checked lock: hot path is lock-free once built; lock only guards first build.
+        if self._client is None:
+            with self._lock:
+                if self._client is None:
+                    self._client = self._make_refreshable_client()
+        return self._client
 
     def put_record(self, stream_name: str, record: Dict[str, Any]) -> Dict[str, Any]:
         """

--- a/model-engine/model_engine_server/inference/infra/gateways/firehose_streaming_storage_gateway.py
+++ b/model-engine/model_engine_server/inference/infra/gateways/firehose_streaming_storage_gateway.py
@@ -59,14 +59,15 @@ class FirehoseStreamingStorageGateway(StreamingStorageGateway):
 
     def _build_client(self):
         # Cross-account: assume the firehose role, then build a client with those temporary creds.
+        # Pure: returns (client, expiry) and does not touch self, so the caller swaps both in
+        # atomically and a failed (re)build never advances _expiry past a client we did not install.
         # Public boto3 API only (no botocore-internal credential injection).
         region = infra_config().default_region
         creds = boto3.client("sts", region_name=region).assume_role(
             RoleArn=infra_config().firehose_role_arn,
             RoleSessionName="AssumeMlLoggingRoleSession",
         )["Credentials"]
-        self._expiry = creds["Expiration"]  # botocore returns a tz-aware datetime
-        return boto3.client(
+        client = boto3.client(
             "firehose",
             region_name=region,
             aws_access_key_id=creds["AccessKeyId"],
@@ -74,6 +75,7 @@ class FirehoseStreamingStorageGateway(StreamingStorageGateway):
             aws_session_token=creds["SessionToken"],
             config=Config(max_pool_connections=_FIREHOSE_MAX_POOL_CONNECTIONS),
         )
+        return client, creds["Expiration"]  # botocore returns a tz-aware datetime
 
     def _needs_rebuild(self) -> bool:
         if self._expiry is None:
@@ -82,11 +84,12 @@ class FirehoseStreamingStorageGateway(StreamingStorageGateway):
 
     def _get_firehose_client(self):
         # Rebuild only when the assumed-role token is near expiry (~once per token lifetime), never
-        # per task. Double-checked lock: the hot path is lock-free once built and unexpired.
+        # per task. Assign client + expiry together so a failed (re)build leaves the prior client
+        # and expiry intact and the next call retries. Double-checked lock guards the build.
         if self._client is None or self._needs_rebuild():
             with self._lock:
                 if self._client is None or self._needs_rebuild():
-                    self._client = self._build_client()
+                    self._client, self._expiry = self._build_client()
         return self._client
 
     def put_record(self, stream_name: str, record: Dict[str, Any]) -> Dict[str, Any]:

--- a/model-engine/model_engine_server/inference/infra/gateways/firehose_streaming_storage_gateway.py
+++ b/model-engine/model_engine_server/inference/infra/gateways/firehose_streaming_storage_gateway.py
@@ -16,8 +16,23 @@ from model_engine_server.inference.domain.gateways.streaming_storage_gateway imp
 
 logger = make_logger(logger_name())
 
-# Shared client is reused across greenlets under the gevent pool; size the pool to concurrency.
-_FIREHOSE_MAX_POOL_CONNECTIONS = int(os.getenv("FIREHOSE_CLIENT_MAX_POOL_CONNECTIONS", "50"))
+
+def _firehose_max_pool_connections() -> int:
+    # Shared client reused across greenlets under gevent. Default is static; set
+    # FIREHOSE_CLIENT_MAX_POOL_CONNECTIONS >= worker concurrency to avoid pool contention.
+    # Bad / non-positive values fall back to the default rather than crash-loop the forwarder.
+    raw = os.getenv("FIREHOSE_CLIENT_MAX_POOL_CONNECTIONS", "50")
+    try:
+        value = int(raw)
+        if value >= 1:
+            return value
+    except ValueError:
+        pass
+    logger.warning("Invalid FIREHOSE_CLIENT_MAX_POOL_CONNECTIONS=%r; using default 50", raw)
+    return 50
+
+
+_FIREHOSE_MAX_POOL_CONNECTIONS = _firehose_max_pool_connections()
 
 
 class FirehoseStreamingStorageGateway(StreamingStorageGateway):
@@ -60,6 +75,9 @@ class FirehoseStreamingStorageGateway(StreamingStorageGateway):
             method="sts-assume-role",
         )
         botocore_session = get_session()
+        # Private attr honored by Session.get_credentials() on the pinned botocore. If a botocore
+        # upgrade stops honoring it, creds silently fall back to the un-assumed task role and
+        # cross-account PutRecord gets AccessDenied. Re-verify this on boto upgrades.
         botocore_session._credentials = creds
         return boto3.Session(botocore_session=botocore_session).client(
             "firehose",

--- a/model-engine/model_engine_server/inference/infra/gateways/firehose_streaming_storage_gateway.py
+++ b/model-engine/model_engine_server/inference/infra/gateways/firehose_streaming_storage_gateway.py
@@ -21,15 +21,18 @@ def _firehose_max_pool_connections() -> int:
     # Shared client reused across greenlets under gevent. Default is static; set
     # FIREHOSE_CLIENT_MAX_POOL_CONNECTIONS >= worker concurrency to avoid pool contention.
     # Bad / non-positive values fall back to the default rather than crash-loop the forwarder.
-    raw = os.getenv("FIREHOSE_CLIENT_MAX_POOL_CONNECTIONS", "50")
+    default = 50
+    raw = os.getenv("FIREHOSE_CLIENT_MAX_POOL_CONNECTIONS", str(default))
     try:
         value = int(raw)
         if value >= 1:
             return value
     except ValueError:
         pass
-    logger.warning("Invalid FIREHOSE_CLIENT_MAX_POOL_CONNECTIONS=%r; using default 50", raw)
-    return 50
+    logger.warning(
+        "Invalid FIREHOSE_CLIENT_MAX_POOL_CONNECTIONS=%r; using default %d", raw, default
+    )
+    return default
 
 
 _FIREHOSE_MAX_POOL_CONNECTIONS = _firehose_max_pool_connections()

--- a/model-engine/model_engine_server/inference/infra/gateways/firehose_streaming_storage_gateway.py
+++ b/model-engine/model_engine_server/inference/infra/gateways/firehose_streaming_storage_gateway.py
@@ -1,12 +1,11 @@
 import json
 import os
 import threading
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict
 
 import boto3
 from botocore.config import Config
-from botocore.credentials import RefreshableCredentials
-from botocore.session import get_session
 from model_engine_server.core.config import infra_config
 from model_engine_server.core.loggers import logger_name, make_logger
 from model_engine_server.domain.exceptions import StreamPutException
@@ -15,6 +14,9 @@ from model_engine_server.inference.domain.gateways.streaming_storage_gateway imp
 )
 
 logger = make_logger(logger_name())
+
+# Rebuild the cached client this long before the assumed-role token actually expires.
+_CLIENT_REFRESH_LEEWAY = timedelta(minutes=10)
 
 
 def _firehose_max_pool_connections() -> int:
@@ -41,59 +43,51 @@ _FIREHOSE_MAX_POOL_CONNECTIONS = _firehose_max_pool_connections()
 class FirehoseStreamingStorageGateway(StreamingStorageGateway):
     """Stores records via AWS Kinesis Firehose.
 
-    MLI-7328: client is built once and cached. It is called per task by the logging hook;
-    rebuilding per call (STS assume_role + new boto clients) leaked memory and OOM-killed the
-    forwarder. Do not revert to per-call construction. Assumed-role creds are temporary, so the
-    cache uses RefreshableCredentials to re-assume before expiry.
+    MLI-7328: the client is cached, not rebuilt per call. The logging hook calls put_record on
+    every async task; rebuilding per call (STS assume_role + new boto clients) leaked memory and
+    OOM-killed the forwarder. Do not revert to per-call construction. The Firehose stream is
+    cross-account, so creds come from assume_role and are temporary; the cached client is rebuilt
+    just before the token expires (~once per token lifetime, not per task) using only public
+    boto3 APIs.
     """
 
     def __init__(self):
         self._client = None
-        # gevent: greenlets share this client and build() yields on assume_role; lock stops two
-        # greenlets both building. threading.Lock is greenlet-aware after monkey.patch_all().
+        self._expiry = None  # assumed-role token expiry; rebuild before it
+        # gevent: greenlets share this client and the build yields on assume_role; the lock stops
+        # two greenlets both building. threading.Lock is greenlet-aware after monkey.patch_all().
         self._lock = threading.Lock()
 
-    def _make_refreshable_client(self):
-        # Firehose stream is cross-account, so we assume a role; RefreshableCredentials lets
-        # botocore re-assume before the temporary creds expire (no client rebuild needed).
+    def _build_client(self):
+        # Cross-account: assume the firehose role, then build a client with those temporary creds.
+        # Public boto3 API only (no botocore-internal credential injection).
         region = infra_config().default_region
-        role_arn = infra_config().firehose_role_arn
-
-        def _refresh():
-            sts_client = boto3.Session(region_name=region).client("sts")
-            credentials = sts_client.assume_role(
-                RoleArn=role_arn,
-                RoleSessionName="AssumeMlLoggingRoleSession",
-            )["Credentials"]
-            return {
-                "access_key": credentials["AccessKeyId"],
-                "secret_key": credentials["SecretAccessKey"],
-                "token": credentials["SessionToken"],
-                "expiry_time": credentials["Expiration"].isoformat(),
-            }
-
-        creds = RefreshableCredentials.create_from_metadata(
-            metadata=_refresh(),
-            refresh_using=_refresh,
-            method="sts-assume-role",
-        )
-        botocore_session = get_session()
-        # Private attr honored by Session.get_credentials() on the pinned botocore. If a botocore
-        # upgrade stops honoring it, creds silently fall back to the un-assumed task role and
-        # cross-account PutRecord gets AccessDenied. Re-verify this on boto upgrades.
-        botocore_session._credentials = creds
-        return boto3.Session(botocore_session=botocore_session).client(
+        creds = boto3.client("sts", region_name=region).assume_role(
+            RoleArn=infra_config().firehose_role_arn,
+            RoleSessionName="AssumeMlLoggingRoleSession",
+        )["Credentials"]
+        self._expiry = creds["Expiration"]  # botocore returns a tz-aware datetime
+        return boto3.client(
             "firehose",
             region_name=region,
+            aws_access_key_id=creds["AccessKeyId"],
+            aws_secret_access_key=creds["SecretAccessKey"],
+            aws_session_token=creds["SessionToken"],
             config=Config(max_pool_connections=_FIREHOSE_MAX_POOL_CONNECTIONS),
         )
 
+    def _needs_rebuild(self) -> bool:
+        if self._expiry is None:
+            return True
+        return datetime.now(timezone.utc) >= self._expiry - _CLIENT_REFRESH_LEEWAY
+
     def _get_firehose_client(self):
-        # Double-checked lock: hot path is lock-free once built; lock only guards first build.
-        if self._client is None:
+        # Rebuild only when the assumed-role token is near expiry (~once per token lifetime), never
+        # per task. Double-checked lock: the hot path is lock-free once built and unexpired.
+        if self._client is None or self._needs_rebuild():
             with self._lock:
-                if self._client is None:
-                    self._client = self._make_refreshable_client()
+                if self._client is None or self._needs_rebuild():
+                    self._client = self._build_client()
         return self._client
 
     def put_record(self, stream_name: str, record: Dict[str, Any]) -> Dict[str, Any]:

--- a/model-engine/requirements.in
+++ b/model-engine/requirements.in
@@ -27,6 +27,7 @@ boto3>=1.40.46,<1.40.62   # range constrained by aiobotocore 2.25.1 requirement 
 botocore>=1.40.46,<1.40.62
 build~=1.0.3
 celery[redis,sqs,tblib]~=5.5.0  # 5.4.0 broken on Python 3.13 (billiard/multiprocessing fork); 5.5 adds Py3.13 support
+gevent>=26.5.0  # celery gevent worker pool for the celery-forwarder (MLI-7328); 26.5.0 has cp314 wheels
 click~=8.1
 cloudpickle==2.1.0
 croniter==1.4.1

--- a/model-engine/requirements.txt
+++ b/model-engine/requirements.txt
@@ -225,9 +225,12 @@ googleapis-common-protos==1.72.0
     #   grpc-google-iam-v1
     #   grpcio-status
     #   opentelemetry-exporter-otlp-proto-grpc
+gevent==26.5.0
+    # via -r requirements.in
 greenlet==3.3.2
     # via
     #   -r requirements.in
+    #   gevent
     #   sqlalchemy
 grpc-google-iam-v1==0.14.3
     # via
@@ -706,3 +709,7 @@ zipp==3.23.1
     # via
     #   -r requirements.in
     #   importlib-metadata
+zope-event==6.2
+    # via gevent
+zope-interface==8.5
+    # via gevent

--- a/model-engine/tests/integration/inference/test_forwarder_pool.py
+++ b/model-engine/tests/integration/inference/test_forwarder_pool.py
@@ -1,0 +1,266 @@
+"""Integration tests for the celery-forwarder worker pools (MLI-7328).
+
+Exercises the real forwarder (`python -m ...celery_forwarder`) end to end against a stub model
+server, covering:
+  - task completes under BOTH prefork (default) and gevent pools (redis broker),
+  - gevent handles many concurrent in-flight tasks in ONE process (the memory win's premise),
+  - gevent warm-shutdown drains an in-flight task on SIGTERM (pod scale-down),
+  - the forwarder works over the SQS broker (prod's broker) under gevent, via localstack.
+
+Local only: needs redis on localhost (USE_REDIS_LOCALHOST=1); the SQS case also needs a
+localstack SQS endpoint (AWS_ENDPOINT_URL). Skipped in CI, like test_async_inference.py.
+"""
+import os
+import signal
+import subprocess
+import sys
+import time
+from datetime import datetime
+from tempfile import NamedTemporaryFile
+from typing import Iterator
+from uuid import uuid4
+
+import multiprocess
+import pytest
+import redis
+import requests
+import uvicorn
+from fastapi import FastAPI, Request
+from model_engine_server.common.constants import LIRA_CELERY_TASK_NAME
+from model_engine_server.core.celery import TaskVisibility, celery_app
+from model_engine_server.domain.entities import ModelEndpointConfig
+from tenacity import Retrying, retry_if_exception_type, stop_after_attempt, wait_fixed
+
+MAIN_PORT = 5005  # forwarder.async.user_port (overridden via --set below)
+CONFIG_PATH = "model_engine_server/inference/configs/service--forwarder.yaml"
+AWS_ENDPOINT_URL = os.getenv("AWS_ENDPOINT_URL", "http://localhost:4566")
+
+
+def _redis_available() -> bool:
+    try:
+        return bool(redis.Redis(host="localhost", port=6379).ping())
+    except Exception:
+        return False
+
+
+def _localstack_sqs_available() -> bool:
+    try:
+        import boto3
+
+        boto3.client("sqs", endpoint_url=AWS_ENDPOINT_URL, region_name="us-west-2").list_queues()
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = [
+    pytest.mark.skipif(not _redis_available(), reason="needs redis on localhost"),
+    pytest.mark.skipif(
+        bool(os.getenv("CIRCLECI")), reason="forwarder integration infra not wired in CI yet"
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def stub_main() -> Iterator[int]:
+    """Stand-in for the model container. /predict sleeps for an optional `sleep_s` found anywhere
+    in the forwarded body (async sleep, so it serves concurrent requests like a real model)."""
+    app = FastAPI()
+
+    def _find_sleep(obj):
+        if isinstance(obj, dict):
+            if "sleep_s" in obj:
+                return obj["sleep_s"]
+            for v in obj.values():
+                found = _find_sleep(v)
+                if found is not None:
+                    return found
+        return None
+
+    @app.get("/readyz")
+    def readyz():
+        return "OK"
+
+    @app.post("/predict")
+    async def predict(request: Request):
+        import asyncio
+
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        sleep_s = _find_sleep(body) or 0
+        if sleep_s:
+            await asyncio.sleep(float(sleep_s))
+        return {"result": "ok"}
+
+    proc = multiprocess.context.Process(
+        target=uvicorn.run, args=(app,), kwargs={"port": MAIN_PORT, "log_level": "warning"}
+    )
+    proc.start()
+    for attempt in Retrying(
+        wait=wait_fixed(1),
+        stop=stop_after_attempt(15),
+        retry=retry_if_exception_type(requests.exceptions.RequestException),
+        reraise=True,
+    ):
+        with attempt:
+            assert requests.get(f"http://localhost:{MAIN_PORT}/readyz", timeout=1).status_code == 200
+    yield MAIN_PORT
+    proc.terminate()
+
+
+@pytest.fixture
+def endpoint_config_location() -> Iterator[str]:
+    # No post-inference hooks: keeps these tests independent of firehose/localstack (firehose
+    # client-cache behaviour is unit-tested).
+    serialized = ModelEndpointConfig(
+        endpoint_name="it-endpoint",
+        bundle_name="it-bundle",
+        post_inference_hooks=[],
+        user_id="it-user",
+        endpoint_id="it-endpoint-id",
+        endpoint_type="async",
+        bundle_id="it-bundle-id",
+        labels={},
+    ).serialize()
+    with NamedTemporaryFile(mode="w+") as f:
+        f.write(serialized)
+        f.seek(0)
+        yield f.name
+
+
+def _start_forwarder(
+    queue: str,
+    pool: str,
+    endpoint_config_location: str,
+    concurrency: int = 4,
+    broker: str = "redis",
+    sqs_url: str = None,
+) -> subprocess.Popen:
+    env = {
+        **os.environ,
+        "USE_REDIS_LOCALHOST": "1",
+        "CELERY_WORKER_POOL": pool,
+        "ENDPOINT_CONFIG_LOCATION": endpoint_config_location,
+        "BASE_PATH": os.getcwd(),
+    }
+    cmd = [
+        sys.executable,
+        "-m",
+        "model_engine_server.inference.forwarding.celery_forwarder",
+        "--config", CONFIG_PATH,
+        "--queue", queue,
+        "--task-visibility", "VISIBILITY_24H",
+        "--num-workers", str(concurrency),
+        "--broker-type", broker,
+        "--backend-protocol", "redis",
+        "--set", f"forwarder.async.user_port={MAIN_PORT}",
+        "--set", "forwarder.async.predict_route=/predict",
+        "--set", "forwarder.async.healthcheck_route=/readyz",
+    ]
+    if broker == "sqs":
+        cmd += ["--sqs-url", sqs_url]
+    return subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+
+def _redis_producer():
+    return celery_app(
+        None, task_visibility=TaskVisibility.VISIBILITY_24H, broker_type="redis", backend_protocol="redis"
+    )
+
+
+def _drain(proc: subprocess.Popen):
+    proc.kill()
+    out, _ = proc.communicate()
+    if out:
+        print(out.decode(errors="replace"))
+
+
+@pytest.mark.parametrize("pool", ["prefork", "gevent"])
+def test_forwarder_processes_task_under_pool(pool, stub_main, endpoint_config_location):
+    queue = f"it-fwd-{pool}-{str(uuid4())[-8:]}"
+    producer = _redis_producer()
+    worker = _start_forwarder(queue, pool, endpoint_config_location)
+    try:
+        payload = {"url": None, "args": {"x": 1}, "return_pickled": False}
+        result = producer.send_task(
+            LIRA_CELERY_TASK_NAME, args=[payload, datetime.utcnow()], queue=queue
+        )
+        assert result.get(timeout=60) is not None
+    finally:
+        _drain(worker)
+
+
+def test_gevent_handles_concurrent_tasks_in_one_process(stub_main, endpoint_config_location):
+    # 25 tasks that each take ~0.5s in the model, concurrency 20 in ONE gevent process. Serial
+    # would take ~12.5s; concurrent should be a few seconds. Proves gevent gives prefork-like
+    # concurrency without N processes.
+    queue = f"it-fwd-conc-{str(uuid4())[-8:]}"
+    producer = _redis_producer()
+    worker = _start_forwarder(queue, "gevent", endpoint_config_location, concurrency=20)
+    try:
+        payload = {"url": None, "args": {"sleep_s": 0.5}, "return_pickled": False}
+        start = time.monotonic()
+        results = [
+            producer.send_task(LIRA_CELERY_TASK_NAME, args=[payload, datetime.utcnow()], queue=queue)
+            for _ in range(25)
+        ]
+        for r in results:
+            assert r.get(timeout=60) is not None
+        elapsed = time.monotonic() - start
+        assert elapsed < 8.0, f"25x0.5s tasks took {elapsed:.1f}s; gevent not running concurrently"
+    finally:
+        _drain(worker)
+
+
+def test_gevent_warm_shutdown_drains_inflight_task(stub_main, endpoint_config_location):
+    # SIGTERM the worker while a task is in flight (pod scale-down). Warm shutdown must let the
+    # task finish, so the result is still retrievable.
+    queue = f"it-fwd-term-{str(uuid4())[-8:]}"
+    producer = _redis_producer()
+    worker = _start_forwarder(queue, "gevent", endpoint_config_location)
+    try:
+        payload = {"url": None, "args": {"sleep_s": 5.0}, "return_pickled": False}
+        result = producer.send_task(
+            LIRA_CELERY_TASK_NAME, args=[payload, datetime.utcnow()], queue=queue
+        )
+        # Wait until the task is actually running (track_started=True) before signalling, so we
+        # test draining an in-flight task, not one still queued during worker boot.
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline and result.state not in ("STARTED", "SUCCESS"):
+            time.sleep(0.5)
+        assert result.state in ("STARTED", "SUCCESS"), f"task never started (state={result.state})"
+        worker.send_signal(signal.SIGTERM)  # warm shutdown
+        assert result.get(timeout=30) is not None  # in-flight task still completed
+    finally:
+        _drain(worker)
+
+
+@pytest.mark.skipif(not _localstack_sqs_available(), reason="needs localstack SQS at AWS_ENDPOINT_URL")
+def test_forwarder_processes_task_over_sqs_gevent(stub_main, endpoint_config_location):
+    # Prod's broker is SQS. Validate the kombu/boto SQS transport under gevent end to end.
+    import boto3
+    from celery import Celery
+
+    queue = f"it-fwd-sqs-{str(uuid4())[-8:]}"
+    sqs = boto3.client("sqs", endpoint_url=AWS_ENDPOINT_URL, region_name="us-west-2")
+    sqs_url = sqs.create_queue(QueueName=queue)["QueueUrl"]
+    worker = _start_forwarder(
+        queue, "gevent", endpoint_config_location, broker="sqs", sqs_url=sqs_url
+    )
+    producer = Celery()
+    producer.conf.broker_url = "sqs://"
+    producer.conf.broker_transport_options = {
+        "predefined_queues": {queue: {"url": sqs_url}},
+        "region": "us-west-2",
+    }
+    producer.conf.result_backend = "redis://localhost:6379/0"
+    try:
+        payload = {"url": None, "args": {"x": 1}, "return_pickled": False}  # keep < 256KB (SQS limit)
+        result = producer.send_task(
+            LIRA_CELERY_TASK_NAME, args=[payload, datetime.utcnow()], queue=queue
+        )
+        assert result.get(timeout=90) is not None
+    finally:
+        _drain(worker)

--- a/model-engine/tests/integration/inference/test_forwarder_pool.py
+++ b/model-engine/tests/integration/inference/test_forwarder_pool.py
@@ -36,10 +36,6 @@ MAIN_PORT = 5005  # forwarder.async.user_port (overridden via --set below)
 CONFIG_PATH = "model_engine_server/inference/configs/service--forwarder.yaml"
 AWS_ENDPOINT_URL = os.getenv("AWS_ENDPOINT_URL", "http://localhost:4566")
 
-# The in-process producer resolves redis via get_redis_host_port(), which honors this env (the
-# worker subprocess sets it too). Set it so the producer and the localhost skip-guard agree.
-os.environ.setdefault("USE_REDIS_LOCALHOST", "1")
-
 
 def _redis_available() -> bool:
     try:
@@ -64,6 +60,13 @@ pytestmark = [
         bool(os.getenv("CIRCLECI")), reason="forwarder integration infra not wired in CI yet"
     ),
 ]
+
+
+@pytest.fixture(autouse=True)
+def _use_localhost_redis(monkeypatch):
+    # The in-process producer resolves redis via get_redis_host_port(), which honors this env. Set
+    # it per-test (auto-restored) instead of mutating global env at collection time.
+    monkeypatch.setenv("USE_REDIS_LOCALHOST", "1")
 
 
 @pytest.fixture(scope="module")
@@ -116,6 +119,8 @@ def stub_main() -> Iterator[int]:
     yield MAIN_PORT
     proc.terminate()
     proc.join(timeout=10)
+    if proc.is_alive():  # don't leave port 5005 bound for the next run
+        proc.kill()
 
 
 @pytest.fixture
@@ -252,6 +257,15 @@ def test_gevent_warm_shutdown_drains_inflight_task(stub_main, endpoint_config_lo
     producer = _redis_producer()
     worker = _start_forwarder(queue, "gevent", endpoint_config_location)
     try:
+        # Warm up so the worker is booted and consuming; otherwise boot can eat the window where
+        # the real task is observably STARTED.
+        warmup = {"url": None, "args": {"x": 1}, "return_pickled": False}
+        assert (
+            producer.send_task(
+                LIRA_CELERY_TASK_NAME, args=[warmup, datetime.utcnow()], queue=queue
+            ).get(timeout=60)
+            is not None
+        )
         payload = {"url": None, "args": {"sleep_s": 5.0}, "return_pickled": False}
         result = producer.send_task(
             LIRA_CELERY_TASK_NAME, args=[payload, datetime.utcnow()], queue=queue

--- a/model-engine/tests/integration/inference/test_forwarder_pool.py
+++ b/model-engine/tests/integration/inference/test_forwarder_pool.py
@@ -10,6 +10,7 @@ server, covering:
 Local only: needs redis on localhost (USE_REDIS_LOCALHOST=1); the SQS case also needs a
 localstack SQS endpoint (AWS_ENDPOINT_URL). Skipped in CI, like test_async_inference.py.
 """
+
 import os
 import signal
 import subprocess
@@ -105,7 +106,9 @@ def stub_main() -> Iterator[int]:
         reraise=True,
     ):
         with attempt:
-            assert requests.get(f"http://localhost:{MAIN_PORT}/readyz", timeout=1).status_code == 200
+            assert (
+                requests.get(f"http://localhost:{MAIN_PORT}/readyz", timeout=1).status_code == 200
+            )
     yield MAIN_PORT
     proc.terminate()
 
@@ -149,15 +152,24 @@ def _start_forwarder(
         sys.executable,
         "-m",
         "model_engine_server.inference.forwarding.celery_forwarder",
-        "--config", CONFIG_PATH,
-        "--queue", queue,
-        "--task-visibility", "VISIBILITY_24H",
-        "--num-workers", str(concurrency),
-        "--broker-type", broker,
-        "--backend-protocol", "redis",
-        "--set", f"forwarder.async.user_port={MAIN_PORT}",
-        "--set", "forwarder.async.predict_route=/predict",
-        "--set", "forwarder.async.healthcheck_route=/readyz",
+        "--config",
+        CONFIG_PATH,
+        "--queue",
+        queue,
+        "--task-visibility",
+        "VISIBILITY_24H",
+        "--num-workers",
+        str(concurrency),
+        "--broker-type",
+        broker,
+        "--backend-protocol",
+        "redis",
+        "--set",
+        f"forwarder.async.user_port={MAIN_PORT}",
+        "--set",
+        "forwarder.async.predict_route=/predict",
+        "--set",
+        "forwarder.async.healthcheck_route=/readyz",
     ]
     if broker == "sqs":
         cmd += ["--sqs-url", sqs_url]
@@ -166,7 +178,10 @@ def _start_forwarder(
 
 def _redis_producer():
     return celery_app(
-        None, task_visibility=TaskVisibility.VISIBILITY_24H, broker_type="redis", backend_protocol="redis"
+        None,
+        task_visibility=TaskVisibility.VISIBILITY_24H,
+        broker_type="redis",
+        backend_protocol="redis",
     )
 
 
@@ -203,7 +218,9 @@ def test_gevent_handles_concurrent_tasks_in_one_process(stub_main, endpoint_conf
         payload = {"url": None, "args": {"sleep_s": 0.5}, "return_pickled": False}
         start = time.monotonic()
         results = [
-            producer.send_task(LIRA_CELERY_TASK_NAME, args=[payload, datetime.utcnow()], queue=queue)
+            producer.send_task(
+                LIRA_CELERY_TASK_NAME, args=[payload, datetime.utcnow()], queue=queue
+            )
             for _ in range(25)
         ]
         for r in results:
@@ -237,7 +254,9 @@ def test_gevent_warm_shutdown_drains_inflight_task(stub_main, endpoint_config_lo
         _drain(worker)
 
 
-@pytest.mark.skipif(not _localstack_sqs_available(), reason="needs localstack SQS at AWS_ENDPOINT_URL")
+@pytest.mark.skipif(
+    not _localstack_sqs_available(), reason="needs localstack SQS at AWS_ENDPOINT_URL"
+)
 def test_forwarder_processes_task_over_sqs_gevent(stub_main, endpoint_config_location):
     # Prod's broker is SQS. Validate the kombu/boto SQS transport under gevent end to end.
     import boto3
@@ -257,7 +276,11 @@ def test_forwarder_processes_task_over_sqs_gevent(stub_main, endpoint_config_loc
     }
     producer.conf.result_backend = "redis://localhost:6379/0"
     try:
-        payload = {"url": None, "args": {"x": 1}, "return_pickled": False}  # keep < 256KB (SQS limit)
+        payload = {
+            "url": None,
+            "args": {"x": 1},
+            "return_pickled": False,
+        }  # keep < 256KB (SQS limit)
         result = producer.send_task(
             LIRA_CELERY_TASK_NAME, args=[payload, datetime.utcnow()], queue=queue
         )

--- a/model-engine/tests/integration/inference/test_forwarder_pool.py
+++ b/model-engine/tests/integration/inference/test_forwarder_pool.py
@@ -69,6 +69,16 @@ def _use_localhost_redis(monkeypatch):
     monkeypatch.setenv("USE_REDIS_LOCALHOST", "1")
 
 
+@pytest.fixture(autouse=True)
+def _use_localstack_aws(monkeypatch):
+    # The SQS test's worker subprocess and in-process producer build kombu/botocore SQS clients with
+    # no explicit endpoint; botocore only routes them to localstack when AWS_ENDPOINT_URL is in the
+    # process env. The skip-gate checks localstack with an explicit endpoint_url, so without this it
+    # green-lights the test while those clients hit real AWS. Export it per-test (auto-restored),
+    # like the redis one. The worker subprocess inherits it via os.environ in _start_forwarder.
+    monkeypatch.setenv("AWS_ENDPOINT_URL", AWS_ENDPOINT_URL)
+
+
 @pytest.fixture(scope="module")
 def stub_main() -> Iterator[int]:
     """Stand-in for the model container. /predict sleeps for an optional `sleep_s` found anywhere

--- a/model-engine/tests/integration/inference/test_forwarder_pool.py
+++ b/model-engine/tests/integration/inference/test_forwarder_pool.py
@@ -36,6 +36,10 @@ MAIN_PORT = 5005  # forwarder.async.user_port (overridden via --set below)
 CONFIG_PATH = "model_engine_server/inference/configs/service--forwarder.yaml"
 AWS_ENDPOINT_URL = os.getenv("AWS_ENDPOINT_URL", "http://localhost:4566")
 
+# The in-process producer resolves redis via get_redis_host_port(), which honors this env (the
+# worker subprocess sets it too). Set it so the producer and the localhost skip-guard agree.
+os.environ.setdefault("USE_REDIS_LOCALHOST", "1")
+
 
 def _redis_available() -> bool:
     try:
@@ -111,6 +115,7 @@ def stub_main() -> Iterator[int]:
             )
     yield MAIN_PORT
     proc.terminate()
+    proc.join(timeout=10)
 
 
 @pytest.fixture
@@ -215,6 +220,15 @@ def test_gevent_handles_concurrent_tasks_in_one_process(stub_main, endpoint_conf
     producer = _redis_producer()
     worker = _start_forwarder(queue, "gevent", endpoint_config_location, concurrency=20)
     try:
+        # Warm up: wait until the worker is booted and consuming before timing, so boot time is
+        # not charged against the concurrency budget.
+        warmup = {"url": None, "args": {"x": 1}, "return_pickled": False}
+        assert (
+            producer.send_task(
+                LIRA_CELERY_TASK_NAME, args=[warmup, datetime.utcnow()], queue=queue
+            ).get(timeout=60)
+            is not None
+        )
         payload = {"url": None, "args": {"sleep_s": 0.5}, "return_pickled": False}
         start = time.monotonic()
         results = [
@@ -245,9 +259,11 @@ def test_gevent_warm_shutdown_drains_inflight_task(stub_main, endpoint_config_lo
         # Wait until the task is actually running (track_started=True) before signalling, so we
         # test draining an in-flight task, not one still queued during worker boot.
         deadline = time.monotonic() + 30
-        while time.monotonic() < deadline and result.state not in ("STARTED", "SUCCESS"):
-            time.sleep(0.5)
-        assert result.state in ("STARTED", "SUCCESS"), f"task never started (state={result.state})"
+        while time.monotonic() < deadline and result.state != "STARTED":
+            time.sleep(0.2)
+        assert (
+            result.state == "STARTED"
+        ), f"task not in-flight (state={result.state}); cannot test drain"
         worker.send_signal(signal.SIGTERM)  # warm shutdown
         assert result.get(timeout=30) is not None  # in-flight task still completed
     finally:
@@ -274,7 +290,9 @@ def test_forwarder_processes_task_over_sqs_gevent(stub_main, endpoint_config_loc
         "predefined_queues": {queue: {"url": sqs_url}},
         "region": "us-west-2",
     }
-    producer.conf.result_backend = "redis://localhost:6379/0"
+    producer.conf.result_backend = (
+        "redis://localhost:6379/1"  # worker writes db 1 (get_redis_endpoint(1))
+    )
     try:
         payload = {
             "url": None,

--- a/model-engine/tests/integration/inference/test_forwarder_pool.py
+++ b/model-engine/tests/integration/inference/test_forwarder_pool.py
@@ -121,6 +121,7 @@ def stub_main() -> Iterator[int]:
     proc.join(timeout=10)
     if proc.is_alive():  # don't leave port 5005 bound for the next run
         proc.kill()
+        proc.join(timeout=5)  # reap the SIGKILL'd child so the socket is released
 
 
 @pytest.fixture

--- a/model-engine/tests/unit/inference/test_celery_forwarder_pool.py
+++ b/model-engine/tests/unit/inference/test_celery_forwarder_pool.py
@@ -40,3 +40,15 @@ def test_gevent_pool_monkeypatches_sockets():
 def test_prefork_pool_does_not_monkeypatch():
     # default/prefork must not import or patch gevent, so existing behaviour is unchanged.
     assert "socket_patched False" in _import_with_pool("prefork")
+
+
+def test_unsupported_pool_fails_fast():
+    # A typo'd / unsupported pool must fail fast at import, not start a misconfigured worker.
+    proc = subprocess.run(
+        [sys.executable, "-c", "import model_engine_server.inference.forwarding.celery_forwarder"],
+        env={**os.environ, "CELERY_WORKER_POOL": "bogus"},
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode != 0
+    assert "Unsupported CELERY_WORKER_POOL" in proc.stderr

--- a/model-engine/tests/unit/inference/test_celery_forwarder_pool.py
+++ b/model-engine/tests/unit/inference/test_celery_forwarder_pool.py
@@ -1,0 +1,41 @@
+"""Guards the celery-forwarder's worker-pool wiring (MLI-7328).
+
+The gevent monkey-patch lives at the top of celery_forwarder.py and must run BEFORE the module
+imports celery/boto/requests, or their sockets stay un-patched and greenlets never yield. These
+run in a subprocess (monkey-patching is process-global) and assert:
+  - CELERY_WORKER_POOL=gevent  -> importing the module patches sockets
+  - default (prefork)          -> nothing is patched (prefork is byte-for-byte unaffected)
+"""
+import os
+import subprocess
+import sys
+
+import pytest
+
+pytest.importorskip("gevent")
+
+_CHECK = (
+    "import model_engine_server.inference.forwarding.celery_forwarder;"  # runs the guarded patch
+    "import gevent.monkey;"
+    "print('socket_patched', gevent.monkey.is_module_patched('socket'))"
+)
+
+
+def _import_with_pool(pool: str) -> str:
+    proc = subprocess.run(
+        [sys.executable, "-c", _CHECK],
+        env={**os.environ, "CELERY_WORKER_POOL": pool},
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout
+
+
+def test_gevent_pool_monkeypatches_sockets():
+    assert "socket_patched True" in _import_with_pool("gevent")
+
+
+def test_prefork_pool_does_not_monkeypatch():
+    # default/prefork must not import or patch gevent, so existing behaviour is unchanged.
+    assert "socket_patched False" in _import_with_pool("prefork")

--- a/model-engine/tests/unit/inference/test_celery_forwarder_pool.py
+++ b/model-engine/tests/unit/inference/test_celery_forwarder_pool.py
@@ -6,6 +6,7 @@ run in a subprocess (monkey-patching is process-global) and assert:
   - CELERY_WORKER_POOL=gevent  -> importing the module patches sockets
   - default (prefork)          -> nothing is patched (prefork is byte-for-byte unaffected)
 """
+
 import os
 import subprocess
 import sys

--- a/model-engine/tests/unit/inference/test_celery_forwarder_pool.py
+++ b/model-engine/tests/unit/inference/test_celery_forwarder_pool.py
@@ -2,12 +2,16 @@
 
 The gevent monkey-patch lives at the top of celery_forwarder.py and must run BEFORE the module
 imports celery/boto/requests, or their sockets stay un-patched and greenlets never yield. These
-run in a subprocess (monkey-patching is process-global) and assert:
-  - CELERY_WORKER_POOL=gevent  -> importing the module patches sockets
+run in a subprocess (monkey-patching is process-global) and the child does the real assertion and
+exits non-zero on failure, so the parent checks the exit code rather than scraping stdout/stderr:
+  - CELERY_WORKER_POOL=gevent  -> importing the module patches socket + ssl
   - default (prefork)          -> nothing is patched (prefork is byte-for-byte unaffected)
+  - an unsupported pool value  -> raises ValueError at import
+  - gevent under ddtrace-run (-m, the prod launch) boots without the import-lock crash
 """
 
 import os
+import shutil
 import subprocess
 import sys
 
@@ -15,40 +19,66 @@ import pytest
 
 pytest.importorskip("gevent")
 
-_CHECK = (
-    "import model_engine_server.inference.forwarding.celery_forwarder;"  # runs the guarded patch
-    "import gevent.monkey;"
-    "print('socket_patched', gevent.monkey.is_module_patched('socket'))"
-)
+_IMPORT = "import model_engine_server.inference.forwarding.celery_forwarder"
 
 
-def _import_with_pool(pool: str) -> str:
-    proc = subprocess.run(
-        [sys.executable, "-c", _CHECK],
+def _run(check: str, pool: str) -> subprocess.CompletedProcess:
+    # Subprocess because gevent monkey-patching is process-global; the child asserts and exits, so
+    # we read the exit code instead of string-matching its output.
+    return subprocess.run(
+        [sys.executable, "-c", check],
         env={**os.environ, "CELERY_WORKER_POOL": pool},
         capture_output=True,
         text=True,
     )
-    assert proc.returncode == 0, proc.stderr
-    return proc.stdout
 
 
-def test_gevent_pool_monkeypatches_sockets():
-    assert "socket_patched True" in _import_with_pool("gevent")
+def test_gevent_pool_monkeypatches_socket_and_ssl():
+    check = (
+        f"{_IMPORT}; import gevent.monkey as g;"
+        " assert g.is_module_patched('socket') and g.is_module_patched('ssl')"
+    )
+    assert _run(check, "gevent").returncode == 0
 
 
 def test_prefork_pool_does_not_monkeypatch():
     # default/prefork must not import or patch gevent, so existing behaviour is unchanged.
-    assert "socket_patched False" in _import_with_pool("prefork")
+    check = (
+        f"{_IMPORT}; import gevent.monkey as g;"
+        " assert not g.is_module_patched('socket') and not g.is_module_patched('ssl')"
+    )
+    assert _run(check, "prefork").returncode == 0
 
 
 def test_unsupported_pool_fails_fast():
-    # A typo'd / unsupported pool must fail fast at import, not start a misconfigured worker.
+    # A typo'd / unsupported pool must raise ValueError at import; exit 0 only if it did.
+    check = (
+        "try:\n"
+        f"    {_IMPORT}\n"
+        "except ValueError:\n"
+        "    raise SystemExit(0)\n"
+        "raise SystemExit(1)\n"
+    )
+    assert _run(check, "bogus").returncode == 0
+
+
+def test_gevent_boots_under_ddtrace_run():
+    # MLI-7328 #2 ordering guard: prod launches `ddtrace-run python -m ...celery_forwarder`.
+    # ddtrace instruments at startup, then the module's patch_all() runs. The chain must boot via
+    # __main__ (-m); a plain import under ddtrace-run instead deadlocks the import lock, which
+    # surfaces as a non-zero exit. --help exits right after the module body, so no infra is needed.
+    if not shutil.which("ddtrace-run"):
+        pytest.skip("ddtrace-run not installed")
     proc = subprocess.run(
-        [sys.executable, "-c", "import model_engine_server.inference.forwarding.celery_forwarder"],
-        env={**os.environ, "CELERY_WORKER_POOL": "bogus"},
+        [
+            "ddtrace-run",
+            sys.executable,
+            "-m",
+            "model_engine_server.inference.forwarding.celery_forwarder",
+            "--help",
+        ],
+        env={**os.environ, "CELERY_WORKER_POOL": "gevent"},
         capture_output=True,
         text=True,
     )
-    assert proc.returncode != 0
-    assert "Unsupported CELERY_WORKER_POOL" in proc.stderr
+    assert proc.returncode == 0, proc.stderr

--- a/model-engine/tests/unit/inference/test_celery_forwarder_pool.py
+++ b/model-engine/tests/unit/inference/test_celery_forwarder_pool.py
@@ -24,12 +24,14 @@ _IMPORT = "import model_engine_server.inference.forwarding.celery_forwarder"
 
 def _run(check: str, pool: str) -> subprocess.CompletedProcess:
     # Subprocess because gevent monkey-patching is process-global; the child asserts and exits, so
-    # we read the exit code instead of string-matching its output.
+    # we read the exit code instead of string-matching its output. timeout so a regression that
+    # deadlocks (e.g. the import-lock hazard) fails the test instead of hanging the run.
     return subprocess.run(
         [sys.executable, "-c", check],
         env={**os.environ, "CELERY_WORKER_POOL": pool},
         capture_output=True,
         text=True,
+        timeout=60,
     )
 
 
@@ -80,5 +82,6 @@ def test_gevent_boots_under_ddtrace_run():
         env={**os.environ, "CELERY_WORKER_POOL": "gevent"},
         capture_output=True,
         text=True,
+        timeout=60,  # a deadlock regression must fail here, not hang the run
     )
     assert proc.returncode == 0, proc.stderr

--- a/model-engine/tests/unit/inference/test_celery_forwarder_worker.py
+++ b/model-engine/tests/unit/inference/test_celery_forwarder_worker.py
@@ -1,0 +1,42 @@
+"""Unit tests for start_celery_service worker wiring (MLI-7328).
+
+CELERY_WORKER_MAX_TASKS_PER_CHILD is an opt-in, prefork-only knob: when set it recycles each
+worker child after N tasks (defense-in-depth against per-task memory residue such as glibc arena
+retention). It is off by default so prefork behaviour is unchanged, and ignored under gevent
+(which has no per-child recycling). app.Worker is mocked so .start() does not run a real worker.
+"""
+
+from unittest.mock import MagicMock
+
+from model_engine_server.inference.forwarding import celery_forwarder
+
+
+def _worker_kwargs(monkeypatch, pool, env_value):
+    monkeypatch.setattr(celery_forwarder, "CELERY_WORKER_POOL", pool)
+    if env_value is None:
+        monkeypatch.delenv("CELERY_WORKER_MAX_TASKS_PER_CHILD", raising=False)
+    else:
+        monkeypatch.setenv("CELERY_WORKER_MAX_TASKS_PER_CHILD", env_value)
+    app = MagicMock()
+    celery_forwarder.start_celery_service(app, "q", 4)
+    app.Worker.assert_called_once()
+    app.Worker.return_value.start.assert_called_once()
+    return app.Worker.call_args.kwargs
+
+
+def test_max_tasks_per_child_unset_by_default(monkeypatch):
+    # Prefork unchanged when the env is not set.
+    kwargs = _worker_kwargs(monkeypatch, "prefork", None)
+    assert "max_tasks_per_child" not in kwargs
+
+
+def test_max_tasks_per_child_applied_under_prefork(monkeypatch):
+    kwargs = _worker_kwargs(monkeypatch, "prefork", "500")
+    assert kwargs["max_tasks_per_child"] == 500
+
+
+def test_max_tasks_per_child_ignored_under_gevent(monkeypatch):
+    # gevent runs one process with no per-child recycling, so the knob is a no-op there.
+    kwargs = _worker_kwargs(monkeypatch, "gevent", "500")
+    assert kwargs["pool"] == "gevent"
+    assert "max_tasks_per_child" not in kwargs

--- a/model-engine/tests/unit/infra/gateways/test_firehose_streaming_storage_gateway.py
+++ b/model-engine/tests/unit/infra/gateways/test_firehose_streaming_storage_gateway.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 from model_engine_server.domain.exceptions import StreamPutException
 from model_engine_server.inference.infra.gateways.firehose_streaming_storage_gateway import (
+    _FIREHOSE_MAX_POOL_CONNECTIONS,
     FirehoseStreamingStorageGateway,
 )
 
@@ -83,9 +84,9 @@ def test_uses_refreshable_assumed_role_credentials(gateway):
     sts.assume_role.assert_called()
     assert create_creds.call_count == 1  # creds/client built once, then reused
     assert firehose.put_record.call_count == 2
-    # built with the sized connection pool (default 50); guards a silent Config drop -> ~10 conns.
+    # built with the sized connection pool; guards a silent Config drop -> ~10 conns.
     _, client_kwargs = firehose_session.client.call_args
-    assert client_kwargs["config"].max_pool_connections == 50
+    assert client_kwargs["config"].max_pool_connections == _FIREHOSE_MAX_POOL_CONNECTIONS
 
 
 def test_refresh_callback_reassumes_role(gateway):

--- a/model-engine/tests/unit/infra/gateways/test_firehose_streaming_storage_gateway.py
+++ b/model-engine/tests/unit/infra/gateways/test_firehose_streaming_storage_gateway.py
@@ -6,92 +6,115 @@ from model_engine_server.inference.infra.gateways.firehose_streaming_storage_gat
     FirehoseStreamingStorageGateway,
 )
 
+GW = "model_engine_server.inference.infra.gateways.firehose_streaming_storage_gateway"
 stream_name = "fake-stream"
-
-return_value = {
-    "RecordId": "fake-record-id",
-    "Encrypted": False,
-    "ResponseMetadata": {"HTTPStatusCode": 200},
-}
+fake_record = {"RESPONSE_BODY": {"task_id": "fake-task-id"}}
+ok_response = {"RecordId": "fake-record-id", "ResponseMetadata": {"HTTPStatusCode": 200}}
+err_response = {"RecordId": "fake-record-id", "ResponseMetadata": {"HTTPStatusCode": 500}}
 
 
 @pytest.fixture
-def streaming_storage_gateway():
-    gateway = FirehoseStreamingStorageGateway()
-    return gateway
+def gateway():
+    return FirehoseStreamingStorageGateway()
 
 
-@pytest.fixture
-def fake_record():
-    return {"RESPONSE_BODY": {"task_id": "fake-task-id"}}
+def _fake_client(put_return):
+    client = mock.Mock()
+    client.put_record.return_value = put_return
+    return client
 
 
-def mock_sts_client(*args, **kwargs):
-    mock_client = mock.Mock()
-    mock_client.assume_role.return_value = {
-        "Credentials": {
-            "AccessKeyId": "fake-access-key-id",
-            "SecretAccessKey": "fake-secret-access-key",
-            "SessionToken": "fake-session-token",
-        }
-    }
-    return mock_client
-
-
-def mock_firehose_client(*args, **kwargs):
-    mock_client = mock.Mock()
-    mock_client.put_record.return_value = return_value
-    return mock_client
-
-
-def mock_firehose_client_with_exception(*args, **kwargs):
-    mock_client = mock.Mock()
-    mock_client.put_record.return_value = {
-        "RecordId": "fake-record-id",
-        "Encrypted": False,
-        "ResponseMetadata": {"HTTPStatusCode": 500},
-    }
-    return mock_client
-
-
-mock_sts_session = mock.Mock()
-mock_sts_session.client.return_value = mock_sts_client()
-
-
-mock_firehose_session = mock.Mock()
-mock_firehose_session.client.return_value = mock_firehose_client()
-
-
-mock_session_with_exception = mock.Mock()
-mock_session_with_exception.client.return_value = mock_firehose_client_with_exception()
-
-
-def test_firehose_streaming_storage_gateway_put_record(streaming_storage_gateway, fake_record):
-    with (
-        mock.patch(
-            "model_engine_server.inference.infra.gateways.firehose_streaming_storage_gateway.boto3.client",
-            mock_sts_client,
-        ),
-        mock.patch(
-            "model_engine_server.inference.infra.gateways.firehose_streaming_storage_gateway.boto3.Session",
-            side_effect=[mock_sts_session, mock_firehose_session],
-        ),
+def test_put_record_success(gateway):
+    with mock.patch.object(
+        FirehoseStreamingStorageGateway,
+        "_make_refreshable_client",
+        return_value=_fake_client(ok_response),
     ):
-        assert streaming_storage_gateway.put_record(stream_name, fake_record) is return_value
+        assert gateway.put_record(stream_name, fake_record) is ok_response
 
 
-def test_firehose_streaming_storage_gateway_put_record_with_exception(
-    streaming_storage_gateway, fake_record
-):
-    with (
-        mock.patch(
-            "model_engine_server.inference.infra.gateways.firehose_streaming_storage_gateway.boto3.client",
-            mock_sts_client,
-        ),
-        mock.patch(
-            "model_engine_server.inference.infra.gateways.firehose_streaming_storage_gateway.boto3.Session",
-            side_effect=[mock_sts_session, mock_session_with_exception],
-        ),
+def test_put_record_raises_on_non_200(gateway):
+    with mock.patch.object(
+        FirehoseStreamingStorageGateway,
+        "_make_refreshable_client",
+        return_value=_fake_client(err_response),
     ):
         with pytest.raises(StreamPutException):
-            streaming_storage_gateway.put_record(stream_name, fake_record)
+            gateway.put_record(stream_name, fake_record)
+
+
+def test_client_built_once_across_calls(gateway):
+    # MLI-7328 regression: client must be cached, not rebuilt per put_record. Per-call
+    # construction leaked memory and OOM-killed the forwarder. Fails if that is reintroduced.
+    client = _fake_client(ok_response)
+    with mock.patch.object(
+        FirehoseStreamingStorageGateway, "_make_refreshable_client", return_value=client
+    ) as make_client:
+        for _ in range(25):
+            gateway.put_record(stream_name, fake_record)
+    assert make_client.call_count == 1
+    assert client.put_record.call_count == 25
+
+
+def test_uses_refreshable_assumed_role_credentials(gateway):
+    # Cached client must be backed by RefreshableCredentials so it survives the temporary STS
+    # token expiry without a rebuild.
+    sts = mock.Mock()
+    sts.assume_role.return_value = {
+        "Credentials": {
+            "AccessKeyId": "ak",
+            "SecretAccessKey": "sk",
+            "SessionToken": "tok",
+            "Expiration": mock.Mock(isoformat=lambda: "2099-01-01T00:00:00Z"),
+        }
+    }
+    firehose = _fake_client(ok_response)
+    sts_session = mock.Mock()
+    sts_session.client.return_value = sts
+    firehose_session = mock.Mock()
+    firehose_session.client.return_value = firehose
+    with (
+        mock.patch(f"{GW}.boto3.Session", side_effect=[sts_session, firehose_session]),
+        mock.patch(f"{GW}.RefreshableCredentials.create_from_metadata") as create_creds,
+        mock.patch(f"{GW}.get_session"),
+    ):
+        gateway.put_record(stream_name, fake_record)
+        gateway.put_record(stream_name, fake_record)
+    sts.assume_role.assert_called()
+    assert create_creds.call_count == 1  # creds/client built once, then reused
+    assert firehose.put_record.call_count == 2
+
+
+def test_refresh_callback_reassumes_role(gateway):
+    # Guards the refresh path deterministically (no 1h wait): botocore calls the refresh_using
+    # callback near expiry; it must re-run assume_role and return fresh creds, so the cached
+    # client keeps working past the temporary token's expiry.
+    sts = mock.Mock()
+    sts.assume_role.return_value = {
+        "Credentials": {
+            "AccessKeyId": "ak",
+            "SecretAccessKey": "sk",
+            "SessionToken": "tok",
+            "Expiration": mock.Mock(isoformat=lambda: "2099-01-01T00:00:00Z"),
+        }
+    }
+    firehose = _fake_client(ok_response)
+    session = mock.Mock()
+    session.client.side_effect = lambda service, **kw: sts if service == "sts" else firehose
+    captured = {}
+
+    def capture_create(metadata, refresh_using, method):
+        captured["refresh_using"] = refresh_using
+        return mock.Mock()
+
+    with (
+        mock.patch(f"{GW}.boto3.Session", return_value=session),
+        mock.patch(f"{GW}.RefreshableCredentials.create_from_metadata", side_effect=capture_create),
+        mock.patch(f"{GW}.get_session"),
+    ):
+        gateway._get_firehose_client()
+        assert sts.assume_role.call_count == 1  # initial assume on build
+
+        refreshed = captured["refresh_using"]()  # what botocore calls near expiry
+        assert sts.assume_role.call_count == 2  # re-assumed, no client rebuild
+        assert refreshed["access_key"] == "ak" and "expiry_time" in refreshed

--- a/model-engine/tests/unit/infra/gateways/test_firehose_streaming_storage_gateway.py
+++ b/model-engine/tests/unit/infra/gateways/test_firehose_streaming_storage_gateway.py
@@ -83,6 +83,9 @@ def test_uses_refreshable_assumed_role_credentials(gateway):
     sts.assume_role.assert_called()
     assert create_creds.call_count == 1  # creds/client built once, then reused
     assert firehose.put_record.call_count == 2
+    # built with the sized connection pool (default 50); guards a silent Config drop -> ~10 conns.
+    _, client_kwargs = firehose_session.client.call_args
+    assert client_kwargs["config"].max_pool_connections == 50
 
 
 def test_refresh_callback_reassumes_role(gateway):

--- a/model-engine/tests/unit/infra/gateways/test_firehose_streaming_storage_gateway.py
+++ b/model-engine/tests/unit/infra/gateways/test_firehose_streaming_storage_gateway.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta, timezone
 from unittest import mock
 
 import pytest
@@ -8,10 +9,10 @@ from model_engine_server.inference.infra.gateways.firehose_streaming_storage_gat
 )
 
 GW = "model_engine_server.inference.infra.gateways.firehose_streaming_storage_gateway"
-stream_name = "fake-stream"
-fake_record = {"RESPONSE_BODY": {"task_id": "fake-task-id"}}
-ok_response = {"RecordId": "fake-record-id", "ResponseMetadata": {"HTTPStatusCode": 200}}
-err_response = {"RecordId": "fake-record-id", "ResponseMetadata": {"HTTPStatusCode": 500}}
+STREAM = "fake-stream"
+RECORD = {"RESPONSE_BODY": {"task_id": "fake-task-id"}}
+OK = {"RecordId": "rid", "ResponseMetadata": {"HTTPStatusCode": 200}}
+ERR = {"RecordId": "rid", "ResponseMetadata": {"HTTPStatusCode": 500}}
 
 
 @pytest.fixture
@@ -19,121 +20,86 @@ def gateway():
     return FirehoseStreamingStorageGateway()
 
 
-def _fake_client(put_return):
+def _firehose(put_return):
     client = mock.Mock()
     client.put_record.return_value = put_return
     return client
 
 
+def _patch_boto(firehose, expiry):
+    # Route boto3.client by service: "sts" returns a stub whose assume_role yields creds expiring
+    # at `expiry`; anything else ("firehose") returns the given firehose stub. The real
+    # _build_client runs, so the assume_role -> client wiring is exercised, not stubbed out.
+    sts = mock.Mock()
+    sts.assume_role.return_value = {
+        "Credentials": {
+            "AccessKeyId": "ak",
+            "SecretAccessKey": "sk",
+            "SessionToken": "tok",
+            "Expiration": expiry,
+        }
+    }
+    return sts, mock.patch(
+        f"{GW}.boto3.client", side_effect=lambda svc, **_: sts if svc == "sts" else firehose
+    )
+
+
+def _valid():
+    return datetime.now(timezone.utc) + timedelta(hours=1)
+
+
 def test_put_record_success(gateway):
-    with mock.patch.object(
-        FirehoseStreamingStorageGateway,
-        "_make_refreshable_client",
-        return_value=_fake_client(ok_response),
-    ):
-        assert gateway.put_record(stream_name, fake_record) is ok_response
+    _, patch = _patch_boto(_firehose(OK), _valid())
+    with patch:
+        assert gateway.put_record(STREAM, RECORD) is OK
 
 
 def test_put_record_raises_on_non_200(gateway):
-    with mock.patch.object(
-        FirehoseStreamingStorageGateway,
-        "_make_refreshable_client",
-        return_value=_fake_client(err_response),
-    ):
+    _, patch = _patch_boto(_firehose(ERR), _valid())
+    with patch:
         with pytest.raises(StreamPutException):
-            gateway.put_record(stream_name, fake_record)
+            gateway.put_record(STREAM, RECORD)
 
 
-def test_client_built_once_across_calls(gateway):
-    # MLI-7328 regression: client must be cached, not rebuilt per put_record. Per-call
-    # construction leaked memory and OOM-killed the forwarder. Fails if that is reintroduced.
-    client = _fake_client(ok_response)
-    with mock.patch.object(
-        FirehoseStreamingStorageGateway, "_make_refreshable_client", return_value=client
-    ) as make_client:
+def test_client_built_once_while_token_valid(gateway):
+    # MLI-7328 regression: while the token is valid the client is built once, not per call.
+    sts, patch = _patch_boto(_firehose(OK), _valid())
+    with patch:
         for _ in range(25):
-            gateway.put_record(stream_name, fake_record)
-    assert make_client.call_count == 1
-    assert client.put_record.call_count == 25
+            gateway.put_record(STREAM, RECORD)
+    assert sts.assume_role.call_count == 1
 
 
-def test_uses_refreshable_assumed_role_credentials(gateway):
-    # Cached client must be backed by RefreshableCredentials so it survives the temporary STS
-    # token expiry without a rebuild.
-    sts = mock.Mock()
-    sts.assume_role.return_value = {
-        "Credentials": {
-            "AccessKeyId": "ak",
-            "SecretAccessKey": "sk",
-            "SessionToken": "tok",
-            "Expiration": mock.Mock(isoformat=lambda: "2099-01-01T00:00:00Z"),
-        }
-    }
-    firehose = _fake_client(ok_response)
-    sts_session = mock.Mock()
-    sts_session.client.return_value = sts
-    firehose_session = mock.Mock()
-    firehose_session.client.return_value = firehose
-    with (
-        mock.patch(f"{GW}.boto3.Session", side_effect=[sts_session, firehose_session]),
-        mock.patch(f"{GW}.RefreshableCredentials.create_from_metadata") as create_creds,
-        mock.patch(f"{GW}.get_session"),
-    ):
-        gateway.put_record(stream_name, fake_record)
-        gateway.put_record(stream_name, fake_record)
-    sts.assume_role.assert_called()
-    assert create_creds.call_count == 1  # creds/client built once, then reused
-    assert firehose.put_record.call_count == 2
-    # built with the sized connection pool; guards a silent Config drop -> ~10 conns.
-    _, client_kwargs = firehose_session.client.call_args
-    assert client_kwargs["config"].max_pool_connections == _FIREHOSE_MAX_POOL_CONNECTIONS
+def test_client_built_with_assumed_role_creds_and_pool(gateway):
+    # Wiring guard: the client uses the assumed-role session token and the sized connection pool
+    # (a silent Config drop would revert to ~10 connections under gevent).
+    _, patch = _patch_boto(_firehose(OK), _valid())
+    with patch as boto_client:
+        gateway.put_record(STREAM, RECORD)
+    fh = next(c for c in boto_client.call_args_list if c.args and c.args[0] == "firehose")
+    assert fh.kwargs["aws_session_token"] == "tok"
+    assert fh.kwargs["config"].max_pool_connections == _FIREHOSE_MAX_POOL_CONNECTIONS
 
 
-def test_refresh_callback_reassumes_role(gateway):
-    # Guards the refresh path deterministically (no 1h wait): botocore calls the refresh_using
-    # callback near expiry; it must re-run assume_role and return fresh creds, so the cached
-    # client keeps working past the temporary token's expiry.
-    sts = mock.Mock()
-    sts.assume_role.return_value = {
-        "Credentials": {
-            "AccessKeyId": "ak",
-            "SecretAccessKey": "sk",
-            "SessionToken": "tok",
-            "Expiration": mock.Mock(isoformat=lambda: "2099-01-01T00:00:00Z"),
-        }
-    }
-    firehose = _fake_client(ok_response)
-    session = mock.Mock()
-    session.client.side_effect = lambda service, **kw: sts if service == "sts" else firehose
-    captured = {}
-
-    def capture_create(metadata, refresh_using, method):
-        captured["refresh_using"] = refresh_using
-        return mock.Mock()
-
-    with (
-        mock.patch(f"{GW}.boto3.Session", return_value=session),
-        mock.patch(f"{GW}.RefreshableCredentials.create_from_metadata", side_effect=capture_create),
-        mock.patch(f"{GW}.get_session"),
-    ):
-        gateway._get_firehose_client()
-        assert sts.assume_role.call_count == 1  # initial assume on build
-
-        refreshed = captured["refresh_using"]()  # what botocore calls near expiry
-        assert sts.assume_role.call_count == 2  # re-assumed, no client rebuild
-        assert refreshed["access_key"] == "ak" and "expiry_time" in refreshed
+def test_rebuilds_when_token_near_expiry(gateway):
+    # Token within the refresh leeway -> the next call re-assumes and rebuilds, rather than reusing
+    # an about-to-expire client. (assume_role goes 1 -> 2.)
+    sts, patch = _patch_boto(_firehose(OK), datetime.now(timezone.utc) + timedelta(minutes=1))
+    with patch:
+        gateway.put_record(STREAM, RECORD)
+        assert sts.assume_role.call_count == 1
+        gateway.put_record(STREAM, RECORD)
+        assert sts.assume_role.call_count == 2
 
 
 def test_failed_build_leaves_client_unset_and_retries(gateway):
-    # If building the client fails, the cache must stay empty so the next call retries instead of
-    # caching a broken client (the build is the load-bearing step of the MLI-7328 fix).
-    good = _fake_client(ok_response)
+    # A failed build must not cache a broken client; the next call retries (and can succeed).
     with mock.patch.object(
         FirehoseStreamingStorageGateway,
-        "_make_refreshable_client",
-        side_effect=[RuntimeError("assume_role failed"), good],
+        "_build_client",
+        side_effect=[RuntimeError("assume_role failed"), _firehose(OK)],
     ):
         with pytest.raises(RuntimeError):
-            gateway.put_record(stream_name, fake_record)
+            gateway.put_record(STREAM, RECORD)
         assert gateway._client is None  # not cached after a failed build
-        assert gateway.put_record(stream_name, fake_record) is ok_response  # retried and succeeded
+        assert gateway.put_record(STREAM, RECORD) is OK  # retried and succeeded

--- a/model-engine/tests/unit/infra/gateways/test_firehose_streaming_storage_gateway.py
+++ b/model-engine/tests/unit/infra/gateways/test_firehose_streaming_storage_gateway.py
@@ -118,3 +118,18 @@ def test_refresh_callback_reassumes_role(gateway):
         refreshed = captured["refresh_using"]()  # what botocore calls near expiry
         assert sts.assume_role.call_count == 2  # re-assumed, no client rebuild
         assert refreshed["access_key"] == "ak" and "expiry_time" in refreshed
+
+
+def test_failed_build_leaves_client_unset_and_retries(gateway):
+    # If building the client fails, the cache must stay empty so the next call retries instead of
+    # caching a broken client (the build is the load-bearing step of the MLI-7328 fix).
+    good = _fake_client(ok_response)
+    with mock.patch.object(
+        FirehoseStreamingStorageGateway,
+        "_make_refreshable_client",
+        side_effect=[RuntimeError("assume_role failed"), good],
+    ):
+        with pytest.raises(RuntimeError):
+            gateway.put_record(stream_name, fake_record)
+        assert gateway._client is None  # not cached after a failed build
+        assert gateway.put_record(stream_name, fake_record) is ok_response  # retried and succeeded

--- a/model-engine/tests/unit/infra/gateways/test_firehose_streaming_storage_gateway.py
+++ b/model-engine/tests/unit/infra/gateways/test_firehose_streaming_storage_gateway.py
@@ -97,9 +97,20 @@ def test_failed_build_leaves_client_unset_and_retries(gateway):
     with mock.patch.object(
         FirehoseStreamingStorageGateway,
         "_build_client",
-        side_effect=[RuntimeError("assume_role failed"), _firehose(OK)],
+        side_effect=[RuntimeError("assume_role failed"), (_firehose(OK), _valid())],
     ):
         with pytest.raises(RuntimeError):
             gateway.put_record(STREAM, RECORD)
         assert gateway._client is None  # not cached after a failed build
         assert gateway.put_record(STREAM, RECORD) is OK  # retried and succeeded
+
+
+def test_build_client_is_pure(gateway):
+    # _build_client must not mutate self; the caller assigns client + expiry atomically. This is
+    # what stops a failed (re)build from advancing _expiry past a client we never installed (which
+    # would skip future rebuilds and pin a stale/expiring client).
+    _, patch = _patch_boto(_firehose(OK), _valid())
+    with patch:
+        client, expiry = gateway._build_client()
+    assert gateway._client is None and gateway._expiry is None  # untouched
+    assert client is not None and expiry is not None  # returned, not stored


### PR DESCRIPTION
## Problem (MLI-7328)
The `logging` post-inference hook calls `FirehoseStreamingStorageGateway.put_record()` on every async task. The gateway rebuilt an STS client, called `assume_role`, and built a new Firehose client on **every** call. Under the celery prefork pool the workers are long-lived with no child recycling, so that per-task client churn grew each worker's RSS until the celery-forwarder was OOM-killed at its 2Gi limit (it OOMs while holding ~no in-flight work, matching the reported symptom).

## Fix
- **Cache the Firehose client** (built once per worker), rebuilt shortly *before* the assumed-role token expires (once per token lifetime, not per task), using only public boto3 APIs (no botocore-internal credential injection). Removes the per-task client churn and per-task STS round-trip. Same role/region assumptions as before.
- **Opt-in gevent worker pool** (`CELERY_WORKER_POOL=gevent`): the forwarder is IO-bound, so gevent runs the same concurrency in one process instead of N, at much lower memory. Monkey-patch happens before imports, in the right order for ddtrace context. **Prefork stays the default; the gevent monkey-patch and pool selection are skipped entirely under it.**
- **Opt-in prefork child recycling** (`CELERY_WORKER_MAX_TASKS_PER_CHILD`): recycle each prefork child after N tasks so the OS reclaims any per-task residue (e.g. glibc arena fragmentation). Off unless set; defense-in-depth, independent of the cache fix. No effect under gevent.

## Changes
- `inference/infra/gateways/firehose_streaming_storage_gateway.py`: cached client, rebuilt ahead of assumed-role token expiry via public `boto3.client(..., aws_session_token=...)` (no botocore-internal credential injection); lazy init guarded by a lock and a sized connection pool (both for gevent-safety; no-ops under prefork).
- `inference/forwarding/celery_forwarder.py`: guarded gevent monkey-patch + pool selection + env-gated `max_tasks_per_child` (prefork).
- `requirements.{in,txt}`: add `gevent`.
- `core/celery/s3.py`: comment noting the per-thread result-backend cache is per-greenlet (bounded) under gevent.
- Tests: firehose built-once + rebuild-before-expiry + build-failure-retry unit tests; gevent import-order + worker-pool wiring unit tests (incl. `max_tasks_per_child` gating); `test_forwarder_pool.py` integration tests (prefork, gevent, concurrency, SQS, warm-shutdown).

## Behavior / rollout
- The firehose cache fix applies to both pools and is the live change on prefork (it is the OOM fix). The pool/concurrency model changes only if `CELERY_WORKER_POOL=gevent` is set.
- Turning gevent on is a companion model-engine-internal change (set the env on the forwarder, resize the pod: ~1 CPU/process, lower memory, scale via replicas). Once deployed with gevent, the existing minikube async e2e covers it.

## Validation (full detail in the linked doc)
- Unit suite green, including the new cache/rebuild/pool-ordering guards.
- Note: the 4h/7h soaks below ran an earlier in-place credential-refresh variant; they validate the cache fix (no per-task churn -> no leak). The shipped rebuild-ahead-of-expiry mechanism is separately validated: unit tests + a 3h prefork soak (52k tasks, ~24 client rebuilds over ~2.4 cycles, memory bounded ~64-79%, 0 errors, no OOM).
- Native prod-equivalent repro: prefork + hook OOMs at ~t25m; with the cache fix memory plateaus, no OOM. gevent runs in 1 process at ~4-6x lower memory, validated for correctness, concurrency, the SQS broker (prod's broker), credential refresh, and warm-shutdown; a 4h gevent + SQS + S3 + firehose soak (results in the doc) stays flat.
- Prefork (the shipping path) + cache soak-validated over SQS + S3 + firehose at 2Gi for 7h / 121k tasks: memory plateaus (bounded, no leak), no OOM, 0 errors, cache holds across ~62 credential refreshes. (At 2Gi the steady-state working set is high ~84% under SQS — a sizing matter, not the leak.)

## Notes for reviewer
- `requirements.txt` was edited by hand; please regenerate with pip-compile to confirm pins.
- gevent is a new dependency; cp314 wheels exist for x86_64 and aarch64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the celery-forwarder OOM by caching the Firehose boto3 client per worker (rebuilding only before assumed-role token expiry, not per task) and adds an opt-in gevent worker pool for lower memory footprint at equal concurrency.

- **Firehose client caching** (`firehose_streaming_storage_gateway.py`): a pure `_build_client()` returns `(client, expiry)` without touching `self`; the caller atomically assigns both under a double-checked lock, so a failed rebuild never advances `_expiry` past a client that was never installed. The lock is `threading.Lock`, which becomes greenlet-aware under `monkey.patch_all()` for gevent safety.
- **Gevent pool** (`celery_forwarder.py`): `monkey.patch_all()` is guarded by `CELERY_WORKER_POOL=gevent` and runs before all other imports at module top-of-file; prefork workers are entirely unaffected. An env-gated `max_tasks_per_child` knob provides defense-in-depth for prefork.
- **Tests**: unit tests cover built-once, rebuild-before-expiry, failed-build-retry, and pool-wiring; subprocess-based tests guard gevent import ordering and ddtrace-run compatibility; integration tests (local-only) cover prefork, gevent, concurrency, warm-shutdown, and SQS.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the client-caching logic is correct under both prefork and gevent, well-tested, and the gevent pool is opt-in behind an env var that defaults to the existing prefork behaviour.

The core fix (cached Firehose client with double-checked locking and a pure _build_client) is safe under both worker modes. Under prefork each child process holds its own instance so there is no cross-process sharing; under gevent cooperative scheduling ensures the unguarded outer check and the non-atomic tuple assignment are both safe. The test suite covers the key failure modes (first-build failure, refresh failure, rebuild-before-expiry). The gevent change is fully opt-in and leaves the default prefork path byte-for-byte unchanged.

requirements.txt was hand-edited; worth regenerating with pip-compile to confirm the gevent/zope pin graph is correct before the next dependency bump.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| model-engine/model_engine_server/inference/infra/gateways/firehose_streaming_storage_gateway.py | Core OOM fix: Firehose client is now cached per-instance with double-checked locking, rebuilt only near token expiry via a pure _build_client(). Logic handles first-build failure and refresh-failure correctly, and is safe under both prefork (per-process instance) and gevent (cooperative scheduling). |
| model-engine/model_engine_server/inference/forwarding/celery_forwarder.py | Opt-in gevent pool (CELERY_WORKER_POOL=gevent) with monkey.patch_all() at module top-of-file before all other imports; prefork is unchanged. Adds env-gated max_tasks_per_child for prefork defense-in-depth. Logic is clean and well-guarded. |
| model-engine/tests/unit/infra/gateways/test_firehose_streaming_storage_gateway.py | Comprehensive rewrite of gateway tests: covers built-once regression, rebuild-before-expiry, failed-build-retries, pure _build_client, and connection-pool wiring. Tests exercise the real _build_client path through mocked boto3.client routing. |
| model-engine/tests/integration/inference/test_forwarder_pool.py | New integration tests for prefork and gevent pools (task completion, concurrency, warm-shutdown, SQS broker). Skipped in CI; local-only. Contains a minor type annotation issue (sqs_url: str = None). |
| model-engine/requirements.txt | Hand-edited to pin gevent==26.5.0 and its transitive deps (zope-event, zope-interface, greenlet). PR author notes this should be regenerated with pip-compile to verify pins. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Task as Celery Task (greenlet/child)
    participant GW as FirehoseStreamingStorageGateway
    participant Lock as threading.Lock
    participant STS as AWS STS
    participant FH as AWS Firehose

    Task->>GW: put_record(stream, record)
    GW->>GW: _get_firehose_client()
    alt _client is None OR _needs_rebuild()
        GW->>Lock: acquire()
        alt still needs rebuild (double-check)
            GW->>STS: boto3.client("sts").assume_role()
            STS-->>GW: Credentials + Expiration
            GW->>FH: boto3.client("firehose", creds, pool_size)
            FH-->>GW: firehose_client
            GW->>GW: "self._client, self._expiry = client, expiry"
        end
        GW->>Lock: release()
    end
    GW-->>Task: firehose_client
    Task->>FH: client.put_record(stream, data)
    FH-->>Task: response
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Task as Celery Task (greenlet/child)
    participant GW as FirehoseStreamingStorageGateway
    participant Lock as threading.Lock
    participant STS as AWS STS
    participant FH as AWS Firehose

    Task->>GW: put_record(stream, record)
    GW->>GW: _get_firehose_client()
    alt _client is None OR _needs_rebuild()
        GW->>Lock: acquire()
        alt still needs rebuild (double-check)
            GW->>STS: boto3.client("sts").assume_role()
            STS-->>GW: Credentials + Expiration
            GW->>FH: boto3.client("firehose", creds, pool_size)
            FH-->>GW: firehose_client
            GW->>GW: "self._client, self._expiry = client, expiry"
        end
        GW->>Lock: release()
    end
    GW-->>Task: firehose_client
    Task->>FH: client.put_record(stream, data)
    FH-->>Task: response
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["test(forwarder): export AWS\_ENDPOINT\_URL..."](https://github.com/scaleapi/llm-engine/commit/8ffaa9d3a8e4074ac014efce6ffdb91213adbace) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40612874)</sub>

<!-- /greptile_comment -->