### PR TITLE
fix(vllm): support TP2 startup and speculative config

### DIFF
--- a/clients/python/llmengine/data_types/vllm.py
+++ b/clients/python/llmengine/data_types/vllm.py
@@ -226,7 +226,10 @@ class VLLMEngineAdditionalArgs(BaseModel):
 
 
 class VLLMEndpointAdditionalArgs(VLLMModelConfig, VLLMEngineAdditionalArgs, BaseModel):
-    pass
+    speculative_config: Optional[Dict[str, Any]] = Field(
+        None,
+        description="Speculative decoding configuration passed to the vLLM server.",
+    )
 
 
 class VLLMSamplingParams(BaseModel):

--- a/model-engine/model_engine_server/common/dtos/llms/vllm.py
+++ b/model-engine/model_engine_server/common/dtos/llms/vllm.py
@@ -230,7 +230,10 @@ class VLLMEngineAdditionalArgs(BaseModel):
 
 
 class VLLMEndpointAdditionalArgs(VLLMModelConfig, VLLMEngineAdditionalArgs, BaseModel):
-    pass
+    speculative_config: Optional[Dict[str, Any]] = Field(
+        None,
+        description="Speculative decoding configuration passed to the vLLM server.",
+    )
 
 
 class VLLMSamplingParams(BaseModel):

--- a/model-engine/model_engine_server/inference/vllm/vllm_server.py
+++ b/model-engine/model_engine_server/inference/vllm/vllm_server.py
@@ -10,24 +10,8 @@ ENABLE_STARTUP_METRICS = os.environ.get("ENABLE_STARTUP_METRICS", "").lower() ==
 
 # Now do heavy imports (noqa: E402 - intentional late import for startup time measurement)
 import asyncio  # noqa: E402
-import sys  # noqa: E402
 import threading  # noqa: E402
 from logging import Logger  # noqa: E402
-
-# vLLM's spawn-mode engine-core workers (used whenever CUDA is initialized in the API
-# server, e.g. tensor-parallel endpoints) re-import this module and fail to resolve the
-# sibling `utils` package even with an identical sys.path: namespace-package resolution
-# misbehaves inside multiprocessing's prepare(). Workers never call the debug hook (the
-# call site is under `if __name__ == "__main__"`), so fall back to a no-op rather than
-# killing engine-core startup.
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-try:
-    from utils.resource_debug import check_unknown_startup_memory_usage  # noqa: E402
-except ModuleNotFoundError:
-
-    def check_unknown_startup_memory_usage() -> None:
-        pass
-
 
 from vllm.entrypoints.openai.api_server import run_server  # noqa: E402
 from vllm.entrypoints.openai.cli_args import make_arg_parser  # noqa: E402
@@ -125,6 +109,13 @@ async def _run_instrumented_server(args):
 
 
 if __name__ == "__main__":
+    # Imported here, not at module top: vLLM's spawn-mode engine-core workers (used
+    # whenever CUDA is initialized in the API server, e.g. tensor-parallel endpoints)
+    # re-import this module as __mp_main__, where namespace-package resolution of the
+    # sibling `utils` package fails inside multiprocessing's prepare() and kills
+    # engine-core startup. Only the real entrypoint needs the hook.
+    from utils.resource_debug import check_unknown_startup_memory_usage
+
     check_unknown_startup_memory_usage()
 
     parser = FlexibleArgumentParser()

--- a/model-engine/model_engine_server/inference/vllm/vllm_server.py
+++ b/model-engine/model_engine_server/inference/vllm/vllm_server.py
@@ -14,12 +14,21 @@ import sys  # noqa: E402
 import threading  # noqa: E402
 from logging import Logger  # noqa: E402
 
