### PR TITLE
fix(cache): harden endpoint-info cache path against apiserver throttling

### DIFF
--- a/charts/model-engine/templates/cacher_deployment.yaml
+++ b/charts/model-engine/templates/cacher_deployment.yaml
@@ -61,6 +61,8 @@ spec:
             - python
             - -m
             - model_engine_server.entrypoints.k8s_cache
+            - --ttl-seconds
+            - {{ ((.Values.cacher).ttlSeconds | default 600) | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- include "modelEngine.cacherEnv" . | indent 10 }}

--- a/charts/model-engine/values_sample.yaml
+++ b/charts/model-engine/values_sample.yaml
@@ -89,6 +89,13 @@ destinationrule:
   enabled: true
   annotations: { }
 
+# cacher configures the kubernetes state caching deployment
+cacher:
+  # ttlSeconds is the redis TTL for cached endpoint infra state. It must comfortably exceed
+  # the cacher's worst-case refresh loop duration; entries expiring between refreshes push
+  # every reader to direct k8s reads.
+  ttlSeconds: 600
+
 # replicaCount specifies the amount of replica pods for each deployment
 replicaCount:
   # gateway is the main LLM Engine server deployment

--- a/model-engine/model_engine_server/domain/use_cases/async_inference_use_cases.py
+++ b/model-engine/model_engine_server/domain/use_cases/async_inference_use_cases.py
@@ -47,7 +47,7 @@ class CreateAsyncInferenceTaskV1UseCase:
         """
         # Task submission only needs the endpoint record; fetching the full endpoint would
         # also read infra state, whose k8s fallback on cache miss is too expensive for this
-        # hot path (fleet-wide apiserver throttling, 2026-08-04).
+        # hot path.
         record = await self.model_endpoint_service.get_model_endpoint_record(
             model_endpoint_id=model_endpoint_id
         )

--- a/model-engine/model_engine_server/domain/use_cases/async_inference_use_cases.py
+++ b/model-engine/model_engine_server/domain/use_cases/async_inference_use_cases.py
@@ -45,30 +45,31 @@ class CreateAsyncInferenceTaskV1UseCase:
             ObjectNotFoundException: If a model endpoint with the given ID could not be found.
             ObjectNotAuthorizedException: If the owner does not own the model endpoint.
         """
-        model_endpoint = await self.model_endpoint_service.get_model_endpoint(
+        # Task submission only needs the endpoint record; fetching the full endpoint would
+        # also read infra state, whose k8s fallback on cache miss is too expensive for this
+        # hot path (fleet-wide apiserver throttling, 2026-08-04).
+        record = await self.model_endpoint_service.get_model_endpoint_record(
             model_endpoint_id=model_endpoint_id
         )
-        if model_endpoint is None:
+        if record is None:
             raise ObjectNotFoundException
 
         if not self.authz_module.check_access_read_owned_entity(
-            user, model_endpoint.record
-        ) and not self.authz_module.check_endpoint_public_inference_for_user(
-            user, model_endpoint.record
-        ):
+            user, record
+        ) and not self.authz_module.check_endpoint_public_inference_for_user(user, record):
             raise ObjectNotAuthorizedException
 
-        if model_endpoint.record.endpoint_type != ModelEndpointType.ASYNC:
+        if record.endpoint_type != ModelEndpointType.ASYNC:
             raise EndpointUnsupportedInferenceTypeException(
                 f"Endpoint {model_endpoint_id} is not an async endpoint."
             )
 
-        task_name = model_endpoint.record.current_model_bundle.celery_task_name()
+        task_name = record.current_model_bundle.celery_task_name()
 
         inference_gateway = self.model_endpoint_service.get_async_model_endpoint_inference_gateway()
