### PR TITLE
fix(helm): make Istio metrics plugin optional

### DIFF
--- a/charts/model-engine/Chart.yaml
+++ b/charts/model-engine/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.7
+version: 0.2.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/model-engine/templates/istio-metrics.yaml
+++ b/charts/model-engine/templates/istio-metrics.yaml
@@ -1,4 +1,4 @@
-{{- if empty .Values.azure }}
+{{- if and (empty .Values.azure) .Values.wasmPlugin.enabled }}
 apiVersion: telemetry.istio.io/v1alpha1
 kind: Telemetry
 metadata:

--- a/charts/model-engine/values.yaml
+++ b/charts/model-engine/values.yaml
@@ -7,6 +7,12 @@ datadog:
   # Set per-cluster (e.g. "sgp-dev") so pods report the cluster's real environment.
   env: ""
 
+# wasmPlugin controls the Istio attributegen plugin used only to enrich request
+# metrics. Disable it in airgapped or TLS-intercepted clusters where the remote
+# WASM binary cannot be fetched safely.
+wasmPlugin:
+  enabled: true
+
 spellbook:
   enabled: false
 


### PR DESCRIPTION
## Summary

- add a real `wasmPlugin.enabled` Helm value, defaulting to `true`
- omit the metrics-only Istio `Telemetry` and `WasmPlugin` resources when disabled
- bump the chart version to `0.2.8`

## Why

The attributegen WASM binary is fetched from `storage.googleapis.com`. In airgapped or TLS-intercepted clusters that fetch can fail, and Istio's fail-closed fallback installs an empty RBAC filter that denies every request to Model Engine. Wrapper charts were already trying to set `wasmPlugin.enabled: false`, but the upstream chart ignored the value.

## Validation

- `helm lint charts/model-engine -f charts/model-engine/values_sample.yaml`
- default render includes both `Telemetry` and `WasmPlugin`
- render with `--set wasmPlugin.enabled=false` includes neither resource
