### PR TITLE
Add error details to model engine failures

### DIFF
--- a/model-engine/model_engine_server/api/app.py
+++ b/model-engine/model_engine_server/api/app.py
@@ -82,7 +82,8 @@ class CustomMiddleware(BaseHTTPMiddleware):
             return JSONResponse(
                 status_code=500,
                 content={
-                    "error": "Internal error occurred. Our team has been notified.",
+                    "error": "Internal error occurred in service model-engine. Our team has been notified.",
+                    "error_details": " ".join((str(e) or "").split())[:200],
                     "timestamp": timestamp,
                     "request_id": request_id,
                 },

--- a/model-engine/tests/unit/api/test_app.py
+++ b/model-engine/tests/unit/api/test_app.py
@@ -1,14 +1,13 @@
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from starlette.middleware import Middleware
-
 from model_engine_server.api.app import (
-    CustomMiddleware,
     OPENAPI_SCHEMA_RENAME_PATTERNS,
+    CustomMiddleware,
     _convert_openapi_31_to_30,
     _rename_openapi_schemas,
     get_openapi_schema,
 )
+from starlette.middleware import Middleware
 
 
 def test_healthcheck(simple_client: TestClient):

--- a/model-engine/tests/unit/api/test_app.py
+++ b/model-engine/tests/unit/api/test_app.py
@@ -22,16 +22,20 @@ def test_healthcheck(simple_client: TestClient):
     assert response.status_code == 200
 
 
-def test_unhandled_exception_response_includes_error_details():
+def _get_unhandled_exception_response(error_details: str):
     test_app = FastAPI(middleware=[Middleware(CustomMiddleware)])
-    error_details = "No checkpoint path found for model Qwen/Qwen3-8B"
 
     @test_app.get("/raises")
     async def raises():
         raise RuntimeError(error_details)
 
     client = TestClient(test_app, raise_server_exceptions=False)
-    response = client.get("/raises")
+    return client.get("/raises")
+
+
+def test_unhandled_exception_response_includes_error_details():
+    error_details = "No checkpoint path found for model Qwen/Qwen3-8B"
+    response = _get_unhandled_exception_response(error_details)
 
     assert response.status_code == 500
     assert (
@@ -39,6 +43,22 @@ def test_unhandled_exception_response_includes_error_details():
         == "Internal error occurred in service model-engine. Our team has been notified."
     )
     assert response.json()["error_details"] == error_details
+
+
+def test_unhandled_exception_error_details_are_truncated():
+    error_details = "x" * 250
+    response = _get_unhandled_exception_response(error_details)
+
+    assert response.status_code == 500
+    assert response.json()["error_details"] == "x" * 200
+
+
+def test_unhandled_exception_error_details_are_whitespace_normalized():
+    error_details = "first line\n\t second   line"
+    response = _get_unhandled_exception_response(error_details)
+
+    assert response.status_code == 500
+    assert response.json()["error_details"] == "first line second line"
 
 
 def test_rename_openapi_schemas_renames_discriminated_unions():

--- a/model-engine/tests/unit/api/test_app.py
+++ b/model-engine/tests/unit/api/test_app.py
@@ -1,5 +1,9 @@
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from starlette.middleware import Middleware
+
 from model_engine_server.api.app import (
+    CustomMiddleware,
     OPENAPI_SCHEMA_RENAME_PATTERNS,
     _convert_openapi_31_to_30,
     _rename_openapi_schemas,
@@ -16,6 +20,25 @@ def test_healthcheck(simple_client: TestClient):
 
     response = simple_client.get("/readyz")
     assert response.status_code == 200
+
+
+def test_unhandled_exception_response_includes_error_details():
+    test_app = FastAPI(middleware=[Middleware(CustomMiddleware)])
+    error_details = "No checkpoint path found for model Qwen/Qwen3-8B"
+
+    @test_app.get("/raises")
+    async def raises():
+        raise RuntimeError(error_details)
+
+    client = TestClient(test_app, raise_server_exceptions=False)
+    response = client.get("/raises")
+
+    assert response.status_code == 500
+    assert (
+        response.json()["error"]
+        == "Internal error occurred in service model-engine. Our team has been notified."
+    )
+    assert response.json()["error_details"] == error_details
 
 
 def test_rename_openapi_schemas_renames_discriminated_unions():


### PR DESCRIPTION
# Pull Request Summary

Adds bounded `error_details` to model-engine's unhandled 500 responses so callers can tell whether a failed model deployment came from model-engine while still preserving the existing generic user-facing error. The returned error string now identifies `service model-engine`, and `error_details` is whitespace-normalized and capped at 200 characters.

## Test Plan and Usage Guide

- `python -m isort --check-only model-engine/tests/unit/api/test_app.py`
- `python -m compileall model-engine/model_engine_server/api/app.py model-engine/tests/unit/api/test_app.py`
- Added unit coverage for normal error detail propagation, 200-character truncation, and multiline whitespace normalization.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an `error_details` field to the 500 error response returned by `CustomMiddleware`, surfacing a truncated (200-char), whitespace-normalised representation of the raw exception message alongside the existing generic error text. It also renames the error message to include the service name for easier triage across multi-service environments.

- **`app.py`**: Adds `\"error_details\": \" \".join((str(e) or \"\").split())[:200]` to the unhandled-exception JSON response and updates the boilerplate error string to identify the `model-engine` service.
- **`test_app.py`**: Adds a reusable `_get_unhandled_exception_response` helper and three new tests covering basic error propagation, 200-character truncation, and multiline/whitespace normalisation.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrowly scoped to the unhandled-exception response path, well-tested, and does not alter any request processing logic.

The middleware change is simple and defensive: whitespace normalisation and a hard 200-character cap mean the new field cannot grow unboundedly. All three meaningful behaviours (basic propagation, truncation, normalisation) are now covered by unit tests. No existing response shape is broken — error_details is an additive field.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| model-engine/model_engine_server/api/app.py | Adds error_details (truncated, whitespace-normalised exception string) to the unhandled-exception 500 response; also prefixes the generic error message with the service name. |
| model-engine/tests/unit/api/test_app.py | Adds three new tests covering normal error propagation, 200-char truncation, and whitespace normalisation of error_details, with a shared test-app helper. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant CustomMiddleware
    participant RouteHandler

    Client->>CustomMiddleware: HTTP Request
    CustomMiddleware->>RouteHandler: call_next(request)
    RouteHandler-->>CustomMiddleware: raises Exception(e)

    CustomMiddleware->>CustomMiddleware: log structured error (traceback, request_id)
    CustomMiddleware->>CustomMiddleware: "error_details = ' '.join(str(e).split())[:200]"

    CustomMiddleware-->>Client: "500 JSON { error, error_details, timestamp, request_id }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant CustomMiddleware
    participant RouteHandler

    Client->>CustomMiddleware: HTTP Request
    CustomMiddleware->>RouteHandler: call_next(request)
    RouteHandler-->>CustomMiddleware: raises Exception(e)

    CustomMiddleware->>CustomMiddleware: log structured error (traceback, request_id)
    CustomMiddleware->>CustomMiddleware: "error_details = ' '.join(str(e).split())[:200]"

    CustomMiddleware-->>Client: "500 JSON { error, error_details, timestamp, request_id }"
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Fix test app import ordering"](https://github.com/scaleapi/llm-engine/commit/7653cbb75fefd25c1b336987651d7b7d4a443dbc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43085550)</sub>

<!-- /greptile_comment -->