### PR TITLE
Fix model-engine image vulnerabilities

### DIFF
--- a/model-engine/Dockerfile
+++ b/model-engine/Dockerfile
@@ -1,5 +1,7 @@
 # syntax = docker/dockerfile:1
 
+FROM cgr.dev/chainguard/kubectl:latest@sha256:e305bc9ffe65a62c20e3bad506a4c42e2d6d79fbe624cd8dcab13a3687f979a6 AS kubectl
+
 FROM cgr.dev/chainguard/python:latest-dev AS builder
 
 USER root
@@ -42,13 +44,11 @@ RUN mkdir -p /tmp/runtime-bin /tmp/runtime-libs && \
   cp /usr/lib/libreadline.so.8* /tmp/runtime-libs/ && \
   cp /usr/lib/libtinfo.so.6* /tmp/runtime-libs/ && \
   cp /usr/lib/libz.so.1* /tmp/runtime-libs/ && \
-  git clone --depth 1 --branch v1.35.4 https://github.com/kubernetes/kubernetes.git /tmp/k8s && \
-  cd /tmp/k8s && \
-  GOTOOLCHAIN=local KUBE_BUILD_PLATFORMS=linux/${TARGETARCH} make WHAT=cmd/kubectl && \
-  cp _output/local/bin/linux/${TARGETARCH}/kubectl /tmp/runtime-bin/kubectl && \
-  git clone --depth 1 --branch v0.7.15 https://github.com/kubernetes-sigs/aws-iam-authenticator.git /tmp/aws-iam-authenticator && \
+  git clone --depth 1 --branch v0.7.18 https://github.com/kubernetes-sigs/aws-iam-authenticator.git /tmp/aws-iam-authenticator && \
   cd /tmp/aws-iam-authenticator && \
   GOOS=linux GOARCH=${TARGETARCH} go build -o /tmp/runtime-bin/aws-iam-authenticator ./cmd/aws-iam-authenticator
+
+COPY --from=kubectl /usr/bin/kubectl /tmp/runtime-bin/kubectl
 
 FROM cgr.dev/chainguard/python:latest AS model-engine
 

--- a/model-engine/requirements.in
+++ b/model-engine/requirements.in
@@ -1,6 +1,6 @@
 GitPython>=3.1.49,<4.0
 Jinja2>=3.1.5   # CVE-2024-56326; 3.1.0 bug was fixed in 3.1.1+
-aiohttp>=3.13.4,<4.0
+aiohttp>=3.14.1,<4.0 # CVE-2026-34993, CVE-2026-47265, CVE-2026-50269, CVE-2026-54273-54280
 redis>=4.6.0  # replaces aioredis~=2.0; aioredis 2.x broken on Python 3.12 (duplicate base class TimeoutError); asyncio support built-in to redis>=4.2
 alembic==1.8.1
 asyncpg>=0.29.0  # 0.27.0 has no cp312/cp313 wheel; Python 3.12/3.13 support added in 0.29.0
@@ -31,7 +31,7 @@ gevent>=26.5.0  # celery gevent worker pool for the celery-forwarder (MLI-7328);
 click~=8.1
 cloudpickle==2.1.0
 croniter==1.4.1
-cryptography>=46.0.7 # not used directly, but needs to be pinned for Microsoft security scan
+cryptography>=48.0.1 # GHSA-537c-gmf6-5ccf fixed in 48.0.1
 dataclasses-json>=0.5.7
 datadog-api-client==2.11.0
 datadog~=0.47.0
@@ -39,7 +39,7 @@ ddtrace>=4.7.1,<5.0  # 4.7.1 publishes CPython 3.14 wheels; needed for public Ch
 numpy>=2.4.4,<2.5  # 2.4.4 publishes CPython 3.14 wheels
 deprecation~=2.1
 docker~=5.0
-fastapi>=0.115.8  # bumped to allow starlette>=0.49.1 (CVE-2025-62727 fix)
+fastapi>=0.138.0  # compatible with starlette>=1.3.1 security fixes
 gitdb2~=2.0
 gunicorn~=23.0
 httptools>=0.6.0  # 0.5.0 has no cp312/cp313 wheel
