### PR TITLE
ci: auto-publish model-engine helm chart to public ECR on merge (MLI-7871)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,34 @@ workflows:
             branches:
               only:
                 - main
+      - publish_helm_chart:
+          requires:
+            - run_unit_tests_python_client
+            - run_unit_tests_server
+            - build_image
+          filters:
+            branches:
+              only:
+                - main
 
 jobs:
+  publish_helm_chart:
+    docker:
+      - image: cimg/aws:2023.09
+    resource_class: small
+    steps:
+      - checkout
+      - aws-cli/setup:
+          role-arn: ${CIRCLECI_ROLE_ARN}
+          aws-region: AWS_REGION
+      - run:
+          name: Install helm
+          command: |
+            curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+      - run:
+          name: Publish model-engine Helm chart to public ECR (idempotent)
+          command: |
+            ./.circleci/scripts/publish-helm-chart.sh
   run_unit_tests_python_client:
     docker:
       - image: python:3.13-bookworm

--- a/.circleci/scripts/publish-helm-chart.sh
+++ b/.circleci/scripts/publish-helm-chart.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Publish the model-engine Helm chart to the public ECR registry.
+#
+# Idempotent: reads the chart version from charts/model-engine/Chart.yaml and
+# only packages + pushes when that version tag is not already published. So it
+# is safe to run on every merge to main — an actual publish happens only when
+# the chart version was bumped.
+#
+# Requires: helm, aws-cli, and AWS credentials for a principal in account
+# 692474966980 with ecr-public publish permission on
+# model-engine-helm-charts/model-engine (the CircleCI `circleci` OIDC role).
+set -euo pipefail
+
+CHART_DIR="charts/model-engine"
+PUBLIC_ECR_REGISTRY="public.ecr.aws/b2z8n5q1"
+CHART_REPO_PATH="model-engine-helm-charts"          # helm appends the chart name (model-engine)
+ECR_REPOSITORY_NAME="model-engine-helm-charts/model-engine"
+ECR_PUBLIC_REGION="us-east-1"                        # ECR Public API only exists in us-east-1
+
+VERSION="$(helm show chart "${CHART_DIR}" | awk '/^version:/ {print $2}')"
+if [[ -z "${VERSION}" ]]; then
+  echo "ERROR: could not determine chart version from ${CHART_DIR}/Chart.yaml" >&2
+  exit 1
+fi
+echo "model-engine chart version: ${VERSION}"
+
+if aws ecr-public describe-images \
+      --region "${ECR_PUBLIC_REGION}" \
+      --repository-name "${ECR_REPOSITORY_NAME}" \
+      --image-ids imageTag="${VERSION}" >/dev/null 2>&1; then
+  echo "Chart ${VERSION} is already published to ${PUBLIC_ECR_REGISTRY}/${ECR_REPOSITORY_NAME} — nothing to do."
+  exit 0
+fi
+
+echo "Publishing model-engine chart ${VERSION}..."
+aws ecr-public get-login-password --region "${ECR_PUBLIC_REGION}" \
+  | helm registry login --username AWS --password-stdin public.ecr.aws
+
+PKG_DIR="$(mktemp -d)"
+helm package "${CHART_DIR}" -d "${PKG_DIR}"
+helm push "${PKG_DIR}/model-engine-${VERSION}.tgz" "oci://${PUBLIC_ECR_REGISTRY}/${CHART_REPO_PATH}"
+
+echo "Published oci://${PUBLIC_ECR_REGISTRY}/${ECR_REPOSITORY_NAME}:${VERSION}"


### PR DESCRIPTION
## What

