### PR TITLE
fix: make DB migrations idempotent and stamp alembic after init_database

### DIFF
--- a/charts/model-engine/Chart.yaml
+++ b/charts/model-engine/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.7
+version: 0.2.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/model-engine/templates/database_init_job.yaml
+++ b/charts/model-engine/templates/database_init_job.yaml
@@ -10,7 +10,7 @@ metadata:
     "helm.sh/hook-weight": "-2"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
-  backoffLimit: 0
+  backoffLimit: 2
   activeDeadlineSeconds: 600
   template:
     metadata:

--- a/charts/model-engine/templates/database_migration_job.yaml
+++ b/charts/model-engine/templates/database_migration_job.yaml
@@ -10,7 +10,7 @@ metadata:
     "helm.sh/hook-weight": "-1"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
-  backoffLimit: 0
+  backoffLimit: 2
   activeDeadlineSeconds: 600
   template:
     metadata:

--- a/model-engine/model_engine_server/db/migrations/README
+++ b/model-engine/model_engine_server/db/migrations/README
@@ -31,7 +31,16 @@ Migrations are self-adopting and safe to re-run:
 2. Subsequent add-column revisions check for column existence before
    adding/dropping, so they no-op on schemas that already have the columns.
 3. The init_database entrypoint stamps `alembic head` after a successful
-   create_all, so freshly initialized databases are never left unstamped.
+   create_all, but ONLY when this run created the schema from scratch:
+   it skips stamping if the database already has an alembic revision
+   recorded (public.alembic_version_model_engine has a row), or if
+   hosted_model_inference.endpoints existed before create_all ran.
+   Stamping an already-stamped database would fast-forward the version
+   table past unapplied migrations and silently skip them; stamping a
+   pre-existing unstamped schema would over-claim, since create_all only
+   creates missing tables and never adds columns to existing ones. In both
+   cases the migration job's `alembic upgrade head` does the right thing
+   (applies pending revisions / adopts the schema via the guards above).
 
 Manual stamping (stamp_initial_schema.sh) is therefore only needed for
 databases created before this behavior existed.

