### PR TITLE
Gateway: async healthcheck handler and explicit readiness probe timeout

### DIFF
--- a/charts/model-engine/templates/gateway_deployment.yaml
+++ b/charts/model-engine/templates/gateway_deployment.yaml
@@ -60,6 +60,7 @@ spec:
               path: /readyz
               port: 5000
             periodSeconds: 2
+            timeoutSeconds: {{ ((.Values.gateway).readinessProbeTimeoutSeconds | default 5) }}
             failureThreshold: 30
           command: 
             - dumb-init

--- a/charts/model-engine/values.yaml
+++ b/charts/model-engine/values.yaml
@@ -33,6 +33,12 @@ celery_broker_type_redis: null
 #     drop:
 #       - ALL
 
+# gateway [optional] tuning for the gateway deployment.
+gateway:
+  # readinessProbeTimeoutSeconds sets the /readyz probe timeout. The k8s default of 1s
+  # ejects saturated-but-healthy pods and concentrates load on the survivors.
+  readinessProbeTimeoutSeconds: 5
+
 redis:
   auth:
   authSecretName: ""

--- a/model-engine/model_engine_server/api/app.py
+++ b/model-engine/model_engine_server/api/app.py
@@ -313,8 +313,13 @@ def load_redis():
     get_or_create_aioredis_pool()
 
 
-def healthcheck() -> Response:
-    """Returns 200 if the app is healthy."""
+async def healthcheck() -> Response:
+    """Returns 200 if the app is healthy.
+
+    Must be async: a sync handler runs in the shared threadpool, so under load the
+    probe queues behind blocked requests and misses its timeout, ejecting pods that
+    are saturated but healthy.
+    """
     return Response(status_code=200)
 
 


### PR DESCRIPTION
## What

- `healthcheck` (serving `/healthcheck`, `/healthz`, `/readyz`) is now `async def`. As a sync handler it was dispatched to the shared anyio threadpool, so under load the readiness probe queued behind blocked requests and timed out while the app container was healthy.
- The gateway `readinessProbe` now sets an explicit `timeoutSeconds` (default 5, configurable via `gateway.readinessProbeTimeoutSeconds`). Previously unset, which means the Kubernetes default of 1s.

## Why

During the 2026-08-13 gateway incident, saturated but healthy pods failed the 1s probe and were ejected from the Service, concentrating load on the remaining pods (11 of 60 Ready at the worst point while ~40 app containers were healthy). The two changes remove that ejection mechanism: the probe no longer competes with request handling for threadpool slots, and the timeout tolerates transient event-loop delay.

## Notes

- No livenessProbe is added. Restarting a saturated pod discards its in-flight work and worsens overload; readiness gating plus the existing container restart policy remain the failure handling.
- Rendered chart verified: probe emits `timeoutSeconds: 5` with default values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves the gateway health endpoints onto the async request path and gives Kubernetes readiness probes a configurable five-second timeout.

- Converts the shared `/healthcheck`, `/healthz`, and `/readyz` handler to `async def`.
- Adds `gateway.readinessProbeTimeoutSeconds` to the Helm values.
- Renders the configured timeout into the gateway Deployment readiness probe.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the async handler and Helm timeout remaining aligned with the existing gateway readiness contract.

The registered health routes are awaited by the ASGI execution path, remain exempt from the application concurrency limiter, and the chart renders a valid five-second readiness timeout from its default values.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| charts/model-engine/templates/gateway_deployment.yaml | Adds the configured readiness timeout to the gateway probe without changing its path, cadence, or failure threshold. |
| charts/model-engine/values.yaml | Introduces a documented five-second default for the gateway readiness timeout. |
| model-engine/model_engine_server/api/app.py | Makes the minimal health handler asynchronous so FastAPI executes it on the event loop rather than the shared worker threadpool. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(gateway): async healthcheck handler ..."](https://github.com/scaleapi/llm-engine/commit/b80547d11ddafef99d16421fa4cdd4ce67339c20) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53421288)</sub>

**Context used:**

- Knowledge Base — [Model-engine API and HTTP surface](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/llm-engine/-/docs/api-and-http-surface.md)
- Knowledge Base — [Model-engine deployment and startup](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/llm-engine/-/docs/deployment-and-startup.md)

<!-- /greptile_comment -->