### PR TITLE
feat(chart): let object-store workloads mount extra volumes

### DIFF
--- a/charts/model-engine/Chart.yaml
+++ b/charts/model-engine/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.9
+version: 0.2.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/model-engine/templates/service_template_config_map.yaml
+++ b/charts/model-engine/templates/service_template_config_map.yaml
@@ -360,6 +360,9 @@ data:
                   memory: ${MEMORY}
                   ${STORAGE_DICT}
               volumeMounts:
+                {{- with $.Values.extraPodVolumeMounts }}
+                {{- toYaml . | nindent 16 }}
+                {{- end }}
                 {{- if $require_aws_config }}
                 - name: config-volume
                   mountPath: /opt/.aws/config
@@ -385,6 +388,9 @@ data:
           securityContext:
             fsGroup: 65534
           volumes:
+            {{- with $.Values.extraPodVolumes }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
             {{- if $require_aws_config }}
             - name: config-volume
               configMap:
@@ -774,6 +780,9 @@ data:
                     memory: ${MEMORY}
                     ${STORAGE_DICT}
                 volumeMounts:
+                  {{- with $.Values.extraPodVolumeMounts }}
+                  {{- toYaml . | nindent 18 }}
+                  {{- end }}
                   {{- if $require_aws_config }}
                   - name: config-volume
                     mountPath: /opt/.aws/config
@@ -795,6 +804,9 @@ data:
                   - containerPort: ${USER_CONTAINER_PORT}
                     name: http
             volumes:
+              {{- with $.Values.extraPodVolumes }}
+              {{- toYaml . | nindent 14 }}
+              {{- end }}
               {{- if $require_aws_config }}
               - name: config-volume
                 configMap:
@@ -871,6 +883,10 @@ data:
                 imagePullPolicy: IfNotPresent
                 command: ${WORKER_COMMAND}
                 env: ${WORKER_ENV}
+                {{- with $.Values.extraPodEnvFrom }}
+                envFrom:
+                {{- toYaml . | nindent 16 }}
+                {{- end }}
                 resources:
                   requests:
                     {{- if eq $device "gpu" }}
@@ -887,6 +903,9 @@ data:
                     memory: ${MEMORY}
                     ${STORAGE_DICT}
                 volumeMounts:
+                  {{- with $.Values.extraPodVolumeMounts }}
+                  {{- toYaml . | nindent 18 }}
+                  {{- end }}
                   {{- if $require_aws_config }}
                   - name: config-volume
                     mountPath: /opt/.aws/config
@@ -908,6 +927,9 @@ data:
                   - containerPort: ${USER_CONTAINER_PORT}
                     name: http
             volumes:
+              {{- with $.Values.extraPodVolumes }}
+              {{- toYaml . | nindent 14 }}
+              {{- end }}
               {{- if $require_aws_config }}
               - name: config-volume
                 configMap:
@@ -1093,6 +1115,9 @@ data:
           {{- end }}
           serviceAccountName: {{ $launch_name }}
           volumes:
+            {{- with $.Values.extraPodVolumes }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
             {{- if $require_aws_config }}
             - name: config-volume
               configMap:
@@ -1128,6 +1153,10 @@ data:
                 {{- end }}
                 {{- end }}
               imagePullPolicy: IfNotPresent
+              {{- with $.Values.extraPodEnvFrom }}
+              envFrom:
+              {{- toYaml . | nindent 14 }}
+              {{- end }}
               command:
                 - dumb-init
                 - --
@@ -1159,6 +1188,9 @@ data:
                   memory: 32Gi
                   ephemeral-storage: 30Gi
               volumeMounts:
+                {{- with $.Values.extraPodVolumeMounts }}
+                {{- toYaml . | nindent 16 }}
+                {{- end }}
                 {{- if $require_aws_config }}
                 - name: config-volume
                   mountPath: /opt/.aws/config
@@ -1221,6 +1253,9 @@ data:
           serviceAccountName: {{ $launch_name }}
           {{- end }}
           volumes:
+            {{- with $.Values.extraPodVolumes }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
             {{- if $require_aws_config }}
             - name: config-volume
               configMap:
@@ -1273,6 +1308,9 @@ data:
                   memory: ${MEMORY}
                   ${STORAGE_DICT}
               volumeMounts:
+                {{- with $.Values.extraPodVolumeMounts }}
+                {{- toYaml . | nindent 16 }}
+                {{- end }}
                 {{- if $require_aws_config }}
                 - name: config-volume
                   mountPath: /opt/.aws/config
@@ -1292,6 +1330,10 @@ data:
               env:
                 - name: AWS_CONFIG_FILE
                   value: "/opt/.aws/config"
+              {{- with $.Values.extraPodEnvFrom }}
+              envFrom:
+              {{- toYaml . | nindent 14 }}
+              {{- end }}
               command:
                 - python
                 - -m
@@ -1311,6 +1353,9 @@ data:
                   cpu: 1
                   memory: 1Gi
               volumeMounts:
+                {{- with $.Values.extraPodVolumeMounts }}
+                {{- toYaml . | nindent 16 }}
+                {{- end }}
                 {{- if $require_aws_config }}
                 - name: config-volume
                   mountPath: /opt/.aws/config

--- a/charts/model-engine/values.yaml
+++ b/charts/model-engine/values.yaml
@@ -111,6 +111,15 @@ extraEnvVars: []              # Extra env vars for all main containers (gateway,
 extraVolumes: []              # Extra volumes for all deployments
 extraVolumeMounts: []         # Extra volume mounts for main containers
 extraPodEnvFrom: []           # Extra envFrom for inference pods (e.g., MinIO credentials)
+# Extra volumes for every workload the service template renders that reads object
+# storage: the endpoint Deployment, both halves of a LeaderWorkerSet, the batch jobs and
+# the input-downloader initContainer. Distinct from extraVolumes above, which only
+# reaches the control-plane deployments. These pod specs have a fixed volume list, so a
+# site that has to hand them a file (a private CA for an S3 endpoint, say) has no other
+# way in: extraPodEnvFrom carries env only, and both existing mounts use subPath/items
+# and project a single named key.
+extraPodVolumes: []
+extraPodVolumeMounts: []
 
 # PVC-backed model cache for endpoint pods. When enabled, model downloads are cached on
 # one endpoint-scoped PVC instead of the pod's ephemeral storage. The default access


### PR DESCRIPTION
The pods the service template renders have a fixed volume list. The existing hooks do not reach them: extraVolumes/extraVolumeMounts apply to the control-plane deployments, and extraPodEnvFrom carries env only. Nor can either mounted ConfigMap smuggle a file in -- config-volume uses subPath and infra-service-config-volume restricts itself to one key via items.

So a site that has to hand these workloads a FILE has no way in at all. The case that surfaced this: an on-prem S3 endpoint whose certificate is signed by the customer's own CA. Verification needs AWS_CA_BUNDLE (and its requests/openssl equivalents) pointing at a real path, and there was no way to put the CA at one short of baking it into the image.

extraPodVolumes and extraPodVolumeMounts are added everywhere the template renders something that talks to object storage: the endpoint Deployment, both halves of a LeaderWorkerSet, batch-job-orchestration, the docker-image batch jobs, and the input-downloader initContainer -- which takes ${S3_FILE} as its argument and so fails against a private CA exactly like the rest.

In every case the block is the FIRST entry under volumeMounts/volumes, never inside a conditional. That is load-bearing rather than stylistic: the pod-level volume is unconditional, so a mount nested under an unrelated `if` yields a CA present in the pod but absent from the container that reads it -- the exact failure this change exists to prevent, and one that hides whenever that condition happens to be true.

The LWS worker and both batch-job templates also gain extraPodEnvFrom, which they did not have. A CA file with no AWS_CA_BUNDLE beside it is dead weight, so without this the volume would land somewhere nothing reads it. That is a behaviour change for anyone already setting extraPodEnvFrom -- those workloads will now receive it too, which is almost certainly what was wanted, but it is a change and reviewers should say so if not.

An earlier revision scoped coverage to "inference pods" on the grounds that it matched extraPodEnvFrom's existing boundary. That was a consistency argument dressed up as a functional one: the batch jobs mount the same AWS config and read the same store, so they break the same way. Coverage now follows what reads object storage rather than what the older hook happened to touch.

Both new values default to [] and render nothing when unset.

Verified against values_circleci.yaml, and again with config.values nulled so config_values is falsy: the embedded templates parse identically in both modes and against the unmodified chart (17 parse, 15 fail on unsubstituted ${STORAGE_DICT}/${NODE_PORT_DICT} placeholders throughout), and the volume, mount and envFrom reach every rendered template including the LWS worker and the input-downloader initContainer. Rendering only the config-populated case would have missed a mount nested under $config_values.

# Pull Request Summary

_What is this PR changing? Why is this change being made? Any caveats you'd like to highlight? Link any relevant documents, links, or screenshots here if applicable._

## Test Plan and Usage Guide

_How did you validate that your PR works correctly? How do you run or demo the code? Provide enough detail so a reviewer can reasonably reproduce the testing procedure. Paste example command line invocations if applicable._