Auto-publishes the `model-engine` Helm chart to the public ECR registry on merge to `main`, replacing the manual on-call `helm push` ([MLI-7871](https://linear.app/scale-epd/issue/MLI-7871), [MLI-7863](https://linear.app/scale-epd/issue/MLI-7863)).

- New `publish_helm_chart` CircleCI job — `main`-only, gated on `run_unit_tests_python_client` + `run_unit_tests_server` + `build_image`. Assumes the same `${CIRCLECI_ROLE_ARN}` the `integration_tests` job already uses.
- New `.circleci/scripts/publish-helm-chart.sh` — reads the version from `charts/model-engine/Chart.yaml`, checks whether that tag is already in public ECR, and **only packages + pushes when it's new**.

## Workflow after this lands

Bump `charts/model-engine/Chart.yaml` `version:` in a PR → merge → the chart auto-publishes. No version bump → the job is a no-op. On-call is out of the loop.

## Dependency + merge order

Requires the `circleci` OIDC role to have `ecr-public` publish permission on `model-engine-helm-charts/model-engine`, added in **Terracode-ML https://github.com/scaleapi/Terracode-ML/pull/1530**. That PR must land (and atlantis apply) **before** this one, or the job's push will 403.

## Confirm before/at merge

The llm-engine CircleCI project env var `CIRCLECI_ROLE_ARN` must resolve to `arn:aws:iam::692474966980:role/circleci` (the role the Terracode PR grants). Every signal in Terraform + live IAM matches; the env var itself lives in CircleCI project settings.

## Notes

- Image tag `cimg/aws:2023.09` — bump to a current tag if preferred.
- Verified manually today: chart `0.2.9` published + `helm pull --version 0.2.9` resolves digest `sha256:8b9960…536ac8`. This automates that same path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR automates publishing the `model-engine` Helm chart to the public ECR registry on every merge to `main`, replacing the previous manual on-call `helm push`. The new `publish_helm_chart` job is gated on the three existing CI jobs and is fully idempotent — it skips the push when the chart version is already present in ECR.

- New CircleCI job (`publish_helm_chart`) runs after tests and image build pass on `main`, uses the existing OIDC role (`CIRCLECI_ROLE_ARN`), and delegates all publish logic to a new shell script.
- New `publish-helm-chart.sh` reads the version from `Chart.yaml`, checks ECR for an existing tag, and only packages + pushes when the version is new — requires the companion Terraform PR to grant `ecr-public` publish permission to the OIDC role before this can succeed.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge once the companion Terraform PR (Terracode-ML #1530) is applied; the publish job will 403 until that IAM change lands.

The core logic is correct and the idempotency design is sound. The Helm installer is unpinned, diverging from the pinned pattern already used in run_unit_tests_server, and the ECR describe-images check silently treats all non-zero exits including permission errors as not yet published.

.circleci/config.yml Helm install step and the describe-images error handling in publish-helm-chart.sh
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .circleci/config.yml | Adds publish_helm_chart job gated on tests + build_image, main-only; Helm install is unpinned unlike the existing run_unit_tests_server pattern |
| .circleci/scripts/publish-helm-chart.sh | New idempotent publish script; version check, ECR login, package, and push are correct, but the describe-images error check silently treats all non-zero exits (including permission errors) as not published |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GH as GitHub (main merge)
    participant CCI as CircleCI
    participant ECR as ECR Public (us-east-1)

    GH->>CCI: trigger ci workflow
    par parallel gates
        CCI->>CCI: run_unit_tests_python_client
        CCI->>CCI: run_unit_tests_server
        CCI->>CCI: build_image
    end
    CCI->>CCI: publish_helm_chart (requires all three)
    CCI->>CCI: helm show chart parse VERSION from Chart.yaml
    CCI->>ECR: "ecr-public describe-images imageTag=VERSION"
    alt tag already exists
        ECR-->>CCI: exit 0 image found
        CCI->>CCI: no-op exit
    else tag not found or any error
        ECR-->>CCI: non-zero exit
        CCI->>ECR: ecr-public get-login-password
        ECR-->>CCI: token
        CCI->>CCI: helm registry login public.ecr.aws
        CCI->>CCI: helm package model-engine-VERSION.tgz
        CCI->>ECR: helm push oci to model-engine-helm-charts
        ECR-->>CCI: published
    end
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.circleci%2Fconfig.yml%3A39-42%0AThe%20Helm%20install%20here%20differs%20from%20the%20more%20careful%20pattern%20already%20established%20in%20the%20%60run_unit_tests_server%60%20command%20%28lines%20322%E2%80%93326%29%2C%20which%20downloads%20the%20script%20first%2C%20pins%20an%20explicit%20version%20via%20%60DESIRED_VERSION%3Dv3.17.3%60%2C%20and%20verifies%20with%20%60helm%20version%60.%20This%20job%20runs%20with%20live%20AWS%20OIDC%20credentials%20and%20is%20directly%20responsible%20for%20publishing%20artifacts%2C%20so%20using%20an%20unpinned%20%60curl%20%7C%20bash%60%20means%20any%20future%20change%20to%20the%20%60main%60%20branch%20of%20the%20Helm%20repo's%20installer%20is%20picked%20up%20immediately%20without%20review.%20Using%20a%20different%20Helm%20version%20than%20the%20rest%20of%20CI%20is%20also%20a%20latent%20inconsistency.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20run%3A%0A%20%20%20%20%20%20%20%20%20%20name%3A%20Install%20helm%0A%20%20%20%20%20%20%20%20%20%20command%3A%20%7C%0A%20%20%20%20%20%20%20%20%20%20%20%20curl%20-fsSL%20https%3A%2F%2Fraw.githubusercontent.com%2Fhelm%2Fhelm%2Fmain%2Fscripts%2Fget-helm-3%20-o%20get_helm.sh%0A%20%20%20%20%20%20%20%20%20%20%20%20chmod%20700%20get_helm.sh%0A%20%20%20%20%20%20%20%20%20%20%20%20DESIRED_VERSION%3Dv3.17.3%20.%2Fget_helm.sh%0A%20%20%20%20%20%20%20%20%20%20%20%20helm%20version%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0A.circleci%2Fscripts%2Fpublish-helm-chart.sh%3A27-33%0A**Silent%20failure%20on%20non-404%20errors%20in%20idempotency%20check**%0A%0A%60describe-images%60%20errors%20are%20fully%20suppressed%20%28%60%3E%2Fdev%2Fnull%202%3E%261%60%29%2C%20so%20any%20failure%20%E2%80%94%20permission%20denied%2C%20transient%20network%20error%2C%20throttling%20%E2%80%94%20is%20interpreted%20the%20same%20way%20as%20%22image%20not%20found%22%20and%20causes%20the%20script%20to%20proceed%20to%20publish.%20If%20the%20OIDC%20role%20gains%20push%20permission%20but%20is%20missing%20%60ecr-public%3ADescribeImages%60%2C%20the%20check%20is%20effectively%20bypassed%20on%20every%20run%3B%20publishing%20would%20succeed%20on%20new%20versions%20but%20produce%20a%20redundant%20push%20attempt%20on%20unchanged%20versions.%20Consider%20checking%20the%20exit%20code%20separately%20from%20error%20output%20so%20a%20non-404%20failure%20can%20surface%20rather%20than%20silently%20proceeding.%0A%0A&pr=859&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.circleci%2Fconfig.yml%3A39-42%0AThe%20Helm%20install%20here%20differs%20from%20the%20more%20careful%20pattern%20already%20established%20in%20the%20%60run_unit_tests_server%60%20command%20%28lines%20322%E2%80%93326%29%2C%20which%20downloads%20the%20script%20first%2C%20pins%20an%20explicit%20version%20via%20%60DESIRED_VERSION%3Dv3.17.3%60%2C%20and%20verifies%20with%20%60helm%20version%60.%20This%20job%20runs%20with%20live%20AWS%20OIDC%20credentials%20and%20is%20directly%20responsible%20for%20publishing%20artifacts%2C%20so%20using%20an%20unpinned%20%60curl%20%7C%20bash%60%20means%20any%20future%20change%20to%20the%20%60main%60%20branch%20of%20the%20Helm%20repo's%20installer%20is%20picked%20up%20immediately%20without%20review.%20Using%20a%20different%20Helm%20version%20than%20the%20rest%20of%20CI%20is%20also%20a%20latent%20inconsistency.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20run%3A%0A%20%20%20%20%20%20%20%20%20%20name%3A%20Install%20helm%0A%20%20%20%20%20%20%20%20%20%20command%3A%20%7C%0A%20%20%20%20%20%20%20%20%20%20%20%20curl%20-fsSL%20https%3A%2F%2Fraw.githubusercontent.com%2Fhelm%2Fhelm%2Fmain%2Fscripts%2Fget-helm-3%20-o%20get_helm.sh%0A%20%20%20%20%20%20%20%20%20%20%20%20chmod%20700%20get_helm.sh%0A%20%20%20%20%20%20%20%20%20%20%20%20DESIRED_VERSION%3Dv3.17.3%20.%2Fget_helm.sh%0A%20%20%20%20%20%20%20%20%20%20%20%20helm%20version%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0A.circleci%2Fscripts%2Fpublish-helm-chart.sh%3A27-33%0A**Silent%20failure%20on%20non-404%20errors%20in%20idempotency%20check**%0A%0A%60describe-images%60%20errors%20are%20fully%20suppressed%20%28%60%3E%2Fdev%2Fnull%202%3E%261%60%29%2C%20so%20any%20failure%20%E2%80%94%20permission%20denied%2C%20transient%20network%20error%2C%20throttling%20%E2%80%94%20is%20interpreted%20the%20same%20way%20as%20%22image%20not%20found%22%20and%20causes%20the%20script%20to%20proceed%20to%20publish.%20If%20the%20OIDC%20role%20gains%20push%20permission%20but%20is%20missing%20%60ecr-public%3ADescribeImages%60%2C%20the%20check%20is%20effectively%20bypassed%20on%20every%20run%3B%20publishing%20would%20succeed%20on%20new%20versions%20but%20produce%20a%20redundant%20push%20attempt%20on%20unchanged%20versions.%20Consider%20checking%20the%20exit%20code%20separately%20from%20error%20output%20so%20a%20non-404%20failure%20can%20surface%20rather%20than%20silently%20proceeding.%0A%0A&repo=scaleapi%2Fllm-engine&pr=859&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fllm-engine%22%20on%20the%20existing%20branch%20%22billyang%2F_claude%2Fpublish-helm-chart-ci%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22billyang%2F_claude%2Fpublish-helm-chart-ci%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.circleci%2Fconfig.yml%3A39-42%0AThe%20Helm%20install%20here%20differs%20from%20the%20more%20careful%20pattern%20already%20established%20in%20the%20%60run_unit_tests_server%60%20command%20%28lines%20322%E2%80%93326%29%2C%20which%20downloads%20the%20script%20first%2C%20pins%20an%20explicit%20version%20via%20%60DESIRED_VERSION%3Dv3.17.3%60%2C%20and%20verifies%20with%20%60helm%20version%60.%20This%20job%20runs%20with%20live%20AWS%20OIDC%20credentials%20and%20is%20directly%20responsible%20for%20publishing%20artifacts%2C%20so%20using%20an%20unpinned%20%60curl%20%7C%20bash%60%20means%20any%20future%20change%20to%20the%20%60main%60%20branch%20of%20the%20Helm%20repo's%20installer%20is%20picked%20up%20immediately%20without%20review.%20Using%20a%20different%20Helm%20version%20than%20the%20rest%20of%20CI%20is%20also%20a%20latent%20inconsistency.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20run%3A%0A%20%20%20%20%20%20%20%20%20%20name%3A%20Install%20helm%0A%20%20%20%20%20%20%20%20%20%20command%3A%20%7C%0A%20%20%20%20%20%20%20%20%20%20%20%20curl%20-fsSL%20https%3A%2F%2Fraw.githubusercontent.com%2Fhelm%2Fhelm%2Fmain%2Fscripts%2Fget-helm-3%20-o%20get_helm.sh%0A%20%20%20%20%20%20%20%20%20%20%20%20chmod%20700%20get_helm.sh%0A%20%20%20%20%20%20%20%20%20%20%20%20DESIRED_VERSION%3Dv3.17.3%20.%2Fget_helm.sh%0A%20%20%20%20%20%20%20%20%20%20%20%20helm%20version%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0A.circleci%2Fscripts%2Fpublish-helm-chart.sh%3A27-33%0A**Silent%20failure%20on%20non-404%20errors%20in%20idempotency%20check**%0A%0A%60describe-images%60%20errors%20are%20fully%20suppressed%20%28%60%3E%2Fdev%2Fnull%202%3E%261%60%29%2C%20so%20any%20failure%20%E2%80%94%20permission%20denied%2C%20transient%20network%20error%2C%20throttling%20%E2%80%94%20is%20interpreted%20the%20same%20way%20as%20%22image%20not%20found%22%20and%20causes%20the%20script%20to%20proceed%20to%20publish.%20If%20the%20OIDC%20role%20gains%20push%20permission%20but%20is%20missing%20%60ecr-public%3ADescribeImages%60%2C%20the%20check%20is%20effectively%20bypassed%20on%20every%20run%3B%20publishing%20would%20succeed%20on%20new%20versions%20but%20produce%20a%20redundant%20push%20attempt%20on%20unchanged%20versions.%20Consider%20checking%20the%20exit%20code%20separately%20from%20error%20output%20so%20a%20non-404%20failure%20can%20surface%20rather%20than%20silently%20proceeding.%0A%0A&repo=scaleapi%2Fllm-engine&pr=859&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.circleci/config.yml:39-42
The Helm install here differs from the more careful pattern already established in the `run_unit_tests_server` command (lines 322–326), which downloads the script first, pins an explicit version via `DESIRED_VERSION=v3.17.3`, and verifies with `helm version`. This job runs with live AWS OIDC credentials and is directly responsible for publishing artifacts, so using an unpinned `curl | bash` means any future change to the `main` branch of the Helm repo's installer is picked up immediately without review. Using a different Helm version than the rest of CI is also a latent inconsistency.

```suggestion
      - run:
          name: Install helm
          command: |
            curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 -o get_helm.sh
            chmod 700 get_helm.sh
            DESIRED_VERSION=v3.17.3 ./get_helm.sh
            helm version
```

### Issue 2 of 2
.circleci/scripts/publish-helm-chart.sh:27-33
**Silent failure on non-404 errors in idempotency check**

`describe-images` errors are fully suppressed (`>/dev/null 2>&1`), so any failure — permission denied, transient network error, throttling — is interpreted the same way as "image not found" and causes the script to proceed to publish. If the OIDC role gains push permission but is missing `ecr-public:DescribeImages`, the check is effectively bypassed on every run; publishing would succeed on new versions but produce a redundant push attempt on unchanged versions. Consider checking the exit code separately from error output so a non-404 failure can surface rather than silently proceeding.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: auto-publish model-engine helm chart..."](https://github.com/scaleapi/llm-engine/commit/261647cf3941c93ac332427e3831e0c3a676dd18) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46784898)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->