### PR TITLE
Chart: exclude 503 from gateway retries and make the retry policy configurable

### DIFF
--- a/charts/model-engine/templates/istio-virtualservice.yaml
+++ b/charts/model-engine/templates/istio-virtualservice.yaml
@@ -26,6 +26,12 @@ spec:
             port:
               number: 80
       retries:
-        attempts: 3
-        retryOn: connect-failure,unavailable,gateway-error
+        attempts: {{ ((.Values.virtualservice).retries).attempts | default 3 }}
+        {{- /* 503 is deliberately not retried: it is the overload signal, and retrying
+             it multiplies offered load exactly when the fleet is saturated. Numeric
+             codes in retryOn map to Envoy retriable-status-codes. */}}
+        retryOn: {{ ((.Values.virtualservice).retries).retryOn | default "connect-failure,unavailable,502,504" | quote }}
+        {{- with ((.Values.virtualservice).retries).perTryTimeout }}
+        perTryTimeout: {{ . }}
+        {{- end }}
 {{- end }}

--- a/charts/model-engine/values_sample.yaml
+++ b/charts/model-engine/values_sample.yaml
@@ -80,6 +80,14 @@ virtualservice:
     - llm-engine.domain.com
   gateways:
     - default/internal-gateway
+  # retries [optional] Envoy retry policy for the gateway route. 503 is excluded from
+  # the default retryOn because retrying the overload signal amplifies offered load.
+  # perTryTimeout is unset by default: the route also carries streaming and other
+  # long-lived requests, which a per-try timeout would abort mid-flight.
+  retries:
+    attempts: 3
+    retryOn: connect-failure,unavailable,502,504
+    perTryTimeout: null
 
 hostDomain:
   prefix: http://


### PR DESCRIPTION
## What

- The VirtualService retry policy defaults change from `retryOn: connect-failure,unavailable,gateway-error` to `retryOn: connect-failure,unavailable,502,504` (numeric codes map to Envoy retriable-status-codes). 503 is no longer retried.
- `attempts`, `retryOn`, and `perTryTimeout` are now configurable under `virtualservice.retries`; the previous values were hardcoded.

## Why

`gateway-error` bundles 502/503/504. 503 is the overload and no-healthy-upstream signal, so retrying it multiplies offered load when the service is least able to absorb it; during the 2026-08-13 incident this roughly 4x-ed traffic at saturation (disabling retries live cut envoy rps 68 to 39). 502/504 remain retried since they are usually transient single-upstream failures.

## Notes

- `perTryTimeout` is unset by default: the single catch-all route also carries streaming and long-lived LLM requests, which a per-try timeout would abort and re-send mid-flight.
- Deleting the `retries` block entirely would restore Istio's implicit default of 2 attempts, so the block always renders.
- Rendered with default and override values to verify output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR removes HTTP 503 from the gateway's default retry policy and exposes the retry count, retry conditions, and optional per-try timeout as Helm values.
- Defaults retries to connection failures, unavailable gRPC responses, HTTP 502, and HTTP 504.
- Keeps per-try timeout unset for streaming and long-lived requests.
- Adds a production-shaped retry configuration example.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The retry-default change is directionally safe, but explicit zero-attempt configurations must be preserved before merging; the Helm values reference should also document the new settings.

The template correctly removes HTTP 503 from its default retry set, but Helm's empty-value semantics cause an explicit `attempts: 0` to render as three attempts, defeating an operator's attempt to disable retries.