-        task_expires = model_endpoint.record.task_expires_seconds or DEFAULT_TASK_EXPIRES_SECONDS
+        task_expires = record.task_expires_seconds or DEFAULT_TASK_EXPIRES_SECONDS
         return await inference_gateway.create_task(
-            topic=model_endpoint.record.destination,
+            topic=record.destination,
             predict_request=request,
             task_expires_seconds=task_expires,
             task_name=task_name,

--- a/model-engine/model_engine_server/entrypoints/k8s_cache.py
+++ b/model-engine/model_engine_server/entrypoints/k8s_cache.py
@@ -160,14 +160,22 @@ async def main(args: Any):
         docker_repo = GenericDockerRepository()
     while True:
         loop_start = time.time()
-        await loop_iteration(
-            cache_repo,
-            k8s_resource_manager,
-            endpoint_record_repo,
-            image_cache_gateway,
-            docker_repo,
-            args.ttl_seconds,
-        )
+        # A failed iteration (e.g. the apiserver throttling with 429s) must not kill the
+        # process: a restart loses the in-flight refresh and lets cache entries expire,
+        # which pushes readers to direct k8s reads and adds more apiserver load.
+        loop_succeeded = True
+        try:
+            await loop_iteration(
+                cache_repo,
+                k8s_resource_manager,
+                endpoint_record_repo,
+                image_cache_gateway,
+                docker_repo,
+                args.ttl_seconds,
+            )
+        except Exception:
+            loop_succeeded = False
+            logger.exception("Cache write loop iteration failed; retrying after sleep")
         loop_end = time.time()
         loop_duration = loop_end - loop_start
         logger.info(f"Loop took {loop_duration} seconds")
@@ -179,14 +187,14 @@ async def main(args: Any):
             await asyncio.sleep(args.sleep_interval_seconds - loop_duration)
 
         # k8s health check
-        if not os.path.exists(READYZ_FPATH):
+        if loop_succeeded and not os.path.exists(READYZ_FPATH):
             with open(READYZ_FPATH, "w") as f:
                 f.write("READY")
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--ttl-seconds", type=int, default=60)
+    parser.add_argument("--ttl-seconds", type=int, default=600)
     parser.add_argument("--sleep-interval-seconds", type=int, default=15)
     parser.add_argument("--redis-url-override", type=str, default=None)
     main_args = parser.parse_args()

--- a/model-engine/model_engine_server/entrypoints/k8s_cache.py
+++ b/model-engine/model_engine_server/entrypoints/k8s_cache.py
@@ -176,6 +176,10 @@ async def main(args: Any):
         except Exception:
             loop_succeeded = False
             logger.exception("Cache write loop iteration failed; retrying after sleep")
+            # Drop readiness so persistent failures stay visible to k8s now that the
+            # process no longer exits on them.
+            if os.path.exists(READYZ_FPATH):
+                os.remove(READYZ_FPATH)
         loop_end = time.time()
         loop_duration = loop_end - loop_start
         logger.info(f"Loop took {loop_duration} seconds")

--- a/model-engine/model_engine_server/infra/gateways/resources/k8s_endpoint_resource_delegate.py
+++ b/model-engine/model_engine_server/infra/gateways/resources/k8s_endpoint_resource_delegate.py
@@ -1351,7 +1351,7 @@ class K8SEndpointResourceDelegate:
     ):
         k8s_core_api = get_kubernetes_core_client()
         config_maps = await k8s_core_api.list_namespaced_config_map(
-            namespace=hmi_config.endpoint_namespace
+            namespace=hmi_config.endpoint_namespace, resource_version="0"
         )
         return config_maps.items
 
@@ -2403,12 +2403,17 @@ class K8SEndpointResourceDelegate:
         apps_client = get_kubernetes_apps_client()
         autoscaling_client = get_kubernetes_autoscaling_client()
         custom_objects_client = get_kubernetes_custom_objects_client()
+        # resource_version="0" serves these full-namespace LISTs from the apiserver watch
+        # cache instead of quorum-reading etcd; freshness within one poll interval is enough
+        # for a cache that is rebuilt every loop.
         deployments = (
-            await apps_client.list_namespaced_deployment(namespace=hmi_config.endpoint_namespace)
+            await apps_client.list_namespaced_deployment(
+                namespace=hmi_config.endpoint_namespace, resource_version="0"
+            )
         ).items
         hpas = (
             await autoscaling_client.list_namespaced_horizontal_pod_autoscaler(
-                namespace=hmi_config.endpoint_namespace
+                namespace=hmi_config.endpoint_namespace, resource_version="0"
             )
         ).items
         try:
@@ -2418,6 +2423,7 @@ class K8SEndpointResourceDelegate:
                     version="v1",
                     namespace=hmi_config.endpoint_namespace,
                     plural="verticalpodautoscalers",
+                    resource_version="0",
                 )
             )["items"]
         except ApiException as e:
@@ -2432,6 +2438,7 @@ class K8SEndpointResourceDelegate:
                     version="v1alpha1",
                     namespace=hmi_config.endpoint_namespace,
                     plural="scaledobjects",
+                    resource_version="0",
                 )
             )["items"]
         except ApiException as e:
@@ -2447,6 +2454,7 @@ class K8SEndpointResourceDelegate:
                     version="v1",
                     namespace=hmi_config.endpoint_namespace,
                     plural="leaderworkersets",