@@ -54,7 +54,7 @@ py-xid==0.3.0
 pycurl~=7.44  # For celery[sqs]
 pytz>=2024.1
 pydantic==2.12.5
-python-multipart>=0.0.26
+python-multipart>=0.0.30 # CVE-2026-53539 fixed in 0.0.30
 quart>=0.20.0,<0.21.0
 werkzeug>=3.0.6  # CVE-2024-34069, CVE-2024-49766, CVE-2024-49767
 requests-auth-aws-sigv4~=0.7
@@ -66,7 +66,7 @@ smart-open~=5.2
 sqlalchemy[asyncio]>=2.0.36  # 2.0.36+ required for Python 3.13 (__static_attributes__ / __firstlineno__ compat)
 sse-starlette==1.6.1
 sseclient-py==1.7.2
-starlette[full]>=0.40.0 # not used directly, but needs to be pinned for Microsoft security scan
+starlette[full]>=1.3.1 # CVE-2026-48818 and CVE-2026-54283 fixed by 1.3.1
 stringcase==1.2.0
 tenacity>=6.0.0,<=6.2.0
 testing-postgresql==1.3.0
@@ -78,16 +78,18 @@ uvicorn==0.30.6
 uvloop>=0.19.0  # 0.17.0 has no cp312/cp313 wheel; Python 3.12/3.13 support added in 0.19.0
 yarl~=1.4
 certifi>=2024.7.4  # CVE-2024-39689
-PyJWT>=2.9.0       # CVE-2024-33663
-urllib3>=2.0.7     # CVE-2023-43804, CVE-2023-45803, CVE-2024-37891
+PyJWT>=2.13.0      # CVE-2024-33663 and CVE-2026-48526
+urllib3>=2.7.0     # CVE-2026-44431 and CVE-2026-44432
+idna>=3.15         # CVE-2026-45409
 setuptools>=70.0.0 # CVE-2024-6345
+wheel>=0.46.2      # CVE-2026-24049 (GHSA-8rrh-rw8j-w5fx)
 h11>=0.16.0        # CVE-2025-43859 (CRITICAL)
 greenlet>=3.0.0    # 2.x has no cp312/cp313 wheel; Python 3.12/3.13 support added in 3.0
 frozenlist>=1.4.0  # 1.3.x has no cp312/cp313 wheel
 multidict>=6.1.0   # 6.0.x has no cp312/cp313 wheel
 azure-core>=1.38.0 # CVE-2026-21226 (HIGH, deserialization) fixed in 1.38.0
 pyasn1>=0.6.3      # CVE-2026-30922 (HIGH, DoS) fixed in 0.6.3
-starlette>=0.49.1  # CVE-2025-62727 (HIGH, DoS) fixed in 0.49.1
+starlette>=1.3.1   # CVE-2025-62727, CVE-2026-48818, CVE-2026-54283
 pg8000>=1.31.5     # CVE-2025-61385 (HIGH, SQL injection) fixed in 1.31.5
 flask>=3.1.3,<4.0  # CVE-2026-27205
 mako>=1.3.11       # GHSA-v92g-xgxw-vvmm

--- a/model-engine/requirements.txt
+++ b/model-engine/requirements.txt
@@ -11,7 +11,7 @@ aiofiles==25.1.0
     #   quart
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.13.5
+aiohttp==3.14.1
     # via
     #   -r requirements.in
     #   aiobotocore
@@ -34,6 +34,7 @@ annotated-types==0.7.0
 anyio==3.7.1
     # via
     #   httpx
+    #   httpx2
     #   starlette
 asn1crypto==1.5.1
     # via scramp
@@ -65,8 +66,6 @@ backoff==2.2.1
     # via gcloud-aio-auth
 billiard==4.2.4
     # via celery
-bleach==6.0.0
-    # via readme-renderer
 blinker==1.9.0
     # via
     #   flask
@@ -135,7 +134,7 @@ commonmark==0.9.1
     # via rich
 croniter==1.4.1
     # via -r requirements.in
