### PR TITLE
fix(vllm): preserve response format schema when forwarding

### DIFF
--- a/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
+++ b/model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py
@@ -195,6 +195,11 @@ VLLM_MANAGED_COMMAND_FIELDS = {
 }
 
 
+def _dump_chat_completion_request(request: ChatCompletionV2Request) -> Dict[str, Any]:
+    """Serialize a chat request using the OpenAI wire-format field names."""
+    return request.model_dump(exclude_none=True, by_alias=True)
+
+
 def is_vllm_inference_framework(
     inference_framework: Optional[Union[LLMInferenceFramework, str]],
 ) -> bool:
@@ -3740,7 +3745,7 @@ class ChatCompletionSyncV2UseCase:
             request.model = VLLM_MODEL_WEIGHTS_FOLDER
 
         inference_request = SyncEndpointPredictV1Request(
-            args=request.model_dump(exclude_none=True),
+            args=_dump_chat_completion_request(request),
             destination_path=OPENAI_CHAT_COMPLETION_PATH,
             num_retries=NUM_DOWNSTREAM_REQUEST_RETRIES,
             timeout_seconds=DOWNSTREAM_REQUEST_TIMEOUT_SECONDS,
@@ -3856,7 +3861,7 @@ class ChatCompletionStreamV2UseCase:
             request.model = VLLM_MODEL_WEIGHTS_FOLDER
 
         inference_request = SyncEndpointPredictV1Request(
-            args=request.model_dump(exclude_none=True),
+            args=_dump_chat_completion_request(request),
             destination_path=OPENAI_CHAT_COMPLETION_PATH,
             num_retries=NUM_DOWNSTREAM_REQUEST_RETRIES,
             timeout_seconds=DOWNSTREAM_REQUEST_TIMEOUT_SECONDS,

--- a/model-engine/tests/unit/domain/test_llm_use_cases.py
+++ b/model-engine/tests/unit/domain/test_llm_use_cases.py
@@ -9,6 +9,7 @@ import model_engine_server.domain.use_cases.llm_model_endpoint_use_cases as llm_
 import pytest
 from model_engine_server.common.dtos.batch_jobs import CreateDockerImageBatchJobResourceRequests
 from model_engine_server.common.dtos.llms import (
+    ChatCompletionV2Request,
     CompletionOutput,
     CompletionStreamV1Request,
     CompletionSyncV1Request,
@@ -98,6 +99,34 @@ def mocked__get_latest_tag():
         return "fake_docker_repository_latest_image_tag"
 
     return mock.AsyncMock(side_effect=async_mock)
+
+
+def test_dump_chat_completion_request_preserves_json_schema_wire_format():
+    schema = {
+        "type": "object",
+        "properties": {"value": {"type": "string"}},
+        "required": ["value"],
+        "additionalProperties": False,
+    }
+    request = ChatCompletionV2Request.model_validate(
+        {
+            "model": "structured-output-model",
+            "messages": [{"role": "user", "content": "Return a value"}],
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "structured_response",
+                    "schema": schema,
+                    "strict": True,
+                },
+            },
+        }
+    )
+
+    dumped = llm_use_cases._dump_chat_completion_request(request)
+
+    assert dumped["response_format"]["json_schema"]["schema"] == schema
+    assert "schema_" not in dumped["response_format"]["json_schema"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Pull Request Summary

Fixes structured output forwarding for OpenAI-compatible chat completions.

`response_format.json_schema.schema` was parsed internally as `schema_` and forwarded without restoring its wire alias. vLLM therefore received no schema and rejected the request with `StructuredOutputsParams(json=None, ...)`.

This change serializes sync and streaming chat-completion requests using Pydantic aliases, preserving schema correctly.

## Test Plan and Usage Guide

The regression test verifies that response_format.json_schema.schema reaches the downstream vLLM request as schema, never schema_.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes structured-output forwarding for synchronous and streaming OpenAI-compatible chat completions.
- Serializes chat-completion requests using Pydantic wire aliases so `response_format.json_schema.schema` is preserved.
- Reuses the serialization helper in both forwarding paths.
- Adds a regression test for the downstream schema key.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The alias-aware serialization changes only the intended nested JSON Schema key, and both chat-completion forwarding paths consistently use the corrected payload.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| model-engine/model_engine_server/domain/use_cases/llm_model_endpoint_use_cases.py | Adds alias-aware chat-request serialization and applies it consistently to synchronous and streaming forwarding. |
| model-engine/tests/unit/domain/test_llm_use_cases.py | Adds focused regression coverage confirming that JSON Schema is emitted under its OpenAI wire-format key. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: preserve response format schema whe..."](https://github.com/scaleapi/llm-engine/commit/1e4d6e4eba003274ab5cb7bfab0811f61f68d2c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51625623)</sub>

<!-- /greptile_comment -->