### PR TITLE
feat(vllm): add reasoning_parser endpoint arg

### DIFF
--- a/clients/python/llmengine/data_types/vllm.py
+++ b/clients/python/llmengine/data_types/vllm.py
@@ -64,6 +64,11 @@ class VLLMModelConfig(BaseModel):
         description="Tool call parser",
     )
 
+    reasoning_parser: Optional[str] = Field(
+        None,
+        description="Reasoning parser (e.g. 'qwen3', 'deepseek_r1'); splits model reasoning into reasoning_content in chat completions",
+    )
+
     enable_auto_tool_choice: Optional[bool] = Field(
         None,
         description="Enable auto tool choice",

--- a/model-engine/model_engine_server/common/dtos/llms/vllm.py
+++ b/model-engine/model_engine_server/common/dtos/llms/vllm.py
@@ -68,6 +68,11 @@ class VLLMModelConfig(BaseModel):
         description="Tool call parser",
     )
 
+    reasoning_parser: Optional[str] = Field(
+        None,
+        description="Reasoning parser (e.g. 'qwen3', 'deepseek_r1'); splits model reasoning into reasoning_content in chat completions",
+    )
+
     enable_auto_tool_choice: Optional[bool] = Field(
         None,
         description="Enable auto tool choice",


### PR DESCRIPTION
## What

Adds `reasoning_parser` to `VLLMModelConfig`. The endpoint command builder emits every set `VLLMEndpointAdditionalArgs` field as a CLI flag, so a set value renders as `--reasoning-parser <value>`; `vllm_server` parses it via vLLM's `make_arg_parser`. Unset (None) renders nothing, so existing endpoints are unaffected.

## Why

Thinking models (e.g. Qwen3.6) need `--reasoning-parser` for the OpenAI-compatible server to split reasoning into `reasoning_content` instead of leaving think-tag markup inline in `content`. First consumer: the model zoo Qwen3.6-27B endpoint replacing the Fireworks deployment for HMC pilot traffic (https://linear.app/scale-epd/issue/MLI-8119/scale-fireworks-qwen-deployment-for-pilot-traffic), where callers already depend on the split-reasoning response shape.

Related: https://github.com/scaleapi/llm-engine/pull/804 adds reasoning parser support for the batch path; this covers the endpoint path only.

## Testing

black / isort / ruff / mypy pass on the changed file. Optional field with None default; no behavior change unless set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR completes reasoning-parser support for endpoint configuration by adding the optional field to both mirrored vLLM DTOs.
- Allows typed Python-client endpoint requests to serialize `reasoning_parser`.
- Allows the server’s generic endpoint command builder to emit the corresponding `--reasoning-parser` CLI argument.
- Preserves existing endpoint behavior when the field is unset.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported client DTO omission is fixed and the endpoint path preserves the configured value through CLI construction.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| clients/python/llmengine/data_types/vllm.py | Adds the missing optional client DTO field, completing the previously reported typed-client serialization path. |
| model-engine/model_engine_server/common/dtos/llms/vllm.py | Adds the mirrored server DTO field consumed generically by endpoint CLI argument construction. |

</details>

<sub>Reviews (2): Last reviewed commit: ["feat(client): mirror reasoning\_parser in..."](https://github.com/scaleapi/llm-engine/commit/d184205463119e785b50970aceb16ed39b279f7f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55322304)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Published Python client](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/llm-engine/-/docs/python-client.md)
- Knowledge Base — [Common and core platform contracts](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/llm-engine/-/docs/common-and-core-platform.md)
- Knowledge Base — [vLLM serving runtime](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/llm-engine/-/docs/vllm-serving-runtime.md)
</details>

<!-- /greptile_comment -->