-cryptography==47.0.0
+cryptography==48.0.1
     # via
     #   -r requirements.in
     #   azure-identity
@@ -155,11 +154,11 @@ deprecation==2.1.0
     # via -r requirements.in
 docker==5.0.3
     # via -r requirements.in
-docutils==0.20.1
+docutils==0.23
     # via readme-renderer
 envier==0.6.1
     # via ddtrace
-fastapi==0.135.1
+fastapi==0.139.0
     # via -r requirements.in
 filelock==3.29.0
     # via
@@ -179,6 +178,8 @@ fsspec==2023.10.0
 gcloud-aio-auth==5.4.4
     # via gcloud-aio-storage
 gcloud-aio-storage==9.6.1
+    # via -r requirements.in
+gevent==26.5.0
     # via -r requirements.in
 gitdb==4.0.10
     # via gitpython
@@ -225,8 +226,6 @@ googleapis-common-protos==1.72.0
     #   grpc-google-iam-v1
     #   grpcio-status
     #   opentelemetry-exporter-otlp-proto-grpc
-gevent==26.5.0
-    # via -r requirements.in
 greenlet==3.3.2
     # via
     #   -r requirements.in
@@ -256,6 +255,7 @@ h11==0.16.0
     # via
     #   -r requirements.in
     #   httpcore
+    #   httpcore2
     #   hypercorn
     #   uvicorn
     #   wsproto
@@ -269,12 +269,16 @@ hpack==4.1.0
     # via h2
 httpcore==1.0.9
     # via httpx
+httpcore2==2.3.0
+    # via httpx2
 httptools==0.7.1
     # via -r requirements.in
 httpx==0.27.0
     # via
     #   huggingface-hub
     #   starlette
+httpx2==2.3.0
+    # via starlette
 huggingface-hub==1.13.0
     # via
     #   tokenizers
@@ -283,10 +287,12 @@ hypercorn==0.14.4
     # via quart
 hyperframe==6.1.0
     # via h2
-idna==3.7
+idna==3.18
     # via
+    #   -r requirements.in
     #   anyio
     #   httpx
+    #   httpx2
     #   requests
     #   yarl
 importlib-metadata==6.8.0
@@ -329,8 +335,6 @@ kubernetes==25.3.0
     # via -r requirements.in
 kubernetes-asyncio==25.11.0
     # via -r requirements.in
-legacy-cgi==2.6.4
-    # via ddtrace
 mako==1.3.12
     # via
     #   -r requirements.in
@@ -379,6 +383,8 @@ mypy-boto3-sqs==1.40.61
     # via boto3-stubs
 mypy-extensions==1.0.0
     # via typing-inspect
+nh3==0.3.6
+    # via readme-renderer
 numpy==2.4.4
     # via
     #   -r requirements.in
@@ -478,7 +484,7 @@ pygments==2.20.0
     #   -r requirements.in
     #   readme-renderer
     #   rich
-pyjwt==2.12.1
+pyjwt==2.13.0
     # via
     #   -r requirements.in
     #   gcloud-aio-auth
@@ -495,7 +501,7 @@ python-dateutil==2.8.2
     #   kubernetes
     #   kubernetes-asyncio
     #   pg8000
-python-multipart==0.0.27
+python-multipart==0.0.32
     # via
     #   -r requirements.in
     #   starlette
@@ -511,7 +517,7 @@ pyyaml==6.0.1
     #   transformers
 quart==0.20.0
     # via -r requirements.in
-readme-renderer==40.0
+readme-renderer==45.0
     # via twine
 redis==4.6.0
     # via
@@ -562,15 +568,12 @@ setuptools==82.0.1
     #   -r requirements.in
     #   kubernetes
     #   kubernetes-asyncio
-wheel==0.46.2
-    # via -r requirements.in  # CVE-2026-24049 (GHSA-8rrh-rw8j-w5fx); patched in 0.46.2
 sh==1.14.3
     # via -r requirements.in
 shellingham==1.5.4
     # via typer
 six==1.16.0
     # via
