### PR TITLE
fix(chart): scope forwarder max_concurrency under forwarder.* so config unwrap keeps sync/stream/routes

### DIFF
--- a/charts/model-engine/Chart.yaml
+++ b/charts/model-engine/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.8
+version: 0.2.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/model-engine/templates/service_template_config_map.yaml
+++ b/charts/model-engine/templates/service_template_config_map.yaml
@@ -147,7 +147,7 @@ data:
                 - --set
                 - "forwarder.sync.routes=${FORWARDER_SYNC_ROUTES}"
                 - --set
-                - "max_concurrency=${FORWARDER_MAX_CONCURRENCY}"
+                - "forwarder.max_concurrency=${FORWARDER_MAX_CONCURRENCY}"
               {{- $sync_forwarder_template_env | nindent 14 }}
               readinessProbe:
                 httpGet:
@@ -205,7 +205,7 @@ data:
                 - --set
                 - "forwarder.stream.routes=${FORWARDER_STREAM_ROUTES}"
                 - --set
-                - "max_concurrency=${FORWARDER_MAX_CONCURRENCY}"
+                - "forwarder.max_concurrency=${FORWARDER_MAX_CONCURRENCY}"
               {{- $sync_forwarder_template_env | nindent 14 }}
               readinessProbe:
                 httpGet:
@@ -615,7 +615,7 @@ data:
                   - --set
                   - "forwarder.sync.routes=${FORWARDER_SYNC_ROUTES}"
                   - --set
-                  - "max_concurrency=${FORWARDER_MAX_CONCURRENCY}"
+                  - "forwarder.max_concurrency=${FORWARDER_MAX_CONCURRENCY}"
                 {{- $sync_forwarder_template_env | nindent 16 }}
                 readinessProbe:
                   httpGet:
@@ -673,7 +673,7 @@ data:
                   - --set
                   - "forwarder.stream.routes=${FORWARDER_STREAM_ROUTES}"
                   - --set
-                  - "max_concurrency=${FORWARDER_MAX_CONCURRENCY}"
+                  - "forwarder.max_concurrency=${FORWARDER_MAX_CONCURRENCY}"
                 {{- $sync_forwarder_template_env | nindent 16 }}
                 readinessProbe:
                   httpGet:


### PR DESCRIPTION
## Problem
Model-engine inference endpoints (sync / async / streaming) return `Upstream service error` for **every** request. The http-forwarder crashes with `KeyError: 'sync'` in `get_forwarder_loader` (`get_config()["sync"]`), so no request ever reaches the model server.

## Root cause
The forwarder config file (`service--http_forwarder.yaml`) is a single-key `forwarder:` wrapper (`sync`, `stream`, `max_concurrency` nested under it). `load_named_config` only unwraps that top-level `forwarder:` key **`if len(config) == 1`**.

The deployment template passes the forwarder concurrency override **without** the `forwarder.` prefix:

    - "max_concurrency=${FORWARDER_MAX_CONCURRENCY}"

That adds a *second* top-level key (`max_concurrency`) → `len(config) == 2` → the unwrap is skipped → `get_config()` returns `{forwarder: {...}, max_concurrency: N}` → `["sync"]` raises `KeyError`. The same unwrap failure also prevents the OpenAI passthrough routes (`/v1/chat/completions`, `/v1/completions`) from registering, since they live under `sync.routes`.

Every other forwarder override in the template is correctly prefixed (`forwarder.sync.*`, `forwarder.stream.*`) — only `max_concurrency` was missing it.

## Fix
Prefix all 4 occurrences: `max_concurrency=…` → `forwarder.max_concurrency=…`. The override then lands inside the wrapper, `len(config) == 1` holds, the unwrap succeeds, and `sync` / `stream` / `routes` all resolve.

## Validation
Reproduced and fixed live on an on-prem cluster (phi-3-mini, vLLM, streaming endpoint): after the prefix, the forwarder logs `Adding route /v1/chat/completions` + `/predict` + `/stream`, the `KeyError` is gone, and both the native (`/predict`) and OpenAI-compatible (`/v1/chat/completions`) paths return 200 with real GPU generation.

Present in 0.2.7, 0.2.8, and main. Chart bumped 0.2.8 → 0.2.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a critical bug where the http-forwarder crashed with `KeyError: 'sync'` on every inference request because `max_concurrency` was passed as a bare top-level key instead of under the `forwarder.` namespace, preventing `load_named_config` from unwrapping the config wrapper.

- Adds the `forwarder.` prefix to all 4 `max_concurrency` override arguments in `service_template_config_map.yaml` (2 for sync/streaming in each of two deployment template blocks), making the config structure consistent with all other `--set` flags.
- Bumps the chart version from 0.2.8 to 0.2.9 to reflect the template change.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is targeted, complete, and directly validated against production behavior.

All 4 affected --set arguments now carry the forwarder. prefix, matching every other override in the template. The root cause (bare max_concurrency key breaking the single-key unwrap heuristic in load_named_config) is fully addressed. The author confirmed the fix restores both native (/predict) and OpenAI-compatible (/v1/chat/completions) routes on a live cluster. The chart version bump is correct and consistent with the project's versioning practice.

No files require special attention — the change is confined to two files and each hunk is a mechanical, one-line prefix addition.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| charts/model-engine/templates/service_template_config_map.yaml | Adds `forwarder.` prefix to all 4 `max_concurrency` --set arguments so the config unwrap logic works correctly; fix is complete, symmetric, and consistent with adjacent --set flags. |
| charts/model-engine/Chart.yaml | Patch version bumped 0.2.8 → 0.2.9 to reflect the template change; no other modifications. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant K8s as Kubernetes Pod
    participant Forwarder as http-forwarder
    participant Config as load_named_config
    participant Model as Model Server

    Note over K8s: --set forwarder.max_concurrency=N (fixed)
    K8s->>Forwarder: Start with --set args
    Forwarder->>Config: load config file
    Note over Config: config = {forwarder: {sync:..., stream:..., max_concurrency: N}}
    Note over Config: len(config) == 1 → unwrap forwarder key ✅
    Config-->>Forwarder: "{sync: {...}, stream: {...}, max_concurrency: N}"
    Forwarder->>Forwarder: get_config()["sync"] ✅
    Forwarder->>Model: Forward /predict, /v1/chat/completions, /stream

    Note over K8s: --set max_concurrency=N (old broken behavior)
    K8s->>Forwarder: Start with --set args
    Forwarder->>Config: load config file
    Note over Config: config = {forwarder: {...}, max_concurrency: N}
    Note over Config: len(config) == 2 → skip unwrap ❌
    Config-->>Forwarder: "{forwarder: {...}, max_concurrency: N}"
    Forwarder->>Forwarder: get_config()["sync"] → KeyError ❌
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(chart): scope forwarder max\_concurre..."](https://github.com/scaleapi/llm-engine/commit/5dc16edc492ada9175394558f12235534221fe1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46665844)</sub>

<!-- /greptile_comment -->