--- a/model-engine/model_engine_server/db/migrations/README
+++ b/model-engine/model_engine_server/db/migrations/README
@@ -19,6 +19,23 @@ alembic revision -m “initial”
 alembic stamp fa3267c80731
 ```
 
+# Idempotency and adoption of pre-alembic databases
+
+Migrations are self-adopting and safe to re-run:
+
+1. The initial revision (fa3267c80731) checks whether
+   hosted_model_inference.endpoints already exists. If it does (e.g. the
+   database was initialized via the init_database entrypoint's create_all
+   before alembic was ever run), it skips initial.sql and just records the
+   revision instead of failing on CREATE SCHEMA.
+2. Subsequent add-column revisions check for column existence before
+   adding/dropping, so they no-op on schemas that already have the columns.
+3. The init_database entrypoint stamps `alembic head` after a successful
+   create_all, so freshly initialized databases are never left unstamped.
+
+Manual stamping (stamp_initial_schema.sh) is therefore only needed for
+databases created before this behavior existed.
+
 # Steps to make generic database schema changes
 
 Steps can be found here: https://alembic.sqlalchemy.org/en/latest/tutorial.html#running-our-second-migration

--- a/model-engine/model_engine_server/db/migrations/alembic/versions/2024_09_09_1736-fa3267c80731_initial.py
+++ b/model-engine/model_engine_server/db/migrations/alembic/versions/2024_09_09_1736-fa3267c80731_initial.py
@@ -22,6 +22,17 @@ depends_on = None
 
 
 def upgrade() -> None:
+    # If the schema already exists (e.g. the database was initialized by
+    # init_database's create_all before alembic was stamped), adopt the
+    # existing schema instead of replaying initial.sql, whose bare
+    # CREATE SCHEMA statements would fail with DuplicateSchema.
+    inspector = sa.inspect(op.get_bind())
+    if inspector.has_table("endpoints", schema="hosted_model_inference"):
+        print(
+            "Table hosted_model_inference.endpoints already exists; "
+            "adopting existing schema and skipping initial.sql."
+        )
+        return
     with open(INITIAL_MIGRATION_PATH) as fd:
         op.execute(fd.read())
 

--- a/model-engine/model_engine_server/db/migrations/alembic/versions/2024_09_09_1831-b574e9711e35_chat_completion_add_extra_routes.py
+++ b/model-engine/model_engine_server/db/migrations/alembic/versions/2024_09_09_1831-b574e9711e35_chat_completion_add_extra_routes.py
@@ -16,17 +16,24 @@ branch_labels = None
 depends_on = None
 
 
+def _has_column(table: str, column: str, schema: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return any(col["name"] == column for col in inspector.get_columns(table, schema=schema))
+
+
 def upgrade() -> None:
-    op.add_column(
-        "bundles",
-        sa.Column("runnable_image_extra_routes", ARRAY(sa.Text), nullable=True),
-        schema="hosted_model_inference",
-    )
+    if not _has_column("bundles", "runnable_image_extra_routes", "hosted_model_inference"):
+        op.add_column(
+            "bundles",
+            sa.Column("runnable_image_extra_routes", ARRAY(sa.Text), nullable=True),
+            schema="hosted_model_inference",
+        )
 
 
 def downgrade():
-    op.drop_column(
-        "bundles",
-        "runnable_image_extra_routes",
-        schema="hosted_model_inference",
-    )
+    if _has_column("bundles", "runnable_image_extra_routes", "hosted_model_inference"):
+        op.drop_column(
+            "bundles",
+            "runnable_image_extra_routes",
+            schema="hosted_model_inference",
+        )

--- a/model-engine/model_engine_server/db/migrations/alembic/versions/2024_09_24_1456-f55525c81eb5_multinode_bundle.py
+++ b/model-engine/model_engine_server/db/migrations/alembic/versions/2024_09_24_1456-f55525c81eb5_multinode_bundle.py
@@ -16,27 +16,36 @@ branch_labels = None
 depends_on = None
 
 
+def _has_column(table: str, column: str, schema: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return any(col["name"] == column for col in inspector.get_columns(table, schema=schema))
+
+
 def upgrade() -> None:
-    op.add_column(
-        "bundles",
-        sa.Column("runnable_image_worker_command", ARRAY(sa.Text), nullable=True),
-        schema="hosted_model_inference",
-    )
-    op.add_column(
-        "bundles",
-        sa.Column("runnable_image_worker_env", sa.JSON, nullable=True),
-        schema="hosted_model_inference",
-    )
+    if not _has_column("bundles", "runnable_image_worker_command", "hosted_model_inference"):
+        op.add_column(
+            "bundles",
+            sa.Column("runnable_image_worker_command", ARRAY(sa.Text), nullable=True),
+            schema="hosted_model_inference",
+        )
+    if not _has_column("bundles", "runnable_image_worker_env", "hosted_model_inference"):
+        op.add_column(
+            "bundles",
+            sa.Column("runnable_image_worker_env", sa.JSON, nullable=True),
+            schema="hosted_model_inference",
+        )
 
 
 def downgrade() -> None:
-    op.drop_column(
-        "bundles",
-        "runnable_image_worker_command",
-        schema="hosted_model_inference",
-    )
-    op.drop_column(
-        "bundles",
-        "runnable_image_worker_env",
-        schema="hosted_model_inference",
-    )
+    if _has_column("bundles", "runnable_image_worker_command", "hosted_model_inference"):
+        op.drop_column(
+            "bundles",
+            "runnable_image_worker_command",
+            schema="hosted_model_inference",
+        )
+    if _has_column("bundles", "runnable_image_worker_env", "hosted_model_inference"):
+        op.drop_column(
+            "bundles",
+            "runnable_image_worker_env",
+            schema="hosted_model_inference",
+        )

--- a/model-engine/model_engine_server/db/migrations/alembic/versions/2025_09_16_1741-e580182d6bfd_add_passthrough_forwarder.py
+++ b/model-engine/model_engine_server/db/migrations/alembic/versions/2025_09_16_1741-e580182d6bfd_add_passthrough_forwarder.py
@@ -15,17 +15,24 @@ branch_labels = None
 depends_on = None
 
 
+def _has_column(table: str, column: str, schema: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return any(col["name"] == column for col in inspector.get_columns(table, schema=schema))
+
+
 def upgrade() -> None:
-    op.add_column(
-        "bundles",
-        sa.Column("runnable_image_forwarder_type", sa.String(), nullable=True),
-        schema="hosted_model_inference",
-    )
+    if not _has_column("bundles", "runnable_image_forwarder_type", "hosted_model_inference"):
+        op.add_column(
+            "bundles",
+            sa.Column("runnable_image_forwarder_type", sa.String(), nullable=True),
+            schema="hosted_model_inference",
+        )
 
 
 def downgrade() -> None:
-    op.drop_column(
-        "bundles",
-        "runnable_image_forwarder_type",
-        schema="hosted_model_inference",
-    )
+    if _has_column("bundles", "runnable_image_forwarder_type", "hosted_model_inference"):
+        op.drop_column(
+            "bundles",
+            "runnable_image_forwarder_type",
+            schema="hosted_model_inference",
+        )

--- a/model-engine/model_engine_server/db/migrations/alembic/versions/2025_09_25_1940-221aa19d3f32_add_routes_column.py
+++ b/model-engine/model_engine_server/db/migrations/alembic/versions/2025_09_25_1940-221aa19d3f32_add_routes_column.py
@@ -15,17 +15,24 @@ branch_labels = None
 depends_on = None
 
 
+def _has_column(table: str, column: str, schema: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return any(col['name'] == column for col in inspector.get_columns(table, schema=schema))
+
+
 def upgrade() -> None:
-    op.add_column(
-        'bundles',
-        sa.Column('runnable_image_routes', sa.ARRAY(sa.Text), nullable=True),
-        schema='hosted_model_inference',
-    )
+    if not _has_column('bundles', 'runnable_image_routes', 'hosted_model_inference'):
+        op.add_column(
+            'bundles',
+            sa.Column('runnable_image_routes', sa.ARRAY(sa.Text), nullable=True),
+            schema='hosted_model_inference',
+        )
 
 
 def downgrade() -> None:
-    op.drop_column(
-        'bundles',
-        'runnable_image_routes',
-        schema='hosted_model_inference',
-    )
+    if _has_column('bundles', 'runnable_image_routes', 'hosted_model_inference'):
+        op.drop_column(
+            'bundles',
+            'runnable_image_routes',
+            schema='hosted_model_inference',
+        )

--- a/model-engine/model_engine_server/db/migrations/alembic/versions/2026_02_10_1920-62da4f8b3403_add_task_expires_seconds_column.py
+++ b/model-engine/model_engine_server/db/migrations/alembic/versions/2026_02_10_1920-62da4f8b3403_add_task_expires_seconds_column.py
@@ -15,17 +15,24 @@ branch_labels = None
 depends_on = None
 
 
+def _has_column(table: str, column: str, schema: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return any(col['name'] == column for col in inspector.get_columns(table, schema=schema))
+
+
 def upgrade() -> None:
-    op.add_column(
-        'endpoints',
-        sa.Column('task_expires_seconds', sa.Integer, nullable=True),
-        schema='hosted_model_inference',
-    )
+    if not _has_column('endpoints', 'task_expires_seconds', 'hosted_model_inference'):
+        op.add_column(
+            'endpoints',
+            sa.Column('task_expires_seconds', sa.Integer, nullable=True),
+            schema='hosted_model_inference',
+        )
 
 
 def downgrade() -> None:
-    op.drop_column(
-        'endpoints',
-        'task_expires_seconds',
-        schema='hosted_model_inference',
-    )
+    if _has_column('endpoints', 'task_expires_seconds', 'hosted_model_inference'):
+        op.drop_column(
+            'endpoints',
+            'task_expires_seconds',
+            schema='hosted_model_inference',
+        )

--- a/model-engine/model_engine_server/db/migrations/alembic/versions/2026_02_20_1200-a1b2c3d4e5f6_add_queue_message_timeout_seconds_column.py
+++ b/model-engine/model_engine_server/db/migrations/alembic/versions/2026_02_20_1200-a1b2c3d4e5f6_add_queue_message_timeout_seconds_column.py
@@ -15,17 +15,24 @@ branch_labels = None
 depends_on = None
 
 
+def _has_column(table: str, column: str, schema: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return any(col['name'] == column for col in inspector.get_columns(table, schema=schema))
+
+
 def upgrade() -> None:
-    op.add_column(
-        'endpoints',
-        sa.Column('queue_message_timeout_seconds', sa.Integer, nullable=True),
-        schema='hosted_model_inference',
-    )
+    if not _has_column('endpoints', 'queue_message_timeout_seconds', 'hosted_model_inference'):
+        op.add_column(
+            'endpoints',
+            sa.Column('queue_message_timeout_seconds', sa.Integer, nullable=True),
+            schema='hosted_model_inference',
+        )
 
 
 def downgrade() -> None:
-    op.drop_column(
-        'endpoints',
-        'queue_message_timeout_seconds',
-        schema='hosted_model_inference',
-    )
+    if _has_column('endpoints', 'queue_message_timeout_seconds', 'hosted_model_inference'):
+        op.drop_column(
+            'endpoints',
+            'queue_message_timeout_seconds',
+            schema='hosted_model_inference',
+        )

--- a/model-engine/model_engine_server/db/migrations/alembic/versions/2026_06_16_1200-c4d5e6f7a8b9_add_status_reason_column.py
+++ b/model-engine/model_engine_server/db/migrations/alembic/versions/2026_06_16_1200-c4d5e6f7a8b9_add_status_reason_column.py
@@ -15,17 +15,24 @@ branch_labels = None
 depends_on = None
 
 
+def _has_column(table: str, column: str, schema: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return any(col['name'] == column for col in inspector.get_columns(table, schema=schema))
+
+
 def upgrade() -> None:
-    op.add_column(
-        'endpoints',
-        sa.Column('status_reason', sa.Text, nullable=True),
-        schema='hosted_model_inference',
-    )
+    if not _has_column('endpoints', 'status_reason', 'hosted_model_inference'):
+        op.add_column(
+            'endpoints',
+            sa.Column('status_reason', sa.Text, nullable=True),
+            schema='hosted_model_inference',
+        )
 
 
 def downgrade() -> None:
-    op.drop_column(
-        'endpoints',
-        'status_reason',
-        schema='hosted_model_inference',
-    )
+    if _has_column('endpoints', 'status_reason', 'hosted_model_inference'):
+        op.drop_column(
+            'endpoints',
+            'status_reason',
+            schema='hosted_model_inference',
+        )

--- a/model-engine/model_engine_server/entrypoints/init_database.py
+++ b/model-engine/model_engine_server/entrypoints/init_database.py
@@ -1,14 +1,18 @@
 # flake8: noqa
 import os
+import subprocess
+from pathlib import Path
 
 import psycopg2
 from model_engine_server.db.base import Base, get_engine_url
 from model_engine_server.db.models import *
 from sqlalchemy import create_engine
-from sqlalchemy.engine import Engine
+from sqlalchemy.engine import Engine, make_url
 from tenacity import Retrying, stop_after_attempt, wait_exponential
 
 SCHEMAS = ["hosted_model_inference", "model"]
+
+MIGRATIONS_DIR = Path(__file__).resolve().parents[1] / "db" / "migrations"
 
 
 def init_database(database_url: str, psycopg_connection):
@@ -36,6 +40,17 @@ def init_database_and_engine(database_url) -> Engine:
     return engine
 
 
+def stamp_alembic_head() -> None:
+    # Mark the database as being at the latest alembic revision, so that a
+    # database initialized via create_all is not left unstamped (which would
+    # cause a subsequent `alembic upgrade head` to replay migrations from the
+    # very beginning). This mirrors run_database_migration.sh, which invokes
+    # alembic from the migrations directory; env.py resolves the database URL
+    # itself (from ML_INFRA_DATABASE_URL if set, otherwise from cloud secrets),
+    # and the subprocess inherits our environment.
+    subprocess.run(["alembic", "stamp", "head"], cwd=MIGRATIONS_DIR, check=True)
+
+
 if __name__ == "__main__":
     url = os.getenv("ML_INFRA_DATABASE_URL")
     # If we are at this point, we want to init the db.
@@ -50,4 +65,7 @@ if __name__ == "__main__":
         with attempt:
             init_database_and_engine(url)
 
-    print(f"Successfully initialized database at {url}")
+    stamp_alembic_head()
+
+    safe_url = make_url(url)
+    print(f"Successfully initialized database {safe_url.database} at {safe_url.host}")

--- a/model-engine/model_engine_server/entrypoints/init_database.py
+++ b/model-engine/model_engine_server/entrypoints/init_database.py
@@ -6,13 +6,17 @@ from pathlib import Path
 import psycopg2
 from model_engine_server.db.base import Base, get_engine_url
 from model_engine_server.db.models import *
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.engine import Engine, make_url
 from tenacity import Retrying, stop_after_attempt, wait_exponential
 
 SCHEMAS = ["hosted_model_inference", "model"]
 
 MIGRATIONS_DIR = Path(__file__).resolve().parents[1] / "db" / "migrations"
+
+# Must match ALEMBIC_TABLE_NAME / version_table_schema in db/migrations/alembic/env.py.
+ALEMBIC_VERSION_TABLE = "alembic_version_model_engine"
+ALEMBIC_VERSION_TABLE_SCHEMA = "public"
 
 
 def init_database(database_url: str, psycopg_connection):
@@ -40,14 +44,52 @@ def init_database_and_engine(database_url) -> Engine:
     return engine
 
 
+def schema_already_initialized(database_url: str) -> bool:
+    # Return True if hosted_model_inference.endpoints already exists, i.e. the
+    # schema was initialized by a previous run (possibly of an older image whose
+    # models lacked columns that current migrations would add). In that case
+    # this run's create_all only created missing tables, so we must not claim
+    # the database is at head.
+    engine = create_engine(database_url, echo=False, future=True)
+    try:
+        with engine.connect() as connection:
+            return inspect(connection).has_table("endpoints", schema="hosted_model_inference")
+    finally:
+        engine.dispose()
+
+
+def alembic_is_stamped(database_url: str) -> bool:
+    # Return True if the alembic version table already records a revision.
+    # In that case we must NOT `alembic stamp head`: stamping moves the version
+    # table without running migrations, so a database stamped at an older
+    # revision would silently skip every pending (and future) migration.
+    engine = create_engine(database_url, echo=False, future=True)
+    try:
+        with engine.connect() as connection:
+            if not inspect(connection).has_table(
+                ALEMBIC_VERSION_TABLE, schema=ALEMBIC_VERSION_TABLE_SCHEMA
+            ):
+                return False
+            row = connection.execute(
+                text(
+                    f"SELECT version_num FROM "  # nosec: identifiers are constants
+                    f"{ALEMBIC_VERSION_TABLE_SCHEMA}.{ALEMBIC_VERSION_TABLE} LIMIT 1"
+                )
+            ).first()
+            return row is not None
+    finally:
+        engine.dispose()
+
+
 def stamp_alembic_head() -> None:
     # Mark the database as being at the latest alembic revision, so that a
     # database initialized via create_all is not left unstamped (which would
     # cause a subsequent `alembic upgrade head` to replay migrations from the
-    # very beginning). This mirrors run_database_migration.sh, which invokes
-    # alembic from the migrations directory; env.py resolves the database URL
-    # itself (from ML_INFRA_DATABASE_URL if set, otherwise from cloud secrets),
-    # and the subprocess inherits our environment.
+    # very beginning). Only call this when the database has no alembic revision
+    # yet (see alembic_is_stamped). This mirrors run_database_migration.sh,
+    # which invokes alembic from the migrations directory; env.py resolves the
+    # database URL itself (from ML_INFRA_DATABASE_URL if set, otherwise from
+    # cloud secrets), and the subprocess inherits our environment.
     subprocess.run(["alembic", "stamp", "head"], cwd=MIGRATIONS_DIR, check=True)
 
 
@@ -57,15 +99,38 @@ if __name__ == "__main__":
     if url is None:
         print("No k8s secret for DB url found, trying AWS secret")
         url = get_engine_url(read_only=False, sync=True).url
+    schema_pre_existed = None
     for attempt in Retrying(
         stop=stop_after_attempt(6),
         wait=wait_exponential(),
         reraise=True,
     ):
         with attempt:
+            # Record (once, on the first attempt that can connect) whether the
+            # schema existed before this run's create_all, so we only stamp
+            # databases we actually initialized from scratch.
+            if schema_pre_existed is None:
+                schema_pre_existed = schema_already_initialized(url)
             init_database_and_engine(url)
 
-    stamp_alembic_head()
+    if alembic_is_stamped(url):
+        # An existing revision means migrations manage this database already.
+        # Stamping here would fast-forward the version table past unapplied
+        # migrations (e.g. new add-column revisions shipped in this image),
+        # so leave it alone and let the migration job run `alembic upgrade head`.
+        print("Database already has an alembic revision; skipping `alembic stamp head`.")
+    elif schema_pre_existed:
+        # Unstamped, but the schema predates this run (likely create_all from an
+        # older image): its tables may be missing columns that migrations would
+        # add, and create_all never alters existing tables. Leave it unstamped so
+        # the migration job's initial revision adopts it and the guarded
+        # add-column revisions bring it to head.
+        print(
+            "Schema already existed but has no alembic revision; skipping "
+            "`alembic stamp head` so migrations can adopt it."
+        )
+    else:
+        stamp_alembic_head()
 
     safe_url = make_url(url)
     print(f"Successfully initialized database {safe_url.database} at {safe_url.host}")


### PR DESCRIPTION
## Problem

The chart ships two pre-install/pre-upgrade hook Jobs for the database — an init job (`db.runDbInitScript`, hook weight -2, runs `init_database` which does `CREATE SCHEMA IF NOT EXISTS` + SQLAlchemy `Base.metadata.create_all`) and a migration job (`db.runDbMigrationScript`, hook weight -1, runs `alembic upgrade head`). As written they cannot be safely enabled together, and each has failure modes on its own:

1. **Init never stamps alembic.** A database created by the init job has the full schema but no alembic version row (`public.alembic_version_model_engine`). The next time the migration job runs, alembic replays from base: the initial revision executes `initial.sql`, whose bare `CREATE SCHEMA hosted_model_inference` fails with `DuplicateSchema`, and the whole helm operation fails.
2. **Both flags on = broken first install.** On a fresh database the init job creates everything (unstamped) at weight -2, then the migration job at weight -1 replays from base and hits the same collision. So the flags are mutually exclusive in practice, silently.
3. **Even a stamped-at-initial database still breaks.** `create_all` creates tables from the current models, i.e. including every column the add-column migrations would add. Stamping only the initial revision then leaves 7 migrations that all fail with `DuplicateColumn`.
4. **`backoffLimit: 0`** on both Jobs means any transient pod failure (node drain, image pull hiccup, brief DB unavailability) fails the entire install/upgrade with no retry.

## What changed

**Migrations (`model-engine/model_engine_server/db/migrations/alembic/versions/`)**
- Initial revision `fa3267c80731`: `upgrade()` now inspects the bind first — if `hosted_model_inference.endpoints` already exists, it logs an adoption message and returns without executing `initial.sql`. Existing databases are adopted instead of erroring.
- All 7 add-column revisions (`b574e9711e35`, `f55525c81eb5`, `e580182d6bfd`, `221aa19d3f32`, `62da4f8b3403`, `a1b2c3d4e5f6`, `c4d5e6f7a8b9`): every `op.add_column` is guarded by an inspector column-existence check (small self-contained `_has_column` helper per revision file, no app imports), and `downgrade()` drops are mirror-guarded. Multi-column revisions guard each column independently.

**`model-engine/model_engine_server/entrypoints/init_database.py`**
- After a successful `init_database_and_engine`, the entrypoint runs `alembic stamp head` (subprocess from the migrations directory, same invocation style as `run_database_migration.sh`; `env.py` resolves the DB URL itself from `ML_INFRA_DATABASE_URL` or cloud secrets, both inherited by the subprocess) — but **only when this run initialized the schema from scratch**. Stamping is skipped in two cases:
  - `public.alembic_version_model_engine` already records a revision. Migrations already manage this database; stamping would fast-forward the version table past unapplied revisions (e.g. a new add-column revision shipped in this image) and the migration job would then no-op, silently skipping that migration — and every future one — leaving the app to fail at runtime with `UndefinedColumn`. Instead the migration job's `alembic upgrade head` applies the pending revisions as before.
  - `hosted_model_inference.endpoints` existed before `create_all` ran (recorded on the first attempt that can connect, before any retry). `create_all` only creates missing tables and never adds columns to existing ones, so a pre-existing unstamped schema (e.g. created by an older image's `create_all`) may be missing columns; it is left unstamped so the adopting initial revision plus the guarded add-column revisions bring it to head.
- The final success log now prints only host/database instead of the full connection URL — routine log hygiene.

**`model-engine/model_engine_server/db/migrations/README`**
- Documents the new self-adopting/idempotent behavior, the conditional-stamp rules, and when manual stamping is still needed.

**`charts/model-engine`**
- `backoffLimit: 0` → `2` on both `database_init_job.yaml` and `database_migration_job.yaml` (migrations run in transactions and are now idempotent, so retry is safe).
- Chart version `0.2.7` → `0.2.8`. No `values.yaml` default changes.

## Behavior matrix

| DB state | Flags | Before | After |
|---|---|---|---|
| Fresh (empty) | init + migration on | Init creates schema unstamped; migration replays from base → `DuplicateSchema`, helm fails | Init creates schema and stamps head; migration is a no-op at head |
| Fresh (empty) | migration only | `alembic upgrade head` applies all revisions (worked) | Same, unchanged |
| Stamped at previous head, new revision in image | init + migration on (routine upgrade) | Init no-ops, migration applies N→head (worked) | Init detects the existing revision and skips stamping; migration applies N→head. Same outcome, preserved |
| Created via init/`create_all`, unstamped | migration turned on later | Replay from base → `DuplicateSchema` | Initial revision adopts the schema, guarded revisions no-op, DB ends stamped at head |
| Created via older image's `create_all`, unstamped | init + migration on | Replay from base → `DuplicateSchema` | Init sees the pre-existing schema and skips stamping; migration adopts it and guarded revisions add any missing columns, ends at head |
| Stamped at initial only, columns already present | migration on | First add-column revision → `DuplicateColumn` | Guards skip existing columns, missing ones are added, ends at head |
| Already stamped at head | migration on | No-op (worked) | Same, unchanged |

## Rollout notes

- The behavioral fix lives in the **image** (revision files + `init_database.py`), not the chart. A cluster must run an image containing this commit before `runDbMigrationScript` can be enabled unconditionally against databases created by the init path; chart `0.2.8` only adds retry headroom (`backoffLimit: 2`).
- The init job never stamps a database that already has an alembic revision, so enabling `runDbInitScript` on clusters that already use migrations does not interfere with pending migrations on upgrade.
- Retry interaction: if an init pod creates the schema but dies before stamping, the retry pod sees the schema as pre-existing and leaves it unstamped — the migration job then adopts it to head (fail-safe direction; nothing is ever over-stamped).
- No values defaults changed; both Jobs remain opt-in via the existing flags.
- Downgrades are guarded the same way, so a partially-converged schema won't fail `alembic downgrade` either.

## Testing

- `python3 -m py_compile` on all edited Python files — pass. `black==24.8.0` (repo config), `ruff==0.6.8`, `isort==5.13.2` on `init_database.py` — clean.
- `helm lint charts/model-engine -f values_circleci.yaml` — pass (lint with only default values fails on unrelated pre-existing templates, e.g. `service_template_config_map.yaml`, on `main` too).
- `helm template ... --set db.runDbInitScript=true --set db.runDbMigrationScript=true --show-only` for both Job templates — both render with `backoffLimit: 2`.
- Empirical verification against a throwaway `postgres:13` container (alembic 1.8.1 / SQLAlchemy 2.0.48, matching `requirements.txt`), running the actual `python -m model_engine_server.entrypoints.init_database` entrypoint and `run_database_migration.sh` with `ML_INFRA_DATABASE_URL`:
  - Fresh DB: init entrypoint runs `create_all` and stamps `c4d5e6f7a8b9 (head)`; a subsequent `run_database_migration.sh` is a no-op.
  - Stamped at previous head (`a1b2c3d4e5f6`) with the `status_reason` revision pending: init entrypoint logs the skip and leaves the version row untouched; `run_database_migration.sh` then applies `a1b2c3d4e5f6 → c4d5e6f7a8b9` and the column appears.
  - Re-run of the init entrypoint on an at-head DB: skip message, version unchanged.
  - Legacy simulation (schema present, `status_reason` column dropped, version table dropped): init entrypoint skips stamping; migration prints the adoption message, adds the missing column, ends at head.
  - Fresh DB: plain `alembic upgrade head` applies all 8 revisions; re-run is a no-op. Stamped-at-initial DB with only 2 of the 7 columns present: upgrade skips existing columns and adds the missing ones. `alembic downgrade base` with one column pre-dropped: guarded drops succeed.
- Not run: the full test suite, the FIPS image build, and cloud-secret URL resolution (AWS/GCP/Azure paths in `env.py`) — the latter is exercised only via the `ML_INFRA_DATABASE_URL` path locally; the cloud path relies on `env.py` resolving the URL identically for `stamp` and `upgrade`, which is unchanged code. Also not exercised: `alembic` must be on `PATH` for the stamp subprocess — true in the Dockerfile images (pip-installed console script), verified locally by putting the venv bin on `PATH`.