-    #   bleach
     #   isodate
     #   kubernetes
     #   kubernetes-asyncio
@@ -596,7 +599,7 @@ sse-starlette==1.6.1
     # via -r requirements.in
 sseclient-py==1.7.2
     # via -r requirements.in
-starlette==0.52.1
+starlette==1.3.1
     # via
     #   -r requirements.in
     #   fastapi
@@ -623,6 +626,10 @@ tqdm==4.67.3
     #   twine
 transformers==5.7.0
     # via -r requirements.in
+truststore==0.10.4
+    # via
+    #   httpcore2
+    #   httpx2
 twine==3.7.1
     # via -r requirements.in
 typer==0.23.1
@@ -663,7 +670,7 @@ typing-inspection==0.4.2
     #   pydantic
 tzdata==2025.3
     # via kombu
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements.in
     #   botocore
@@ -684,8 +691,6 @@ vine==5.1.0
     #   kombu
 wcwidth==0.2.6
     # via prompt-toolkit
-webencodings==0.5.1
-    # via bleach
 websocket-client==1.6.1
     # via
     #   docker
@@ -695,6 +700,8 @@ werkzeug==3.1.6
     #   -r requirements.in
     #   flask
     #   quart
+wheel==0.47.0
+    # via -r requirements.in
 wrapt==1.17.3
     # via
     #   aiobotocore

--- a/model-engine/tests/unit/inference/test_http_forwarder.py
+++ b/model-engine/tests/unit/inference/test_http_forwarder.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 import pytest
 import requests_mock
+from aiohttp import ClientResponse
 from aioresponses import aioresponses
 from fastapi import BackgroundTasks, FastAPI
 from fastapi.responses import JSONResponse
@@ -30,6 +31,19 @@ from model_engine_server.inference.post_inference_hooks import PostInferenceHook
 from tests.unit.conftest import FakeStreamingStorageGateway
 
 PAYLOAD: Mapping[str, str] = {"hello": "world"}
+
+
+@pytest.fixture(autouse=True)
+def aioresponses_aiohttp_314_compat(monkeypatch):
+    """Allow aioresponses 0.7.9 to construct aiohttp 3.14 responses."""
+    original_init = ClientResponse.__init__
+
+    def compatible_init(self, *args, stream_writer=None, **kwargs):
+        if stream_writer is None:
+            stream_writer = mock.Mock(output_size=0)
+        original_init(self, *args, stream_writer=stream_writer, **kwargs)
+
+    monkeypatch.setattr(ClientResponse, "__init__", compatible_init)
 
 
 class ExceptionCapturedThread(threading.Thread):


### PR DESCRIPTION
## Summary

- upgrade the Python dependencies responsible for the current model-engine vulnerability findings
- replace the source-built kubectl binary with the digest-pinned Chainguard kubectl binary
- update aws-iam-authenticator from v0.7.15 to v0.7.18
- add a focused compatibility fixture for aioresponses with aiohttp 3.14

## Why

The latest model-engine-internal image inherited 28 Trivy findings from the public model-engine image. The findings came from vulnerable Python packages and Go dependencies embedded in kubectl and aws-iam-authenticator.

## Impact

The rebuilt model-engine image reports zero Trivy vulnerability findings while preserving its health endpoint and bundled Kubernetes authentication tools. model-engine-internal can consume the remediated public image after the corresponding models submodule update.

## Validation

- production-parity linux/amd64 Docker build
- Trivy: 28 findings before, 0 after
- unit/API tests: 173 passed, 3 skipped
- health tests: 16 passed
- runtime FastAPI /health smoke test: 200 OK
- kubectl version --client smoke test
- aws-iam-authenticator version smoke test
- uv pip check: 251 packages compatible
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR remediates 28 Trivy vulnerability findings in the model-engine image by upgrading vulnerable Python dependencies and replacing the source-built kubectl binary with a digest-pinned Chainguard image, while also bumping aws-iam-authenticator from v0.7.15 to v0.7.18.