-# vLLM's spawn-mode engine-core workers re-import this module with a sys.path/cwd that
-# no longer resolves the sibling `utils` package (a differently-rooted `utils` wins the
-# lookup and raises ModuleNotFoundError). Anchor resolution to this file's directory so
-# the import behaves identically in the parent and in spawned children.
+# vLLM's spawn-mode engine-core workers (used whenever CUDA is initialized in the API
+# server, e.g. tensor-parallel endpoints) re-import this module and fail to resolve the
+# sibling `utils` package even with an identical sys.path: namespace-package resolution
+# misbehaves inside multiprocessing's prepare(). Workers never call the debug hook (the
+# call site is under `if __name__ == "__main__"`), so fall back to a no-op rather than
+# killing engine-core startup.
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from utils.resource_debug import check_unknown_startup_memory_usage  # noqa: E402
+try:
+    from utils.resource_debug import check_unknown_startup_memory_usage  # noqa: E402
+except ModuleNotFoundError:
+
+    def check_unknown_startup_memory_usage() -> None:
+        pass
+
+
 from vllm.entrypoints.openai.api_server import run_server  # noqa: E402
 from vllm.entrypoints.openai.cli_args import make_arg_parser  # noqa: E402
 from vllm.utils.argparse_utils import FlexibleArgumentParser  # noqa: E402

--- a/model-engine/model_engine_server/inference/vllm/vllm_server.py
+++ b/model-engine/model_engine_server/inference/vllm/vllm_server.py
@@ -10,9 +10,15 @@ ENABLE_STARTUP_METRICS = os.environ.get("ENABLE_STARTUP_METRICS", "").lower() ==
 
 # Now do heavy imports (noqa: E402 - intentional late import for startup time measurement)
 import asyncio  # noqa: E402
+import sys  # noqa: E402
 import threading  # noqa: E402
 from logging import Logger  # noqa: E402
 
+# vLLM's spawn-mode engine-core workers re-import this module with a sys.path/cwd that
+# no longer resolves the sibling `utils` package (a differently-rooted `utils` wins the
+# lookup and raises ModuleNotFoundError). Anchor resolution to this file's directory so
+# the import behaves identically in the parent and in spawned children.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from utils.resource_debug import check_unknown_startup_memory_usage  # noqa: E402
 from vllm.entrypoints.openai.api_server import run_server  # noqa: E402
 from vllm.entrypoints.openai.cli_args import make_arg_parser  # noqa: E402

--- a/model-engine/tests/unit/domain/test_llm_use_cases.py
+++ b/model-engine/tests/unit/domain/test_llm_use_cases.py
@@ -497,6 +497,16 @@ async def test_create_model_endpoint_w_vllm_args(
     fake_llm_artifact_gateway,
     create_llm_model_endpoint_request_llama_3_70b_chat_vllm_args: CreateLLMModelEndpointV1Request,
 ):
