### PR TITLE
fix(chart): reap failed db-init hook Jobs with a TTL

### DIFF
--- a/charts/model-engine/templates/database_init_job.yaml
+++ b/charts/model-engine/templates/database_init_job.yaml
@@ -10,6 +10,10 @@ metadata:
     "helm.sh/hook-weight": "-2"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
+  # before-hook-creation only clears a same-named Job and hook-succeeded only fires
+  # on success, so with the Release.Revision suffix a failed hook from an earlier
+  # revision is never cleaned up by either — hence the TTL.
+  ttlSecondsAfterFinished: 3600
   backoffLimit: 0
   activeDeadlineSeconds: 600
   template:


### PR DESCRIPTION
The Job name embeds .Release.Revision, so every attempt gets a unique name. before-hook-creation only deletes a same-named object, so it never reaches an earlier revision's leftover, and hook-succeeded only fires on success — a failed hook Job therefore persists indefinitely, one per revision.

On a cold start where the hook fails a few times before the database is reachable, these pile up and have to be deleted by hand before the release can be recovered. ttlSecondsAfterFinished reaps them an hour after they finish, which still leaves the logs readable for debugging.

# Pull Request Summary

_What is this PR changing? Why is this change being made? Any caveats you'd like to highlight? Link any relevant documents, links, or screenshots here if applicable._

## Test Plan and Usage Guide

_How did you validate that your PR works correctly? How do you run or demo the code? Provide enough detail so a reviewer can reasonably reproduce the testing procedure. Paste example command line invocations if applicable._

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a one-hour Kubernetes TTL to completed database-initialization hook Jobs so failed Jobs from earlier Helm revisions are eventually removed while retaining logs temporarily.

- Configures `ttlSecondsAfterFinished: 3600` on the database initialization Job.
- Documents why Helm's existing hook deletion policies do not clean up failed, revision-suffixed Jobs.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable issues identified.

The added TTL applies only after a Job finishes, preserves the failed Job and its logs for one hour, and is supported by the Kubernetes version exercised by repository CI.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| charts/model-engine/templates/database_init_job.yaml | Adds a supported Job TTL that addresses accumulation of failed Helm hook Jobs without changing execution behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(chart): reap failed db-init hook Job..."](https://github.com/scaleapi/llm-engine/commit/814eae50a602a932837cfd184f59e14a2155c019) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51274764)</sub>

<!-- /greptile_comment -->