- **Dockerfile**: kubectl is now pulled from `cgr.dev/chainguard/kubectl` at a pinned digest instead of being compiled from source (kubernetes/kubernetes v1.35.4); aws-iam-authenticator is bumped to v0.7.18 and still cross-compiled with `GOARCH=${TARGETARCH}`.
- **requirements.in / requirements.txt**: aiohttp, cryptography, fastapi, starlette (0.x → 1.x), python-multipart, PyJWT, urllib3, idna, and wheel are all updated to versions that resolve the reported CVEs; the lock file gains httpx2, httpcore2, and truststore as new transitive dependencies of starlette 1.3.1, and drops bleach/webencodings in favour of nh3.
- **test_http_forwarder.py**: An `autouse` fixture patches `ClientResponse.__init__` to bridge the aioresponses 0.7.9 / aiohttp 3.14 API incompatibility (new required `stream_writer` parameter).

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for linux/amd64 builds; the kubectl digest warrants a quick manifest-list check before enabling arm64 builds.

All changes are targeted vulnerability remediations validated by the author (zero Trivy findings, 173 unit tests passing). The only open question is whether the pinned kubectl digest resolves to a multi-arch manifest list — if it doesn't, future arm64 builds would silently copy the wrong-arch binary. The aioresponses shim is a clean workaround with a minor risk of masking regressions on untested stream_writer attributes, but it is clearly scoped and documented.