**Files Needing Attention:** charts/model-engine/templates/istio-virtualservice.yaml and charts/model-engine/values_sample.yaml
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| charts/model-engine/templates/istio-virtualservice.yaml | Makes the retry policy configurable and excludes 503 by default, but `default 3` silently overrides an explicit zero-attempt setting. |
| charts/model-engine/values_sample.yaml | Documents the new retry settings in the sample values, although the corresponding published Helm values reference was not updated. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20scaleapi%2Fllm-engine%20PR%20%23866%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=866&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Acharts%2Fmodel-engine%2Ftemplates%2Fistio-virtualservice.yaml%3A29%0A**Zero%20retry%20count%20is%20overwritten**%0A%0AWhen%20a%20deployment%20sets%20%60virtualservice.retries.attempts%3A%200%60%20to%20disable%20retries%2C%20Helm%20treats%20zero%20as%20empty%20and%20%60default%203%60%20emits%20three%20attempts%2C%20causing%20requests%20to%20be%20retried%20despite%20the%20explicit%20configuration%20and%20potentially%20restoring%20load%20amplification.%0A%0A%23%23%23%20Issue%202%0Acharts%2Fmodel-engine%2Fvalues_sample.yaml%3A87-90%0A**Retry%20values%20missing%20from%20reference**%0A%0AThe%20new%20%60virtualservice.retries%60%20settings%20are%20absent%20from%20the%20published%20Helm%20values%20reference%2C%20so%20operators%20cannot%20discover%20the%20supported%20fields%20and%20duration%20format%20there%20and%20may%20continue%20using%20defaults%20or%20provide%20an%20incorrectly%20formatted%20%60perTryTimeout%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=866&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Acharts%2Fmodel-engine%2Ftemplates%2Fistio-virtualservice.yaml%3A29%0A**Zero%20retry%20count%20is%20overwritten**%0A%0AWhen%20a%20deployment%20sets%20%60virtualservice.retries.attempts%3A%200%60%20to%20disable%20retries%2C%20Helm%20treats%20zero%20as%20empty%20and%20%60default%203%60%20emits%20three%20attempts%2C%20causing%20requests%20to%20be%20retried%20despite%20the%20explicit%20configuration%20and%20potentially%20restoring%20load%20amplification.%0A%0A%23%23%23%20Issue%202%0Acharts%2Fmodel-engine%2Fvalues_sample.yaml%3A87-90%0A**Retry%20values%20missing%20from%20reference**%0A%0AThe%20new%20%60virtualservice.retries%60%20settings%20are%20absent%20from%20the%20published%20Helm%20values%20reference%2C%20so%20operators%20cannot%20discover%20the%20supported%20fields%20and%20duration%20format%20there%20and%20may%20continue%20using%20defaults%20or%20provide%20an%20incorrectly%20formatted%20%60perTryTimeout%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=scaleapi%2Fllm-engine&pr=866&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fllm-engine%22%20on%20the%20existing%20branch%20%22lorenzonorcini%2Fgateway-retry-policy%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22lorenzonorcini%2Fgateway-retry-policy%22.%0A%0A%23%23%23%20Issue%201%0Acharts%2Fmodel-engine%2Ftemplates%2Fistio-virtualservice.yaml%3A29%0A**Zero%20retry%20count%20is%20overwritten**%0A%0AWhen%20a%20deployment%20sets%20%60virtualservice.retries.attempts%3A%200%60%20to%20disable%20retries%2C%20Helm%20treats%20zero%20as%20empty%20and%20%60default%203%60%20emits%20three%20attempts%2C%20causing%20requests%20to%20be%20retried%20despite%20the%20explicit%20configuration%20and%20potentially%20restoring%20load%20amplification.%0A%0A%23%23%23%20Issue%202%0Acharts%2Fmodel-engine%2Fvalues_sample.yaml%3A87-90%0A**Retry%20values%20missing%20from%20reference**%0A%0AThe%20new%20%60virtualservice.retries%60%20settings%20are%20absent%20from%20the%20published%20Helm%20values%20reference%2C%20so%20operators%20cannot%20discover%20the%20supported%20fields%20and%20duration%20format%20there%20and%20may%20continue%20using%20defaults%20or%20provide%20an%20incorrectly%20formatted%20%60perTryTimeout%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=scaleapi%2Fllm-engine&pr=866&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
charts/model-engine/templates/istio-virtualservice.yaml:29
**Zero retry count is overwritten**

When a deployment sets `virtualservice.retries.attempts: 0` to disable retries, Helm treats zero as empty and `default 3` emits three attempts, causing requests to be retried despite the explicit configuration and potentially restoring load amplification.

### Issue 2
charts/model-engine/values_sample.yaml:87-90
**Retry values missing from reference**

The new `virtualservice.retries` settings are absent from the published Helm values reference, so operators cannot discover the supported fields and duration format there and may continue using defaults or provide an incorrectly formatted `perTryTimeout`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(chart): stop retrying 503 at the gat..."](https://github.com/scaleapi/llm-engine/commit/95197835849cbcda2731d4f82bfc91f929451e69) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53421719)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Model-engine deployment and startup](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/llm-engine/-/docs/deployment-and-startup.md)

<!-- /greptile_comment -->