+    create_llm_model_endpoint_request_llama_3_70b_chat_vllm_args = (
+        create_llm_model_endpoint_request_llama_3_70b_chat_vllm_args.model_copy(
+            update={
+                "speculative_config": {
+                    "method": "mtp",
+                    "num_speculative_tokens": 3,
+                }
+            }
+        )
+    )
     fake_model_endpoint_service.model_bundle_repository = fake_model_bundle_repository
     bundle_use_case = CreateModelBundleV2UseCase(
         model_bundle_repository=fake_model_bundle_repository,
@@ -531,9 +541,21 @@ async def test_create_model_endpoint_w_vllm_args(
     )[0]
 
     bundle_command = endpoint.record.current_model_bundle.flavor.command[2]
-    expected_vllm_args = ["max-model-len", "max-num-seqs", "chat-template"]
+    expected_vllm_args = [
+        "max-model-len",
+        "max-num-seqs",
+        "chat-template",
+        "speculative-config",
+    ]
     for arg in expected_vllm_args:
         assert arg in bundle_command
+    expected_speculative_config_arg = "--speculative-config " + shlex.quote(
+        json.dumps(
+            {"method": "mtp", "num_speculative_tokens": 3},
+            separators=(",", ":"),
+        )
+    )
+    assert expected_speculative_config_arg in bundle_command
     assert endpoint.record.endpoint_type == ModelEndpointType.STREAMING
     assert endpoint.record.metadata == {
         "_llm": {
@@ -549,6 +571,7 @@ async def test_create_model_endpoint_w_vllm_args(
             "vllm_additional_args": {
                 "max_model_len": create_llm_model_endpoint_request_llama_3_70b_chat_vllm_args.max_model_len,
                 "max_num_seqs": create_llm_model_endpoint_request_llama_3_70b_chat_vllm_args.max_num_seqs,
+                "speculative_config": create_llm_model_endpoint_request_llama_3_70b_chat_vllm_args.speculative_config,
             },
         }
     }


### PR DESCRIPTION
## What

- Marks the vLLM runtime `utils` directory as a Python package.
- Imports `utils.resource_debug` only from the real server entrypoint so spawn-mode engine workers do not import the startup-only hook.
- Exposes optional `speculative_config` in the server and Python client endpoint DTOs. The existing command builder serializes dictionary values as compact JSON. The default remains unset.

## Why

vLLM uses spawn-mode engine workers for tensor-parallel endpoints after CUDA is initialized in the API server. The previous runtime failed while re-importing `vllm_server.py` because the sibling `utils` namespace package did not resolve in the spawned child. TP1 endpoints were unaffected.

The optional endpoint field is needed to run speculative-decoding canaries through the normal model configuration path instead of patching a Deployment command. It does not enable speculative decoding for any endpoint.

## Validation

- `black --check --config .black.toml .`
- `isort . --check-only`
- `ruff check .`
- Server and Python client mypy checks
- Focused server unit tests: 2 passed
- Python client DTO serialization smoke
- `vllm:0.17.0-rc4` TP2 without MTP: 121/121 structured and mixed-concurrency requests passed on H100
- `vllm:0.17.0-rc4` TP2 with MTP-3: the canary failed under concurrent long structured output with a CUDA illegal-memory-access and `EngineDeadError`; MTP therefore remains disabled in production


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes tensor-parallel vLLM startup by making the runtime utilities a package and limiting the startup-only resource hook to the real server entrypoint. It also exposes optional speculative-decoding configuration through the server and Python client DTOs.
- Adds matching `speculative_config` fields to the client and server endpoint models.
- Serializes speculative configuration into the generated vLLM command and retains it in endpoint metadata.
- Prevents spawned engine workers from importing the startup-only resource-debug hook.
- Adds focused command-generation and metadata assertions.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| clients/python/llmengine/data_types/vllm.py | Adds the optional speculative-decoding configuration to the Python client endpoint DTO. |
| model-engine/model_engine_server/common/dtos/llms/vllm.py | Adds the corresponding server-side endpoint field used by metadata and command generation. |
| model-engine/model_engine_server/inference/vllm/utils/__init__.py | Marks the runtime utility directory as a regular Python package. |
| model-engine/model_engine_server/inference/vllm/vllm_server.py | Defers the startup-only resource-debug import to the true server entrypoint so spawned workers skip it. |
| model-engine/tests/unit/domain/test_llm_use_cases.py | Verifies compact JSON command serialization and metadata persistence for speculative configuration. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Request[Endpoint request] --> DTO[VLLM endpoint DTO]
  DTO --> Metadata[Endpoint metadata]
  DTO --> Builder[Command builder]
  Builder --> Flag[--speculative-config JSON]
  Flag --> Server[vLLM server entrypoint]
  Server --> Hook[Startup resource hook]
  Server --> Workers[Spawn-mode engine workers]
  Workers -. skip entrypoint-only hook .-> Hook
```
</details>

<sub>Reviews (4): Last reviewed commit: ["feat(vllm): support speculative decoding..."](https://github.com/scaleapi/llm-engine/commit/8bf9a78da922af3a221ec3d82e8a86b40acb3ae9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55611056)</sub>

<!-- /greptile_comment -->