### PR TITLE
feat(chart): opt-in securityContext on model-engine db-init Job

### DIFF
--- a/charts/model-engine/Chart.yaml
+++ b/charts/model-engine/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.7
+version: 0.2.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/model-engine/templates/database_init_job.yaml
+++ b/charts/model-engine/templates/database_init_job.yaml
@@ -20,6 +20,10 @@ spec:
         {{- include "modelEngine.labels" . | nindent 8 }}
     spec:
       restartPolicy: Never
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -27,6 +31,10 @@ spec:
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       containers:
         - name: {{ include "modelEngine.fullname" . }}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.image.gatewayRepository }}:{{ .Values.tag}}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:

--- a/charts/model-engine/templates/database_migration_job.yaml
+++ b/charts/model-engine/templates/database_migration_job.yaml
@@ -20,12 +20,20 @@ spec:
         {{- include "modelEngine.labels" . | nindent 8 }}
     spec:
       restartPolicy: Never
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: {{ include "modelEngine.fullname" . }}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.image.gatewayRepository }}:{{ .Values.tag}}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:


### PR DESCRIPTION
## What
Adds `securityContext` support to the `database_init_job.yaml` pre-upgrade hook Job, guarded by the same values the main deployments already use:

```yaml
{{- with .Values.podSecurityContext }}
securityContext: {{- toYaml . | nindent 8 }}
{{- end }}
# ... and on the container:
{{- with .Values.containerSecurityContext }}
securityContext: {{- toYaml . | nindent 12 }}
{{- end }}
```

Bumps the chart `0.2.7 → 0.2.8`.

## Why
On a PodSecurity **`restricted`**-enforcing cluster (SGP on-prem / pubsec), the db-setup hook Job is rejected at admission — it hardcoded no securityContext, so it fails on `runAsNonRoot`, `seccompProfile`, `capabilities.drop=[ALL]`, and `allowPrivilegeEscalation`. Because it's a `pre-install,pre-upgrade` hook, that failure blocks the entire `model-engine` release from installing. `gateway`/`endpoint_builder`/`cacher` deployments already consume `.Values.podSecurityContext` / `.Values.containerSecurityContext`; this extends the same pattern to the Job.

The image is already chainguard `USER nonroot` (uid 65532), so it runs nonroot cleanly when the values are applied.

## Impact — none for existing deployments (opt-in)
The blocks use `{{- with .Values.podSecurityContext }}` / `containerSecurityContext`, and both keys are **unset by default** (commented out in `values.yaml`). Verified by rendering:

| Render | securityContext in the Job |
|---|---|
| default values (all existing setups) | **0** — byte-identical to before |
| with the values set (opt-in) | 2 (pod + container) |

Only consumers that explicitly set those values (SGP on-prem `pubsec-donovan` overlay) get the hardening. Cloud/GCP/staging render unchanged, and pinned chart versions aren't auto-upgraded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends pod/container security context support to the `database_init_job.yaml` and `database_migration_job.yaml` Helm hook Jobs, mirroring the pattern already in place on the main deployments (`gateway`, `endpoint_builder`, `cacher`). It also bumps the chart version from `0.2.7` to `0.2.8`.

- Both `{{- with .Values.podSecurityContext }}` and `{{- with .Values.containerSecurityContext }}` guards are strictly opt-in — clusters that don't set these values render byte-identical manifests to before.
- The Helm template YAML structure and `nindent` levels are correct and match the reference pattern in `gateway_deployment.yaml` exactly.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes are strictly opt-in and existing deployments render byte-identical manifests.

The template additions use `{{- with ... }}` guards on unset-by-default values, so no existing deployment is affected. The Helm YAML structure, nindent levels, and field placement all match the established pattern from `gateway_deployment.yaml` exactly. The chart version bump is appropriate.

No files require special attention. The one follow-up worth tracking is `spellbook_init_job.yaml`, which is not in this PR but will face the same admission issue on restricted clusters when spellbook is enabled.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| charts/model-engine/templates/database_init_job.yaml | Adds opt-in pod and container securityContext blocks using the same `{{- with ... }}` guard pattern as the main deployments; correct nindent levels and placement. |
| charts/model-engine/templates/database_migration_job.yaml | Same opt-in securityContext additions as the init job; consistent with gateway_deployment.yaml pattern and correct nindent values. |
| charts/model-engine/Chart.yaml | Version bump 0.2.7 → 0.2.8, appropriate for the template changes introduced in this PR. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[helm upgrade/install] --> B{pre-install / pre-upgrade hooks}
    B --> C[database_init_job\nhook-weight: -2]
    B --> D[database_migration_job\nhook-weight: -1]
    C --> E{podSecurityContext set?}
    E -- yes --> F[pod securityContext injected\ncontainer securityContext injected]
    E -- no --> G[no securityContext rendered\nbyte-identical to before]
    D --> H{podSecurityContext set?}
    H -- yes --> I[pod securityContext injected\ncontainer securityContext injected]
    H -- no --> J[no securityContext rendered\nbyte-identical to before]
    F --> K[Admission control passes\non restricted cluster]
    I --> K
    G --> L[Existing clusters unaffected]
    J --> L
    K --> M[Main chart resources deployed]
    L --> M
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[helm upgrade/install] --> B{pre-install / pre-upgrade hooks}
    B --> C[database_init_job\nhook-weight: -2]
    B --> D[database_migration_job\nhook-weight: -1]
    C --> E{podSecurityContext set?}
    E -- yes --> F[pod securityContext injected\ncontainer securityContext injected]
    E -- no --> G[no securityContext rendered\nbyte-identical to before]
    D --> H{podSecurityContext set?}
    H -- yes --> I[pod securityContext injected\ncontainer securityContext injected]
    H -- no --> J[no securityContext rendered\nbyte-identical to before]
    F --> K[Admission control passes\non restricted cluster]
    I --> K
    G --> L[Existing clusters unaffected]
    J --> L
    K --> M[Main chart resources deployed]
    L --> M
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["feat(chart): also harden the db-migratio..."](https://github.com/scaleapi/llm-engine/commit/b2ebd6929895272b86371e4474050ca42f6610eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45656532)</sub>

<!-- /greptile_comment -->