+                    resource_version="0",
                 )
             )["items"]
         except ApiException as e:

--- a/model-engine/model_engine_server/infra/services/live_model_endpoint_service.py
+++ b/model-engine/model_engine_server/infra/services/live_model_endpoint_service.py
@@ -134,7 +134,18 @@ class LiveModelEndpointService(ModelEndpointService):
             if inflight is None:
                 inflight = asyncio.create_task(self._read_and_cache_infra_state(record=record))
                 _infra_state_inflight[record.id] = inflight
-                inflight.add_done_callback(lambda _task: _infra_state_inflight.pop(record.id, None))
+
+                def _cleanup(task: "asyncio.Task", endpoint_id: str = record.id) -> None:
+                    _infra_state_inflight.pop(endpoint_id, None)
+                    # Retrieve the exception in case every awaiter was cancelled before
+                    # consuming it, so the shared task never logs as unretrieved.
+                    if not task.cancelled() and task.exception() is not None:
+                        logger.warning(
+                            f"Coalesced infra state read for {endpoint_id} failed: "
+                            f"{task.exception()!r}"
+                        )
+
+                inflight.add_done_callback(_cleanup)
             # shield so one awaiter's cancellation (e.g. client disconnect) doesn't cancel
             # the shared fetch for the others
             state = await asyncio.shield(inflight)

--- a/model-engine/model_engine_server/infra/services/live_model_endpoint_service.py
+++ b/model-engine/model_engine_server/infra/services/live_model_endpoint_service.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any, Dict, List, Optional
 
 from datadog import statsd
@@ -42,6 +43,11 @@ logger = make_logger(logger_name())
 
 STATSD_CACHE_HIT_NAME = "launch.get_infra_state.cache_hit"
 STATSD_CACHE_MISS_NAME = "launch.get_infra_state.cache_miss"
+
+# Coalesces concurrent cache-miss reads of the same endpoint's infra state into a single
+# k8s fetch per process. The service is constructed per-request, so this must live at
+# module scope to be shared across requests.
+_infra_state_inflight: Dict[str, "asyncio.Task[Optional[ModelEndpointInfraState]]"] = {}
 
 
 class LiveModelEndpointService(ModelEndpointService):
@@ -124,13 +130,26 @@ class LiveModelEndpointService(ModelEndpointService):
             else:
                 statsd.increment(STATSD_CACHE_HIT_NAME, 1, tags=tags)
         if state is None:
