### PR TITLE
fix(k8s): JSON-encode bare-rendered command/env lists in load_k8s_yaml

### DIFF
--- a/model-engine/model_engine_server/infra/gateways/resources/k8s_endpoint_resource_delegate.py
+++ b/model-engine/model_engine_server/infra/gateways/resources/k8s_endpoint_resource_delegate.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import os
 import re
 from string import Template
@@ -282,6 +283,11 @@ def load_k8s_yaml(key: str, substitution_kwargs: ResourceArguments) -> Dict[str,
     # so any ${DD_ENV} in labels / env vars / log configs resolves to the gateway's
     # per-cluster env (set via the chart's datadog.env). setdefault lets a caller override.
     filtered_kwargs.setdefault("DD_ENV", DD_ENV)
+    # These render bare into the template (`command: ${COMMAND}`, `env: ${MAIN_ENV}`), where
+    # str()'s Python repr escapes quotes as \' and breaks YAML; JSON is a valid YAML subset.
+    for structured_key in ("COMMAND", "WORKER_COMMAND", "MAIN_ENV", "WORKER_ENV"):
+        if isinstance(filtered_kwargs.get(structured_key), list):
+            filtered_kwargs[structured_key] = json.dumps(filtered_kwargs[structured_key])
     yaml_str = Template(template_str).safe_substitute(**filtered_kwargs)
     try:
         yaml_obj = yaml.safe_load(yaml_str)

--- a/model-engine/tests/unit/infra/gateways/resources/test_k8s_endpoint_resource_delegate.py
+++ b/model-engine/tests/unit/infra/gateways/resources/test_k8s_endpoint_resource_delegate.py
@@ -3,7 +3,7 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
 
 import pytest
@@ -1510,3 +1510,26 @@ def test_add_pod_metadata_env_to_container():
 
     node_name_env = next(e for e in container["env"] if e["name"] == "NODE_NAME")
     assert node_name_env["valueFrom"]["fieldRef"]["fieldPath"] == "spec.nodeName"
+
+
+def test_load_k8s_yaml_command_with_mixed_quotes_renders_valid_yaml(tmp_path):
+    # Regression: a command mixing single-quoted (model-cache `find '*.safetensors'`)
+    # and double-quoted (vLLM `--host "::"`) tokens must round-trip through
+    # load_k8s_yaml instead of raising ScannerError from str()-coerced YAML.
+    command = [
+        "/bin/bash",
+        "-c",
+        "find /mnt/model-cache/model_files -maxdepth 1 -type f "
+        r"\( -name '*.safetensors' -o -name '*.bin' \) | head; "
+        'python -m vllm_server --model /mnt/model-cache/model_files --host "::"',
+    ]
+    config_map_path = tmp_path / "config_map.yaml"
+    config_map_path.write_text(json.dumps({"data": {"command-only.yaml": "command: ${COMMAND}\n"}}))
+
+    with (
+        patch(f"{MODULE_PATH}.LAUNCH_SERVICE_TEMPLATE_FOLDER", None),
+        patch(f"{MODULE_PATH}.LAUNCH_SERVICE_TEMPLATE_CONFIG_MAP_PATH", str(config_map_path)),
+    ):
+        rendered = load_k8s_yaml("command-only.yaml", cast(ResourceArguments, {"COMMAND": command}))
+
+    assert rendered["command"] == command


### PR DESCRIPTION
## Summary

`load_k8s_yaml` builds each k8s manifest by running `string.Template(...).safe_substitute(**kwargs)` over a YAML text template. `string.Template` coerces every value with `str()`, so a list/dict kwarg renders as a Python repr. When such a value contains a string with both single and double quotes, the repr escapes the single quotes as `\'`, which is not valid YAML (YAML escapes a single quote by doubling it, `''`). The quoted scalar terminates early, the following `*` is scanned as a YAML alias, and `yaml.safe_load` raises `yaml.scanner.ScannerError: while scanning an alias`.

Four substitution kwargs are rendered bare into the deployment templates and are exposed to this: `COMMAND`, `WORKER_COMMAND` (`command: ${COMMAND}`) and `MAIN_ENV`, `WORKER_ENV` (`env: ${MAIN_ENV}`).

The concrete trigger: enabling the model cache emits a lock command that hardcodes `find ... -name '*.safetensors' -o -name '*.bin'` (single quotes) in the same script as vLLM's `--host "::"` (double quotes), so `build_endpoint` raises `ScannerError` and no Deployment is ever created (the model-cache PVC is created first, then the task dies). Env values are user controlled via `flavor.env`, so `MAIN_ENV`/`WORKER_ENV` are reachable the same way.

## Fix

JSON-encode these four bare-rendered kwargs before substitution. JSON is a subset of YAML, renders as a valid flow sequence/mapping, and round-trips the exact argv/env. `FORWARDER_SYNC_ROUTES`/`FORWARDER_STREAM_ROUTES` are intentionally left untouched: they render inside a double-quoted YAML string and are parsed downstream via `ast.literal_eval`, so they must keep Python-repr formatting.

Adds a unit test that renders a command mixing `'...'` and `"::"` through `load_k8s_yaml` and asserts it round-trips instead of raising.

The deeper fix is to stop string-templating YAML and substitute into a parsed structure, but that is a large refactor of this module; this is the surgical patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Kubernetes manifest rendering by JSON-encoding list-valued command and environment substitutions before YAML parsing.
- Encodes `COMMAND`, `WORKER_COMMAND`, `MAIN_ENV`, and `WORKER_ENV` as YAML-compatible JSON flow collections.
- Adds a regression test proving commands containing mixed single and double quotes round-trip without a YAML scanner error.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The affected arguments are constructed as JSON-serializable lists, all repository template occurrences use compatible bare YAML contexts, and the regression test verifies exact command round-tripping.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| model-engine/model_engine_server/infra/gateways/resources/k8s_endpoint_resource_delegate.py | Safely serializes the four list-valued placeholders that are rendered directly into Kubernetes command and environment fields. |
| model-engine/tests/unit/infra/gateways/resources/test_k8s_endpoint_resource_delegate.py | Adds focused regression coverage for the mixed-quote command that previously produced invalid YAML. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(k8s): JSON-encode bare-rendered comm..."](https://github.com/scaleapi/llm-engine/commit/fbac73d5ea591dd5e44ca9124d49c02ed111672e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51873788)</sub>

<!-- /greptile_comment -->