### PR TITLE
fix(vllm): stop forcing --enforce-eager on all LLM endpoints

### DIFF
--- a/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
+++ b/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
@@ -1431,7 +1431,15 @@ class CreateLLMModelBundleV1UseCase:
         if not is_worker:
             vllm_args.tensor_parallel_size = num_shards
 
-            if vllm_args.gpu_memory_utilization is not None:
+            # At very high GPU memory utilization there is little headroom left for
+            # CUDA graph capture, which can OOM on startup. Default to eager mode in
+            # that regime; below it, leave CUDA graphs enabled for faster decode.
+            # Respect an explicit enforce_eager from the caller (True or False).
+            if (
+                vllm_args.enforce_eager is None
+                and vllm_args.gpu_memory_utilization is not None
+                and vllm_args.gpu_memory_utilization >= 0.95
+            ):
                 vllm_args.enforce_eager = True
 
             if multinode:

--- a/model-engine/tests/unit/domain/test_llm_use_cases.py
+++ b/model-engine/tests/unit/domain/test_llm_use_cases.py
@@ -1603,7 +1603,6 @@ async def test_update_vllm_force_bundle_recreation_preserves_legacy_vllm_args(
         "max_num_seqs": 10,
         "trust_remote_code": True,
         "gpu_memory_utilization": 0.75,
-        "enforce_eager": True,
         "quantization": "awq",
         "disable_log_requests": True,
         "chat_template": "test-template",
@@ -1625,7 +1624,7 @@ async def test_update_vllm_force_bundle_recreation_preserves_legacy_vllm_args(
     assert "--max-model-len 2000" in bundle_command
     assert "--max-num-seqs 10" in bundle_command
     assert "--gpu-memory-utilization 0.75" in bundle_command
-    assert "--enforce-eager" in bundle_command
+    assert "--enforce-eager" not in bundle_command
     assert "--quantization awq" in bundle_command
     assert "--disable-log-requests" in bundle_command
     assert "--chat-template" in bundle_command
@@ -1637,7 +1636,6 @@ async def test_update_vllm_force_bundle_recreation_preserves_legacy_vllm_args(
         "max_num_seqs": 10,
         "trust_remote_code": False,
         "gpu_memory_utilization": 0.75,
-        "enforce_eager": True,
         "quantization": "awq",
         "disable_log_requests": True,
         "chat_template": "test-template",


### PR DESCRIPTION
## Summary

Removes the code that unconditionally adds `--enforce-eager` to the vLLM startup command for every endpoint deployed via the `llmengine` provider pathway.

In `_create_vllm_bundle_command` (`llm_model_endpoint_use_cases.py`) we had:

```python
if vllm_args.gpu_memory_utilization is not None:
    vllm_args.enforce_eager = True
```

Because `infer_addition_engine_args_from_model_name()` **always** seeds a default `gpu_memory_utilization` (0.9, or 0.95 for ≥70B models), this condition was effectively always true. The net effect:

- **Every** llmengine vLLM endpoint was launched with `--enforce-eager`.
- A user explicitly passing `enforce_eager: false` had it silently clobbered back to `true` — there was no way to turn eager mode off.

`--enforce-eager` disables CUDA graphs and forces eager-mode PyTorch, which **massively slows down decode**. We were paying that cost globally.

## Historical context

- **#524 "Hardcode llama 3 70b endpoint param"** introduced the flag, hardcoded *only* for `llama-3-70b`, as a coupled pair: `--gpu-memory-utilization 0.95 --enforce-eager`. The intent was a targeted OOM workaround — at very high memory utilization there is little headroom for vLLM's CUDA-graph capture, so eager mode was forced *alongside* the high mem-util for that one large model.
- **#637 "Refactor client data types + add vllm arg passthrough"** generalized the coupling to "whenever `gpu_memory_utilization` is set, force `enforce_eager`." Combined with the always-on default mem-util, a 70B-specific safety hack quietly became a global default that disabled CUDA graphs on all endpoints.

## Change

Remove the auto-injection. Endpoints now use vLLM's default hybrid eager + CUDA graph mode (better decode throughput). Models that genuinely need eager mode (e.g. several vision / qwen entries in the internal model zoo) already set `enforce_eager: true` explicitly via `additional_args` and are unaffected.

## Risk

Re-enabling CUDA graphs requires a little extra VRAM for graph capture. At the default `gpu_memory_utilization` of 0.9–0.95 this is the scenario the original workaround guarded against, so watch for startup OOM on memory-tight models after rollout. Mitigations if needed: lower the default mem-util, or have callers set `enforce_eager: true` for specific models.

## Testing

- Updated `test_update_vllm_force_bundle_recreation_preserves_legacy_vllm_args` to reflect that `enforce_eager` is no longer auto-added.
- `pytest tests/unit/domain/test_llm_use_cases.py` — 74 passed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the unconditional `--enforce-eager` injection that was silently disabling CUDA graphs on every vLLM endpoint. The condition is now narrowed to only auto-apply eager mode when `gpu_memory_utilization >= 0.95` **and** the caller has not explicitly set `enforce_eager`, restoring the original targeted workaround for large (≥70B) models while enabling CUDA-graph-accelerated decode for everything else.

- **Core logic change** (`llm_model_endpoint_use_cases.py`): replaces `if gpu_memory_utilization is not None` with a three-way guard (`enforce_eager is None`, `gpu_memory_utilization is not None`, `>= 0.95`), so the 70B OOM workaround is preserved, explicit caller overrides are respected, and smaller models regain CUDA graphs.
- **Test update** (`test_llm_use_cases.py`): removes `enforce_eager: True` from the `gpu_memory_utilization=0.75` fixture and flips the assertion to `"--enforce-eager" not in bundle_command`, correctly reflecting the new behaviour for below-threshold utilization.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the targeted OOM guard for ≥70B models is preserved and the decode-speed regression on smaller models is corrected.

The change is surgical and well-motivated. The three-part guard correctly retains the original llama-3-70b workaround (0.95 threshold), respects explicit caller overrides, and lifts the global CUDA-graph penalty for all sub-0.95 models. The test update accurately reflects the new behaviour for the 0.75-utilization fixture. The only gap is that no assertion pins the ≥0.95 auto-eager path in the llama-3-70b test, but the production logic for that path is correct and unchanged in effect.

The llama-3-70b section of test_llm_use_cases.py (around line 237) would benefit from an explicit --enforce-eager assertion to cover the retained auto-eager path.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py | Auto-eager injection narrowed from "any gpu_memory_utilization" to "≥0.95 only when enforce_eager is not explicitly set"; logic is correct and well-commented |
| model-engine/tests/unit/domain/test_llm_use_cases.py | Updated test correctly removes enforce_eager from the 0.75-utilization case, but the ≥0.95 auto-eager path (llama-3-70b) has no assertion confirming the flag is still emitted |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Build vLLM command] --> B{is_worker?}
    B -- Yes --> Z[Skip enforce_eager logic]
    B -- No --> C{enforce_eager\nexplicitly set?}
    C -- Yes, True or False --> D[Use caller value as-is]
    C -- No, None --> E{gpu_memory_utilization\nis not None?}
    E -- No --> F[Leave enforce_eager unset\nCUDA graphs enabled]
    E -- Yes --> G{gpu_memory_utilization\n>= 0.95?}
    G -- No, e.g. 0.9 default --> F
    G -- Yes, e.g. 70B models at 0.95 --> H[Auto-set enforce_eager = True\nSafe OOM workaround]
    D --> I[Emit --enforce-eager or omit flag]
    F --> I
    H --> I
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Build vLLM command] --> B{is_worker?}
    B -- Yes --> Z[Skip enforce_eager logic]
    B -- No --> C{enforce_eager\nexplicitly set?}
    C -- Yes, True or False --> D[Use caller value as-is]
    C -- No, None --> E{gpu_memory_utilization\nis not None?}
    E -- No --> F[Leave enforce_eager unset\nCUDA graphs enabled]
    E -- Yes --> G{gpu_memory_utilization\n>= 0.95?}
    G -- No, e.g. 0.9 default --> F
    G -- Yes, e.g. 70B models at 0.95 --> H[Auto-set enforce_eager = True\nSafe OOM workaround]
    D --> I[Emit --enforce-eager or omit flag]
    F --> I
    H --> I
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into ollie/remove-au..."](https://github.com/scaleapi/llm-engine/commit/591b00a36e785592d4769351ebf0ef5e31a801bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40774034)</sub>

<!-- /greptile_comment -->