model-engine/Dockerfile — verify that the sha256 digest on the kubectl FROM line is an OCI manifest list (multi-arch index) rather than a single-platform manifest before any arm64 build is attempted.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| model-engine/Dockerfile | Replaces source-built kubectl (v1.35.4 from GitHub) with a digest-pinned Chainguard image, and bumps aws-iam-authenticator from v0.7.15 to v0.7.18; multi-arch correctness depends on the digest resolving to a manifest list rather than a single-platform manifest. |
| model-engine/requirements.in | Bumps aiohttp, cryptography, fastapi, python-multipart, starlette, PyJWT, urllib3, and adds idna and wheel lower-bounds to address CVE findings; changes are straightforward security pin updates. |
| model-engine/requirements.txt | Locked dependency tree regenerated to match requirements.in; notable new transitive dependencies are httpx2, httpcore2, and truststore pulled in by starlette 1.3.1, and bleach/webencodings replaced by nh3. |
| model-engine/tests/unit/inference/test_http_forwarder.py | Adds an autouse fixture that patches ClientResponse.__init__ to supply a mock stream_writer, working around an aioresponses 0.7.9 incompatibility with aiohttp 3.14's new required parameter. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["cgr.dev/chainguard/kubectl:latest@sha256:…\n(AS kubectl stage)"] -->|COPY /usr/bin/kubectl| B["/tmp/runtime-bin/kubectl"]
    C["cgr.dev/chainguard/python:latest-dev\n(AS builder stage)"] --> D["pip install requirements.txt\n(updated deps: aiohttp 3.14.1, fastapi 0.139, starlette 1.3.1…)"]
    C --> E["git clone v0.7.18\naws-iam-authenticator\nGOARCH=${TARGETARCH}"]
    E --> F["/tmp/runtime-bin/aws-iam-authenticator"]
    B --> G["COPY → /usr/local/bin/kubectl"]
    F --> H["COPY → /usr/local/bin/aws-iam-authenticator"]
    D --> I["cgr.dev/chainguard/python:latest\n(final model-engine image)"]
    G --> I
    H --> I
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["cgr.dev/chainguard/kubectl:latest@sha256:…\n(AS kubectl stage)"] -->|COPY /usr/bin/kubectl| B["/tmp/runtime-bin/kubectl"]
    C["cgr.dev/chainguard/python:latest-dev\n(AS builder stage)"] --> D["pip install requirements.txt\n(updated deps: aiohttp 3.14.1, fastapi 0.139, starlette 1.3.1…)"]
    C --> E["git clone v0.7.18\naws-iam-authenticator\nGOARCH=${TARGETARCH}"]
    E --> F["/tmp/runtime-bin/aws-iam-authenticator"]
    B --> G["COPY → /usr/local/bin/kubectl"]
    F --> H["COPY → /usr/local/bin/aws-iam-authenticator"]
    D --> I["cgr.dev/chainguard/python:latest\n(final model-engine image)"]
    G --> I
    H --> I
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Amodel-engine%2FDockerfile%3A3%0A**kubectl%20digest%20may%20be%20single-arch%2C%20breaking%20arm64%20builds**%0A%0AThe%20original%20kubectl%20build%20used%20%60KUBE_BUILD_PLATFORMS%3Dlinux%2F%24%7BTARGETARCH%7D%60%20to%20produce%20the%20correct%20architecture%20binary.%20The%20replacement%20%60COPY%20--from%3Dkubectl%60%20does%20not%20reference%20%60TARGETARCH%60%2C%20so%20its%20correctness%20depends%20entirely%20on%20whether%20this%20digest%20resolves%20to%20a%20multi-arch%20manifest%20list%20or%20a%20single-platform%20%28amd64%29%20manifest.%20If%20the%20digest%20is%20for%20the%20amd64-specific%20manifest%20rather%20than%20the%20OCI%20index%2C%20an%20arm64%20buildx%20invocation%20will%20silently%20copy%20the%20wrong-arch%20binary%20into%20the%20image.%20The%20PR%20description%20validates%20only%20%60linux%2Famd64%60%2C%20but%20%60ARG%20TARGETARCH%60%20on%20line%209%20and%20the%20cross-compiled%20aws-iam-authenticator%20on%20line%2049%20indicate%20multi-arch%20intent.%20It%20is%20worth%20verifying%20with%20%60docker%20manifest%20inspect%20cgr.dev%2Fchainguard%2Fkubectl%3Alatest%40sha256%3Ae305bc9ffe65a62c20e3bad506a4c42e2d6d79fbe624cd8dcab13a3687f979a6%60%20that%20the%20digest%20refers%20to%20a%20multi-arch%20index%20before%20arm64%20builds%20are%20attempted.%0A%0A%23%23%23%20Issue%202%20of%202%0Amodel-engine%2Ftests%2Funit%2Finference%2Ftest_http_forwarder.py%3A36-46%0A**Compatibility%20shim%20should%20track%20an%20upstream%20fix**%0A%0AThe%20%60autouse%3DTrue%60%20fixture%20patches%20%60ClientResponse.__init__%60%20to%20inject%20a%20%60mock.Mock%28output_size%3D0%29%60%20for%20the%20new%20%60stream_writer%60%20parameter%20introduced%20in%20aiohttp%203.14%2C%20working%20around%20the%20incompatibility%20with%20aioresponses%200.7.9.%20This%20is%20a%20reasonable%20short-term%20shim%2C%20but%20%60output_size%3D0%60%20only%20satisfies%20accesses%20to%20that%20one%20attribute%3B%20any%20test%20that%20exercises%20code%20paths%20reading%20other%20attributes%20of%20%60stream_writer%60%20will%20get%20an%20opaque%20%60Mock%60%20return%20rather%20than%20a%20failure%2C%20potentially%20masking%20regressions.%20It%20would%20be%20helpful%20to%20file%20an%20issue%20against%20the%20%60aioresponses%60%20repo%20tracking%20the%203.14%20incompatibility%20and%20add%20a%20comment%20here%20linking%20to%20it%20so%20the%20shim%20can%20be%20cleaned%20up%20once%20aioresponses%20ships%20a%20fix.%0A%0A&pr=854&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Amodel-engine%2FDockerfile%3A3%0A**kubectl%20digest%20may%20be%20single-arch%2C%20breaking%20arm64%20builds**%0A%0AThe%20original%20kubectl%20build%20used%20%60KUBE_BUILD_PLATFORMS%3Dlinux%2F%24%7BTARGETARCH%7D%60%20to%20produce%20the%20correct%20architecture%20binary.%20The%20replacement%20%60COPY%20--from%3Dkubectl%60%20does%20not%20reference%20%60TARGETARCH%60%2C%20so%20its%20correctness%20depends%20entirely%20on%20whether%20this%20digest%20resolves%20to%20a%20multi-arch%20manifest%20list%20or%20a%20single-platform%20%28amd64%29%20manifest.%20If%20the%20digest%20is%20for%20the%20amd64-specific%20manifest%20rather%20than%20the%20OCI%20index%2C%20an%20arm64%20buildx%20invocation%20will%20silently%20copy%20the%20wrong-arch%20binary%20into%20the%20image.%20The%20PR%20description%20validates%20only%20%60linux%2Famd64%60%2C%20but%20%60ARG%20TARGETARCH%60%20on%20line%209%20and%20the%20cross-compiled%20aws-iam-authenticator%20on%20line%2049%20indicate%20multi-arch%20intent.%20It%20is%20worth%20verifying%20with%20%60docker%20manifest%20inspect%20cgr.dev%2Fchainguard%2Fkubectl%3Alatest%40sha256%3Ae305bc9ffe65a62c20e3bad506a4c42e2d6d79fbe624cd8dcab13a3687f979a6%60%20that%20the%20digest%20refers%20to%20a%20multi-arch%20index%20before%20arm64%20builds%20are%20attempted.%0A%0A%23%23%23%20Issue%202%20of%202%0Amodel-engine%2Ftests%2Funit%2Finference%2Ftest_http_forwarder.py%3A36-46%0A**Compatibility%20shim%20should%20track%20an%20upstream%20fix**%0A%0AThe%20%60autouse%3DTrue%60%20fixture%20patches%20%60ClientResponse.__init__%60%20to%20inject%20a%20%60mock.Mock%28output_size%3D0%29%60%20for%20the%20new%20%60stream_writer%60%20parameter%20introduced%20in%20aiohttp%203.14%2C%20working%20around%20the%20incompatibility%20with%20aioresponses%200.7.9.%20This%20is%20a%20reasonable%20short-term%20shim%2C%20but%20%60output_size%3D0%60%20only%20satisfies%20accesses%20to%20that%20one%20attribute%3B%20any%20test%20that%20exercises%20code%20paths%20reading%20other%20attributes%20of%20%60stream_writer%60%20will%20get%20an%20opaque%20%60Mock%60%20return%20rather%20than%20a%20failure%2C%20potentially%20masking%20regressions.%20It%20would%20be%20helpful%20to%20file%20an%20issue%20against%20the%20%60aioresponses%60%20repo%20tracking%20the%203.14%20incompatibility%20and%20add%20a%20comment%20here%20linking%20to%20it%20so%20the%20shim%20can%20be%20cleaned%20up%20once%20aioresponses%20ships%20a%20fix.%0A%0A&repo=scaleapi%2Fllm-engine&pr=854&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fllm-engine%22%20on%20the%20existing%20branch%20%22sec%2Fmodel-engine-current-cves%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22sec%2Fmodel-engine-current-cves%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Amodel-engine%2FDockerfile%3A3%0A**kubectl%20digest%20may%20be%20single-arch%2C%20breaking%20arm64%20builds**%0A%0AThe%20original%20kubectl%20build%20used%20%60KUBE_BUILD_PLATFORMS%3Dlinux%2F%24%7BTARGETARCH%7D%60%20to%20produce%20the%20correct%20architecture%20binary.%20The%20replacement%20%60COPY%20--from%3Dkubectl%60%20does%20not%20reference%20%60TARGETARCH%60%2C%20so%20its%20correctness%20depends%20entirely%20on%20whether%20this%20digest%20resolves%20to%20a%20multi-arch%20manifest%20list%20or%20a%20single-platform%20%28amd64%29%20manifest.%20If%20the%20digest%20is%20for%20the%20amd64-specific%20manifest%20rather%20than%20the%20OCI%20index%2C%20an%20arm64%20buildx%20invocation%20will%20silently%20copy%20the%20wrong-arch%20binary%20into%20the%20image.%20The%20PR%20description%20validates%20only%20%60linux%2Famd64%60%2C%20but%20%60ARG%20TARGETARCH%60%20on%20line%209%20and%20the%20cross-compiled%20aws-iam-authenticator%20on%20line%2049%20indicate%20multi-arch%20intent.%20It%20is%20worth%20verifying%20with%20%60docker%20manifest%20inspect%20cgr.dev%2Fchainguard%2Fkubectl%3Alatest%40sha256%3Ae305bc9ffe65a62c20e3bad506a4c42e2d6d79fbe624cd8dcab13a3687f979a6%60%20that%20the%20digest%20refers%20to%20a%20multi-arch%20index%20before%20arm64%20builds%20are%20attempted.%0A%0A%23%23%23%20Issue%202%20of%202%0Amodel-engine%2Ftests%2Funit%2Finference%2Ftest_http_forwarder.py%3A36-46%0A**Compatibility%20shim%20should%20track%20an%20upstream%20fix**%0A%0AThe%20%60autouse%3DTrue%60%20fixture%20patches%20%60ClientResponse.__init__%60%20to%20inject%20a%20%60mock.Mock%28output_size%3D0%29%60%20for%20the%20new%20%60stream_writer%60%20parameter%20introduced%20in%20aiohttp%203.14%2C%20working%20around%20the%20incompatibility%20with%20aioresponses%200.7.9.%20This%20is%20a%20reasonable%20short-term%20shim%2C%20but%20%60output_size%3D0%60%20only%20satisfies%20accesses%20to%20that%20one%20attribute%3B%20any%20test%20that%20exercises%20code%20paths%20reading%20other%20attributes%20of%20%60stream_writer%60%20will%20get%20an%20opaque%20%60Mock%60%20return%20rather%20than%20a%20failure%2C%20potentially%20masking%20regressions.%20It%20would%20be%20helpful%20to%20file%20an%20issue%20against%20the%20%60aioresponses%60%20repo%20tracking%20the%203.14%20incompatibility%20and%20add%20a%20comment%20here%20linking%20to%20it%20so%20the%20shim%20can%20be%20cleaned%20up%20once%20aioresponses%20ships%20a%20fix.%0A%0A&repo=scaleapi%2Fllm-engine&pr=854&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
model-engine/Dockerfile:3
**kubectl digest may be single-arch, breaking arm64 builds**