-            state = await self.model_endpoint_infra_gateway.get_model_endpoint_infra(
-                model_endpoint_record=record
+            inflight = _infra_state_inflight.get(record.id)
+            if inflight is None:
+                inflight = asyncio.create_task(self._read_and_cache_infra_state(record=record))
+                _infra_state_inflight[record.id] = inflight
+                inflight.add_done_callback(lambda _task: _infra_state_inflight.pop(record.id, None))
+            # shield so one awaiter's cancellation (e.g. client disconnect) doesn't cancel
+            # the shared fetch for the others
+            state = await asyncio.shield(inflight)
+        return state
+
+    async def _read_and_cache_infra_state(
+        self, record: ModelEndpointRecord
+    ) -> Optional[ModelEndpointInfraState]:
+        state = await self.model_endpoint_infra_gateway.get_model_endpoint_infra(
+            model_endpoint_record=record
+        )
+        if state is not None:
+            await self.model_endpoint_cache_repository.write_endpoint_info(
+                endpoint_id=record.id, endpoint_info=state, ttl_seconds=180
             )
-            if state is not None:
-                await self.model_endpoint_cache_repository.write_endpoint_info(
-                    endpoint_id=record.id, endpoint_info=state, ttl_seconds=180
-                )
         return state
 
     async def create_model_endpoint(

--- a/model-engine/model_engine_server/infra/services/model_endpoint_cache_service.py
+++ b/model-engine/model_engine_server/infra/services/model_endpoint_cache_service.py
@@ -1,5 +1,6 @@
 from typing import Dict, Tuple
 
+from model_engine_server.core.loggers import logger_name, make_logger
 from model_engine_server.domain.entities import ModelEndpointInfraState
 from model_engine_server.infra.gateways.resources.endpoint_resource_gateway import (
     EndpointResourceGateway,
@@ -8,6 +9,8 @@ from model_engine_server.infra.repositories.model_endpoint_cache_repository impo
     ModelEndpointCacheRepository,
 )
 from model_engine_server.infra.services.image_cache_service import ImageCacheService
+
+logger = make_logger(logger_name())
 
 
 class ModelEndpointCacheWriteService:
@@ -43,4 +46,10 @@ class ModelEndpointCacheWriteService:
                     endpoint_id="", endpoint_info=state, ttl_seconds=ttl_seconds
                 )
 
-        await self.image_cache_service.execute(endpoint_infra_states=endpoint_infra_states)
+        # Image caching is a spinup optimization; its k8s writes (daemonset create/update)
+        # must not fail the endpoint cache refresh above, which readers depend on to stay
+        # off the apiserver.
+        try:
+            await self.image_cache_service.execute(endpoint_infra_states=endpoint_infra_states)
+        except Exception:
+            logger.exception("Image cache update failed; endpoint cache was still refreshed")

--- a/model-engine/tests/unit/infra/services/test_live_model_endpoint_service.py
+++ b/model-engine/tests/unit/infra/services/test_live_model_endpoint_service.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -181,6 +182,40 @@ async def test_get_model_endpoint_returns_none(
         model_endpoint_id="invalid_model_endpoint_id"
     )
     assert model_endpoint is None
+
+
+@pytest.mark.asyncio
+async def test_get_model_endpoint_coalesces_concurrent_infra_reads(
+    fake_live_model_endpoint_service: LiveModelEndpointService,
+    model_endpoint_1: ModelEndpoint,
+):
+    model_endpoint_record = await _create_model_endpoint_helper(
+        model_endpoint=model_endpoint_1, service=fake_live_model_endpoint_service
+    )
+
+    infra_gateway = fake_live_model_endpoint_service.model_endpoint_infra_gateway
+    real_get_model_endpoint_infra = infra_gateway.get_model_endpoint_infra
+    call_count = 0
+
+    async def slow_get_model_endpoint_infra(model_endpoint_record):
+        nonlocal call_count
+        call_count += 1
+        # Keep the fetch in flight long enough for the concurrent readers to pile up on it.
+        await asyncio.sleep(0.05)
+        return await real_get_model_endpoint_infra(model_endpoint_record=model_endpoint_record)
+
+    infra_gateway.get_model_endpoint_infra = slow_get_model_endpoint_infra
+
+    model_endpoints = await asyncio.gather(
+        *(
+            fake_live_model_endpoint_service.get_model_endpoint(
+                model_endpoint_id=model_endpoint_record.id
+            )
+            for _ in range(5)
+        )
+    )
+    assert all(model_endpoint is not None for model_endpoint in model_endpoints)
+    assert call_count == 1
 
 
 @pytest.mark.asyncio

--- a/model-engine/tests/unit/infra/services/test_model_endpoint_cache_service.py
+++ b/model-engine/tests/unit/infra/services/test_model_endpoint_cache_service.py
@@ -64,3 +64,30 @@ async def test_model_endpoint_write_success(
         deployment_name=model_endpoint_1.infra_state.deployment_name,
     )
     assert infra_state is None
+
+
+@pytest.mark.asyncio
+async def test_model_endpoint_write_survives_image_cache_failure(
+    fake_model_endpoint_cache_repository,
+    fake_resource_gateway,
+    fake_image_cache_service,
+    model_endpoint_1,
+):
+    fake_resource_gateway.add_resource(
+        endpoint_id=model_endpoint_1.record.id, infra_state=model_endpoint_1.infra_state
+    )
+
+    async def raise_api_error(endpoint_infra_states):
+        raise RuntimeError("simulated k8s failure (e.g. 429)")
+
+    fake_image_cache_service.execute = raise_api_error
+
+    cache_write_service = ModelEndpointCacheWriteService(
+        fake_model_endpoint_cache_repository, fake_resource_gateway, fake_image_cache_service
+    )
+    await cache_write_service.execute(42)
+    infra_state = await fake_model_endpoint_cache_repository.read_endpoint_info(
+        endpoint_id=model_endpoint_1.record.id,
+        deployment_name=model_endpoint_1.infra_state.deployment_name,
+    )
+    assert infra_state == model_endpoint_1.infra_state


### PR DESCRIPTION
## Context

During the 2026-08-04 incident, high async-task volume to one endpoint combined with an endpoint-info cache TTL (60s) shorter than the cacher's refresh loop (~110s under throttling) pushed every gateway replica to per-request label-selector configmap LISTs. This saturated the ml-serving-new apiserver read pool (APF 429s cluster-wide), and a 429 on the image-cache daemonset write crash-looped the cacher (257 restarts), further degrading refresh cadence. Interim mitigation was a live `--ttl-seconds 600` patch on the prod cacher deployment; this PR makes it durable and removes the underlying failure modes.

## Changes

- **Async task submission reads only the endpoint record.** `CreateAsyncInferenceTaskV1UseCase` used `get_model_endpoint()` but consumed only `record.*` fields; the infra-state fetch (and its k8s fallback on cache miss) is removed from the hot path.
- **Singleflight on the cache-miss fallback.** Concurrent misses for the same endpoint coalesce into a single k8s fetch per process (module-level registry; services are constructed per-request). `asyncio.shield` keeps one awaiter's cancellation from cancelling the shared fetch.
- **Cacher crash containment.** A failed loop iteration logs and retries after the sleep interval instead of killing the process; readiness is only advertised after a successful loop.
- **Image-cache step is non-fatal.** Its k8s writes can no longer fail the endpoint cache refresh readers depend on.
- **TTL default 600s** (argparse and chart), exposed as `cacher.ttlSeconds`; nil-safe for values files without the block.
- **`resource_version="0"` on the cacher's five bulk LISTs** — served from the apiserver watch cache instead of quorum etcd reads.

## Verification

- Full unit suite: 785 passed, 17 skipped (CI-exact env)
- black / isort / ruff / mypy: clean
- New tests: cache refresh survives image-cache failure; 5 concurrent reads coalesce to one fetch
- Standalone stress battery (not committed): 2,000 concurrent readers → 1 fetch; per-endpoint isolation across 100 endpoints; awaiter cancellation (partial and total) never cancels the shared fetch; exceptions propagate to all coalesced callers and the next call retries; randomized churn (3,000 ops with cancellations) leaves no registry leaks
- Local k3s e2e with a sanitized copy of the incident endpoint's deployment+configmaps: rv=0 LISTs parse it correctly; redis entries written with TTL 600 and refreshed each loop; a failing image-cache step no longer kills the process; a full redis outage mid-run is caught by the loop containment and writes resume when redis returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens endpoint caching against Kubernetes API throttling and removes unnecessary infrastructure reads from async task submission.
- Coalesces concurrent endpoint cache misses into one shielded Kubernetes fetch per endpoint and process.
- Contains cacher-loop and image-cache failures so endpoint cache refreshes can recover.
- Raises the default cache TTL to 600 seconds and exposes it through Helm values.
- Requests bulk Kubernetes resources from the API server watch cache with `resource_version="0"`.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| model-engine/model_engine_server/domain/use_cases/async_inference_use_cases.py | Async task creation now reads only the endpoint record while retaining the existing authorization, endpoint-type, routing, and expiration behavior. |
| model-engine/model_engine_server/infra/services/live_model_endpoint_service.py | Adds per-process, per-endpoint singleflight handling for cache-miss Kubernetes reads, including cancellation shielding and completion cleanup. |
| model-engine/model_engine_server/entrypoints/k8s_cache.py | Contains refresh-loop failures, ties readiness to successful iterations, and changes the command-line TTL default to 600 seconds. |
| model-engine/model_engine_server/infra/services/model_endpoint_cache_service.py | Makes image-cache updates non-fatal after endpoint cache entries have been refreshed. |
| model-engine/model_engine_server/infra/gateways/resources/k8s_endpoint_resource_delegate.py | Adds resource version zero to the cacher’s bulk Kubernetes LIST operations so they can be served from the API server watch cache. |
| charts/model-engine/templates/cacher_deployment.yaml | Passes the nil-safe Helm-configured cache TTL to the cacher process. |
| charts/model-engine/values_sample.yaml | Documents and supplies the new 600-second cacher TTL value. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Async task submission] --> B[Read endpoint record]
    B --> C[Authorize and validate async type]
    C --> D[Create inference task]

    E[Endpoint infra reader] --> F{Redis cache hit?}
    F -->|Yes| G[Return cached infra state]
    F -->|No| H{Fetch already in flight?}
    H -->|Yes| I[Await shielded shared task]
    H -->|No| J[Create Kubernetes fetch task]
    J --> K[Read infra and populate Redis]
    K --> I

    L[Cacher loop] --> M[Bulk Kubernetes LIST with resourceVersion 0]
    M --> N[Refresh endpoint cache with 600s TTL]
    N --> O[Attempt non-fatal image-cache update]
    O --> P{Iteration succeeded?}
    P -->|Yes| Q[Advertise readiness]
    P -->|No| R[Log, remove readiness, and retry after sleep]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(cache): address review findings on c..."](https://github.com/scaleapi/llm-engine/commit/8b765e7087e09913e91353f5c4536330519169c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50224874)</sub>

<!-- /greptile_comment -->