### PR TITLE
[MLI-8206] Set an explicit, configurable timeout on the sync forwarder

### DIFF
--- a/model-engine/model_engine_server/inference/forwarding/forwarding.py
+++ b/model-engine/model_engine_server/inference/forwarding/forwarding.py
@@ -42,6 +42,8 @@ ENV_SERIALIZE_RESULTS_AS_STRING: str = "SERIALIZE_RESULTS_AS_STRING"
 
 DEFAULT_PORT: int = 5005
 
+DEFAULT_SYNC_TIMEOUT_SECONDS: float = 3600
+
 
 class ModelEngineSerializationMixin:
     """Mixin class for optionally wrapping Model Engine requests."""
@@ -169,6 +171,10 @@ class Forwarder(ModelEngineSerializationMixin):
     # We do this to avoid having to put this data in any sync response and only do it for async responses
     forward_http_status_in_body: bool
     post_inference_hooks_handler: Optional[PostInferenceHooksHandler] = None
+    # Cap on the full round-trip to the user-defined service. Must be explicit: without
+    # one, aiohttp applies its default total=300s and long-running non-streaming
+    # generations get cut off with a 500 while the model server keeps computing.
+    timeout_seconds: float = DEFAULT_SYNC_TIMEOUT_SECONDS
 
     async def forward(self, json_payload: Any, trace_config: Optional[str] = None) -> Any:
         json_payload, using_serialize_results_as_string = self.unwrap_json_payload(json_payload)
@@ -185,6 +191,7 @@ class Forwarder(ModelEngineSerializationMixin):
                     self.predict_endpoint,
                     json=json_payload,
                     headers=headers,
+                    timeout=aiohttp.ClientTimeout(total=self.timeout_seconds),
                 )
                 response = await response_raw.json(
                     content_type=None
@@ -297,6 +304,7 @@ class LoadForwarder:
     wrap_response: bool = True
     forward_http_status: bool = False
     forward_http_status_in_body: bool = False
+    timeout_seconds: float = DEFAULT_SYNC_TIMEOUT_SECONDS
 
     def load(self, resources: Optional[Path], cache: Any) -> Forwarder:
         if self.use_grpc:
@@ -405,6 +413,7 @@ class LoadForwarder:
             wrap_response=self.wrap_response,
             forward_http_status=self.forward_http_status,
             forward_http_status_in_body=self.forward_http_status_in_body,
+            timeout_seconds=self.timeout_seconds,
         )
 
 

--- a/model-engine/model_engine_server/inference/forwarding/forwarding.py
+++ b/model-engine/model_engine_server/inference/forwarding/forwarding.py
@@ -1,5 +1,6 @@
 import ast
 import json
+import math
 import os
 import time
 from dataclasses import dataclass
@@ -307,6 +308,14 @@ class LoadForwarder:
     timeout_seconds: float = DEFAULT_SYNC_TIMEOUT_SECONDS
 
     def load(self, resources: Optional[Path], cache: Any) -> Forwarder:
+        if (
+            not isinstance(self.timeout_seconds, (int, float))
+            or isinstance(self.timeout_seconds, bool)
+            or not math.isfinite(self.timeout_seconds)
+            or self.timeout_seconds <= 0
+        ):
+            raise ValueError(f"timeout_seconds must be a positive number: {self.timeout_seconds=}")
+
         if self.use_grpc:
             raise NotImplementedError(
                 "User-defined service **MUST** use HTTP at the moment. "

--- a/model-engine/tests/unit/inference/test_forwarding.py
+++ b/model-engine/tests/unit/inference/test_forwarding.py
@@ -499,6 +499,22 @@ def test_forwarder_loader_timeout(loader_kwargs, expected_timeout):
     assert fwd.timeout_seconds == expected_timeout
 
 
+@pytest.mark.parametrize(
+    "invalid_timeout",
+    [
+        pytest.param(0, id="zero"),
+        pytest.param(-1, id="negative"),
+        pytest.param(None, id="null"),
+        pytest.param(float("inf"), id="non-finite"),
+        pytest.param("60", id="string"),
+        pytest.param(True, id="bool"),
+    ],
+)
+def test_forwarder_loader_invalid_timeout(invalid_timeout):
+    with pytest.raises(ValueError, match="timeout_seconds"):
+        LoadForwarder(timeout_seconds=invalid_timeout).load(None, None)  # type: ignore
+
+
 @mock.patch("requests.post", mocked_post)
 @mock.patch("requests.get", mocked_get)
 @mock.patch(

--- a/model-engine/tests/unit/inference/test_forwarding.py
+++ b/model-engine/tests/unit/inference/test_forwarding.py
@@ -10,6 +10,7 @@ from fastapi.responses import JSONResponse
 from model_engine_server.core.utils.env import environment
 from model_engine_server.domain.entities import ModelEndpointConfig
 from model_engine_server.inference.forwarding.forwarding import (
+    DEFAULT_SYNC_TIMEOUT_SECONDS,
     ENV_SERIALIZE_RESULTS_AS_STRING,
     KEY_SERIALIZE_RESULTS_AS_STRING,
     Forwarder,
@@ -478,6 +479,24 @@ def test_forwarder_loader():
     fwd = LoadForwarder(wrap_response=False).load(None, None)  # type: ignore
     json_response = fwd({"ignore": "me"})
     _check_responses_not_wrapped(json_response)
+
+
+@mock.patch("requests.post", mocked_post)
+@mock.patch("requests.get", mocked_get)
+@mock.patch(
+    "model_engine_server.inference.forwarding.forwarding.get_endpoint_config",
+    mocked_get_endpoint_config,
+)
+@pytest.mark.parametrize(
+    "loader_kwargs, expected_timeout",
+    [
+        pytest.param({}, DEFAULT_SYNC_TIMEOUT_SECONDS, id="default"),
+        pytest.param({"timeout_seconds": 123.0}, 123.0, id="override"),
+    ],
+)
+def test_forwarder_loader_timeout(loader_kwargs, expected_timeout):
+    fwd = LoadForwarder(**loader_kwargs).load(None, None)  # type: ignore
+    assert fwd.timeout_seconds == expected_timeout
 
 
 @mock.patch("requests.post", mocked_post)


### PR DESCRIPTION
## Problem

The sync http-forwarder posts to the local inference server without an explicit aiohttp timeout, so aiohttp's client default of `total=300s` applies. Non-streaming generations that take longer than 5 minutes are cut off with a 500 (`TimeoutError` in `forwarding.py:forward`) while the inference server keeps computing the response. Observed on the `qwen3-5-9b` model-zoo endpoint ([MLI-8206](https://linear.app/scale-epd/issue/MLI-8206)).

## Change

- Add a `timeout_seconds` field to `Forwarder` and `LoadForwarder`, passed as `aiohttp.ClientTimeout(total=...)` on the forward request.
- Default is 3600s, overridable per deployment via the existing forwarder config path (`forwarder.sync.timeout_seconds`).
- The sync `__call__` path (requests-based) and the streaming forwarder are unchanged.

## Testing

- New parametrized unit test covers the default and an override propagating through `LoadForwarder.load`.
- `tests/unit/inference`: 53 passed, 2 skipped locally.
- black / isort / ruff / mypy clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a configurable one-hour default timeout to asynchronous non-streaming forward requests and validates overrides during forwarder loading.
- Passes the configured timeout to `aiohttp.ClientTimeout`.
- Rejects nonnumeric, Boolean, non-finite, zero, and negative timeout values at startup.
- Tests default and overridden propagation plus invalid configurations.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| model-engine/model_engine_server/inference/forwarding/forwarding.py | Adds and validates the configurable sync-forwarding timeout before applying it to asynchronous HTTP requests. |
| model-engine/tests/unit/inference/test_forwarding.py | Covers default and overridden timeout propagation and rejects representative invalid values. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Validate timeout\_seconds at forwarder lo..."](https://github.com/scaleapi/llm-engine/commit/42369c934e4f3f39d7c8853d8dbe5aa8c47edf48) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53143866)</sub>

<!-- /greptile_comment -->