### PR TITLE
test: cover model-engine migration adoption

### DIFF
--- a/model-engine/tests/test_database_migration_adoption.py
+++ b/model-engine/tests/test_database_migration_adoption.py
@@ -1,0 +1,169 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from typing import Any
+from unittest.mock import Mock, mock_open, patch
+
+import pytest
+
+VERSIONS_DIR = (
+    Path(__file__).parents[1] / "model_engine_server" / "db" / "migrations" / "alembic" / "versions"
+)
+
+INITIAL_MIGRATION = "2024_09_09_1736-fa3267c80731_initial.py"
+
+ADD_COLUMN_MIGRATIONS = [
+    (
+        "2024_09_09_1831-b574e9711e35_chat_completion_add_extra_routes.py",
+        [("bundles", "runnable_image_extra_routes")],
+    ),
+    (
+        "2024_09_24_1456-f55525c81eb5_multinode_bundle.py",
+        [
+            ("bundles", "runnable_image_worker_command"),
+            ("bundles", "runnable_image_worker_env"),
+        ],
+    ),
+    (
+        "2025_09_16_1741-e580182d6bfd_add_passthrough_forwarder.py",
+        [("bundles", "runnable_image_forwarder_type")],
+    ),
+    (
+        "2025_09_25_1940-221aa19d3f32_add_routes_column.py",
+        [("bundles", "runnable_image_routes")],
+    ),
+    (
+        "2026_02_10_1920-62da4f8b3403_add_task_expires_seconds_column.py",
+        [("endpoints", "task_expires_seconds")],
+    ),
+    (
+        "2026_02_20_1200-a1b2c3d4e5f6_add_queue_message_timeout_seconds_column.py",
+        [("endpoints", "queue_message_timeout_seconds")],
+    ),
+    (
+        "2026_06_16_1200-c4d5e6f7a8b9_add_status_reason_column.py",
+        [("endpoints", "status_reason")],
+    ),
+]
+
+
+def load_migration(filename: str) -> Any:
+    path = VERSIONS_DIR / filename
+    spec = spec_from_file_location(path.stem.replace("-", "_"), path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_initial_migration_adopts_an_existing_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    migration = load_migration(INITIAL_MIGRATION)
+    inspector = Mock()
+    inspector.has_table.return_value = True
+    operation = Mock()
+    monkeypatch.setattr(migration.sa, "inspect", Mock(return_value=inspector))
+    monkeypatch.setattr(migration, "op", operation)
+
+    with patch("builtins.open", mock_open()) as open_file:
+        migration.upgrade()
+
+    inspector.has_table.assert_called_once_with("endpoints", schema="hosted_model_inference")
+    open_file.assert_not_called()
+    operation.execute.assert_not_called()
+
+
+def test_initial_migration_initializes_an_empty_database(monkeypatch: pytest.MonkeyPatch) -> None:
+    migration = load_migration(INITIAL_MIGRATION)
+    inspector = Mock()
+    inspector.has_table.return_value = False
+    operation = Mock()
+    monkeypatch.setattr(migration.sa, "inspect", Mock(return_value=inspector))
+    monkeypatch.setattr(migration, "op", operation)
+
+    with patch("builtins.open", mock_open(read_data="SELECT 1;")) as open_file:
+        migration.upgrade()
+
+    open_file.assert_called_once_with(migration.INITIAL_MIGRATION_PATH)
+    operation.execute.assert_called_once_with("SELECT 1;")
+
+
+@pytest.mark.parametrize(("filename", "columns"), ADD_COLUMN_MIGRATIONS)
+def test_upgrade_skips_columns_that_already_exist(
+    filename: str,
+    columns: list[tuple[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    migration = load_migration(filename)
+    inspector = Mock()
+    inspector.get_columns.return_value = [{"name": column} for _, column in columns]
+    operation = Mock()
+    monkeypatch.setattr(migration.sa, "inspect", Mock(return_value=inspector))
+    monkeypatch.setattr(migration, "op", operation)
+
+    migration.upgrade()
+
+    operation.add_column.assert_not_called()
+
+
+@pytest.mark.parametrize(("filename", "columns"), ADD_COLUMN_MIGRATIONS)
+def test_upgrade_adds_only_missing_columns(
+    filename: str,
+    columns: list[tuple[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    migration = load_migration(filename)
+    inspector = Mock()
+    inspector.get_columns.return_value = []
+    operation = Mock()
+    monkeypatch.setattr(migration.sa, "inspect", Mock(return_value=inspector))
+    monkeypatch.setattr(migration, "op", operation)
+
+    migration.upgrade()
+
+    added_columns = [
+        (call.args[0], call.args[1].name, call.kwargs["schema"])
+        for call in operation.add_column.call_args_list
+    ]
+    assert added_columns == [(table, column, "hosted_model_inference") for table, column in columns]
+
+
+@pytest.mark.parametrize(("filename", "columns"), ADD_COLUMN_MIGRATIONS)
+def test_downgrade_skips_columns_that_are_already_absent(
+    filename: str,
+    columns: list[tuple[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    migration = load_migration(filename)
+    inspector = Mock()
+    inspector.get_columns.return_value = []
+    operation = Mock()
+    monkeypatch.setattr(migration.sa, "inspect", Mock(return_value=inspector))
+    monkeypatch.setattr(migration, "op", operation)
+
+    migration.downgrade()
+
+    operation.drop_column.assert_not_called()
+
+
+@pytest.mark.parametrize(("filename", "columns"), ADD_COLUMN_MIGRATIONS)
+def test_downgrade_drops_only_existing_columns(
+    filename: str,
+    columns: list[tuple[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    migration = load_migration(filename)
+    inspector = Mock()
+    inspector.get_columns.return_value = [{"name": column} for _, column in columns]
+    operation = Mock()
+    monkeypatch.setattr(migration.sa, "inspect", Mock(return_value=inspector))
+    monkeypatch.setattr(migration, "op", operation)
+
+    migration.downgrade()
+
+    dropped_columns = [
+        (call.args[0], call.args[1], call.kwargs["schema"])
+        for call in operation.drop_column.call_args_list
+    ]
+    assert dropped_columns == [
+        (table, column, "hosted_model_inference") for table, column in columns
+    ]


### PR DESCRIPTION
Adds automated regression coverage to #852 for the database-adoption behavior that the SGP model-engine recovery depends on.

The tests cover:

- adopting a pre-existing `hosted_model_inference` schema without replaying `initial.sql`;
- initializing an empty database through the initial revision;
- skipping existing columns during every add-column upgrade;
- adding only missing columns;
- skipping absent columns during downgrade; and
- dropping existing columns during downgrade.

This deliberately targets the open fix branch so it strengthens #852 without duplicating or overwriting the author's implementation.

Validation:

- 30 focused pytest cases pass;
- Black 24.8.0 passes;
- isort 5.13.2 passes;
- Ruff 0.6.8 passes.

Real PostgreSQL validation also passes for both an empty database and a simulated
legacy database with an existing, unstamped `hosted_model_inference` schema. Each
case successfully completed upgrade, repeat upgrade, downgrade, and re-upgrade.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new test file that provides regression coverage for the idempotent database-migration adoption behavior introduced in #852. Tests load each migration via `importlib`, replace `sa.inspect` and `op` with mocks via `monkeypatch`, and assert upgrade/downgrade outcomes without hitting a real database.

- 30 parametrised cases cover all seven `ADD_COLUMN` migrations (skip-if-exists and add-if-missing for upgrade; skip-if-absent and drop-if-present for downgrade) plus two cases for the initial migration (adopt existing schema vs. run `initial.sql` on an empty database).
- Migration modules are freshly loaded per test via `spec_from_file_location` + `exec_module`, isolating module-level state while sharing the real `sqlalchemy` module object (safe because `monkeypatch` is function-scoped and restores teardown).

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — only adds tests, touches no production code.

The test logic correctly exercises all six idempotency scenarios across every migration in the chain. The single gap is that the `get_columns` mock is checked only for its return value, not for whether it was called with the correct schema; a migration that dropped the `schema` keyword from the inspector call would still make all tests pass. This is a test-coverage quality concern rather than a correctness defect in production behaviour.

No production files are changed. The only file worth a second look is `test_database_migration_adoption.py` — specifically the `get_columns` assertion gaps noted in the inline comment.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| model-engine/tests/test_database_migration_adoption.py | New test file covering idempotent migration adoption: adopt existing schema vs. fresh initialisation, skip/add missing columns on upgrade, skip/drop existing columns on downgrade. Logic is sound for current migrations; the `get_columns` mock doesn't assert schema arguments, leaving one narrow gap in coverage. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[load_migration - importlib] --> B{Test variant}
    B --> C[test_initial_migration_adopts_existing_schema]
    B --> D[test_initial_migration_initializes_empty_database]
    B --> E[test_upgrade_skips_columns_that_already_exist]
    B --> F[test_upgrade_adds_only_missing_columns]
    B --> G[test_downgrade_skips_columns_that_are_already_absent]
    B --> H[test_downgrade_drops_only_existing_columns]
    C --> C1["inspector.has_table True: open and op.execute NOT called"]
    D --> D1["inspector.has_table False: open called, op.execute called with SQL"]
    E --> E1["get_columns all columns: op.add_column NOT called"]
    F --> F1["get_columns empty: op.add_column called with correct table/column/schema"]
    G --> G1["get_columns empty: op.drop_column NOT called"]
    H --> H1["get_columns all columns: op.drop_column called with correct table/column/schema"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[load_migration - importlib] --> B{Test variant}
    B --> C[test_initial_migration_adopts_existing_schema]
    B --> D[test_initial_migration_initializes_empty_database]
    B --> E[test_upgrade_skips_columns_that_already_exist]
    B --> F[test_upgrade_adds_only_missing_columns]
    B --> G[test_downgrade_skips_columns_that_are_already_absent]
    B --> H[test_downgrade_drops_only_existing_columns]
    C --> C1["inspector.has_table True: open and op.execute NOT called"]
    D --> D1["inspector.has_table False: open called, op.execute called with SQL"]
    E --> E1["get_columns all columns: op.add_column NOT called"]
    F --> F1["get_columns empty: op.add_column called with correct table/column/schema"]
    G --> G1["get_columns empty: op.drop_column NOT called"]
    H --> H1["get_columns all columns: op.drop_column called with correct table/column/schema"]
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Amodel-engine%2Ftests%2Ftest_database_migration_adoption.py%3A88-105%0A**Schema%20argument%20not%20validated%20in%20%60get_columns%60%20mock**%0A%0AThe%20%60inspector.get_columns%60%20mock%20always%20returns%20a%20fixed%20list%20regardless%20of%20the%20arguments%20it%20receives.%20None%20of%20the%20four%20test%20variants%20assert%20that%20%60get_columns%60%20was%20called%20with%20%60schema%3D%22hosted_model_inference%22%60.%20A%20migration%20that%20omits%20the%20%60schema%60%20keyword%20from%20its%20internal%20%60get_columns%60%20call%20would%20silently%20produce%20the%20same%20mock%20return%20value%20and%20the%20tests%20would%20still%20pass%2C%20masking%20the%20missing%20schema%20propagation.%20Adding%20%60inspector.get_columns.assert_any_call%28table%2C%20schema%3D%22hosted_model_inference%22%29%60%20%28or%20equivalent%20per-call%20assertions%29%20in%20the%20upgrade%2Fdowngrade%20tests%20would%20close%20this%20gap%20%E2%80%94%20the%20same%20applies%20to%20%60test_downgrade_skips_columns_that_are_already_absent%60%20and%20%60test_downgrade_drops_only_existing_columns%60.%0A%0A&pr=855&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Amodel-engine%2Ftests%2Ftest_database_migration_adoption.py%3A88-105%0A**Schema%20argument%20not%20validated%20in%20%60get_columns%60%20mock**%0A%0AThe%20%60inspector.get_columns%60%20mock%20always%20returns%20a%20fixed%20list%20regardless%20of%20the%20arguments%20it%20receives.%20None%20of%20the%20four%20test%20variants%20assert%20that%20%60get_columns%60%20was%20called%20with%20%60schema%3D%22hosted_model_inference%22%60.%20A%20migration%20that%20omits%20the%20%60schema%60%20keyword%20from%20its%20internal%20%60get_columns%60%20call%20would%20silently%20produce%20the%20same%20mock%20return%20value%20and%20the%20tests%20would%20still%20pass%2C%20masking%20the%20missing%20schema%20propagation.%20Adding%20%60inspector.get_columns.assert_any_call%28table%2C%20schema%3D%22hosted_model_inference%22%29%60%20%28or%20equivalent%20per-call%20assertions%29%20in%20the%20upgrade%2Fdowngrade%20tests%20would%20close%20this%20gap%20%E2%80%94%20the%20same%20applies%20to%20%60test_downgrade_skips_columns_that_are_already_absent%60%20and%20%60test_downgrade_drops_only_existing_columns%60.%0A%0A&repo=scaleapi%2Fllm-engine&pr=855&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fllm-engine%22%20on%20the%20existing%20branch%20%22codex%2Fmodel-engine-migration-tests%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fmodel-engine-migration-tests%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Amodel-engine%2Ftests%2Ftest_database_migration_adoption.py%3A88-105%0A**Schema%20argument%20not%20validated%20in%20%60get_columns%60%20mock**%0A%0AThe%20%60inspector.get_columns%60%20mock%20always%20returns%20a%20fixed%20list%20regardless%20of%20the%20arguments%20it%20receives.%20None%20of%20the%20four%20test%20variants%20assert%20that%20%60get_columns%60%20was%20called%20with%20%60schema%3D%22hosted_model_inference%22%60.%20A%20migration%20that%20omits%20the%20%60schema%60%20keyword%20from%20its%20internal%20%60get_columns%60%20call%20would%20silently%20produce%20the%20same%20mock%20return%20value%20and%20the%20tests%20would%20still%20pass%2C%20masking%20the%20missing%20schema%20propagation.%20Adding%20%60inspector.get_columns.assert_any_call%28table%2C%20schema%3D%22hosted_model_inference%22%29%60%20%28or%20equivalent%20per-call%20assertions%29%20in%20the%20upgrade%2Fdowngrade%20tests%20would%20close%20this%20gap%20%E2%80%94%20the%20same%20applies%20to%20%60test_downgrade_skips_columns_that_are_already_absent%60%20and%20%60test_downgrade_drops_only_existing_columns%60.%0A%0A&repo=scaleapi%2Fllm-engine&pr=855&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
model-engine/tests/test_database_migration_adoption.py:88-105
**Schema argument not validated in `get_columns` mock**

The `inspector.get_columns` mock always returns a fixed list regardless of the arguments it receives. None of the four test variants assert that `get_columns` was called with `schema="hosted_model_inference"`. A migration that omits the `schema` keyword from its internal `get_columns` call would silently produce the same mock return value and the tests would still pass, masking the missing schema propagation. Adding `inspector.get_columns.assert_any_call(table, schema="hosted_model_inference")` (or equivalent per-call assertions) in the upgrade/downgrade tests would close this gap — the same applies to `test_downgrade_skips_columns_that_are_already_absent` and `test_downgrade_drops_only_existing_columns`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: cover model-engine migration adopt..."](https://github.com/scaleapi/llm-engine/commit/de23ba63f6495a0b5440554b6ccfa356e77d443b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44501748)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->