The original kubectl build used `KUBE_BUILD_PLATFORMS=linux/${TARGETARCH}` to produce the correct architecture binary. The replacement `COPY --from=kubectl` does not reference `TARGETARCH`, so its correctness depends entirely on whether this digest resolves to a multi-arch manifest list or a single-platform (amd64) manifest. If the digest is for the amd64-specific manifest rather than the OCI index, an arm64 buildx invocation will silently copy the wrong-arch binary into the image. The PR description validates only `linux/amd64`, but `ARG TARGETARCH` on line 9 and the cross-compiled aws-iam-authenticator on line 49 indicate multi-arch intent. It is worth verifying with `docker manifest inspect cgr.dev/chainguard/kubectl:latest@sha256:e305bc9ffe65a62c20e3bad506a4c42e2d6d79fbe624cd8dcab13a3687f979a6` that the digest refers to a multi-arch index before arm64 builds are attempted.

### Issue 2 of 2
model-engine/tests/unit/inference/test_http_forwarder.py:36-46
**Compatibility shim should track an upstream fix**

The `autouse=True` fixture patches `ClientResponse.__init__` to inject a `mock.Mock(output_size=0)` for the new `stream_writer` parameter introduced in aiohttp 3.14, working around the incompatibility with aioresponses 0.7.9. This is a reasonable short-term shim, but `output_size=0` only satisfies accesses to that one attribute; any test that exercises code paths reading other attributes of `stream_writer` will get an opaque `Mock` return rather than a failure, potentially masking regressions. It would be helpful to file an issue against the `aioresponses` repo tracking the 3.14 incompatibility and add a comment here linking to it so the shim can be cleaned up once aioresponses ships a fix.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into sec/model-engin..."](https://github.com/scaleapi/llm-engine/commit/e500bf1c06ec26bb49e7ff14b2c3f93176372266) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44156778)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->