### PR TITLE
Chart: CPU request for the gateway istio-proxy sidecar

### DIFF
--- a/charts/model-engine/templates/gateway_deployment.yaml
+++ b/charts/model-engine/templates/gateway_deployment.yaml
@@ -28,6 +28,10 @@ spec:
           }]
         sidecar.istio.io/proxyMemoryLimit: "5Gi"
         sidecar.istio.io/proxyMemory: "1Gi"
+        {{- /* Without a CPU request the sidecar is starved on nodes packed to their CPU
+             request capacity, its postStart hook hangs, and new gateway pods never
+             become Ready. No CPU limit: throttling the proxy adds tail latency. */}}
+        sidecar.istio.io/proxyCPU: {{ ((.Values.gateway).sidecarCPURequest | default "250m") | quote }}
       labels:
         {{- include "modelEngine.selectorLabels.gateway" . | nindent 8 }}
         {{- include "modelEngine.labels" . | nindent 8 }}

--- a/charts/model-engine/values.yaml
+++ b/charts/model-engine/values.yaml
@@ -33,6 +33,12 @@ celery_broker_type_redis: null
 #     drop:
 #       - ALL
 
+# gateway [optional] tuning for the gateway deployment.
+gateway:
+  # sidecarCPURequest sets the istio-proxy CPU request (no limit). Without it the
+  # sidecar is starved on nodes at full CPU request capacity and pods never go Ready.
+  sidecarCPURequest: 250m
+
 redis:
   auth:
   authSecretName: ""


### PR DESCRIPTION
## What

Adds `sidecar.istio.io/proxyCPU: 250m` (values-configurable via `gateway.sidecarCPURequest`, no CPU limit) to the gateway pod annotations, alongside the existing memory-only annotations.

## Why

During the 2026-08-13 incident recovery, scale-out landed new gateway pods on nodes at ~99% CPU request capacity. With no CPU request, the sidecars were starved during bootstrap, postStart hooks hung up to 14 minutes, and fewer than half of the new pods ever became Ready, so the scale-out reduced effective capacity instead of adding it. A CPU request gives the sidecar a scheduling guarantee; no limit is set to avoid throttling proxy tail latency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a configurable CPU request for the gateway’s Istio proxy sidecar while intentionally leaving its CPU limit unset.
- Adds the `sidecar.istio.io/proxyCPU` gateway pod annotation.
- Introduces `gateway.sidecarCPURequest` with a default value of `250m`.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code defects identified.

The new Helm value is safely defaulted when existing overlays omit the gateway mapping, and the resulting annotation uses the established gateway sidecar annotation pattern with a valid CPU quantity.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| charts/model-engine/templates/gateway_deployment.yaml | Adds a correctly quoted, defaulted Istio proxy CPU-request annotation alongside the existing sidecar memory annotations. |
| charts/model-engine/values.yaml | Adds the gateway sidecar CPU-request configuration with a valid Kubernetes quantity as its default. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(chart): add istio-proxy CPU request ..."](https://github.com/scaleapi/llm-engine/commit/0ae0d70b53613e1782b598063040793604dcbfda) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53422016)</sub>

**Context used:**

- Knowledge Base — [Model-engine deployment and startup](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/llm-engine/-/docs/deployment-and-startup.md)

<!-- /greptile_comment -->