### PR TITLE
chart: allow a gateway-only resources override (MLI-8534)

### DIFF
--- a/charts/model-engine/Chart.yaml
+++ b/charts/model-engine/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.9
+version: 0.2.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/model-engine/templates/gateway_deployment.yaml
+++ b/charts/model-engine/templates/gateway_deployment.yaml
@@ -77,7 +77,14 @@ spec:
             - -m
             - model_engine_server.entrypoints.start_fastapi_server
           resources:
+            {{- /* The gateway proxies async-task results inline, so its memory profile is
+                 unrelated to the cacher and endpoint-builder that share .Values.resources.
+                 Falls back to the shared block when gateway.resources is unset. */}}
+            {{- if .Values.gateway.resources }}
+            {{- toYaml .Values.gateway.resources | nindent 12 }}
+            {{- else }}
             {{- toYaml .Values.resources | nindent 12 }}
+            {{- end }}
           {{- include "modelEngine.gatewayEnv" . | indent 10 }}
           {{- include "modelEngine.volumeMounts" . | indent 10 }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}

--- a/charts/model-engine/templates/gateway_deployment.yaml
+++ b/charts/model-engine/templates/gateway_deployment.yaml
@@ -84,12 +84,13 @@ spec:
           resources:
             {{- /* The gateway proxies async-task results inline, so its memory profile is
                  unrelated to the cacher and endpoint-builder that share .Values.resources.
-                 Falls back to the shared block when gateway.resources is unset. */}}
-            {{- if .Values.gateway.resources }}
-            {{- toYaml .Values.gateway.resources | nindent 12 }}
-            {{- else }}
-            {{- toYaml .Values.resources | nindent 12 }}
-            {{- end }}
+                 gateway.resources deep-merges OVER that shared block, so a memory-only
+                 override keeps the shared cpu / ephemeral-storage requests.
+                 deepCopy is required: mergeOverwrite mutates its first argument, and
+                 .Values.resources is also rendered into the cacher and endpoint-builder. */}}
+            {{- $base := .Values.resources | default dict }}
+            {{- $gatewayResources := (.Values.gateway | default dict).resources | default dict }}
+            {{- toYaml (mergeOverwrite (deepCopy $base) $gatewayResources) | nindent 12 }}
           {{- include "modelEngine.gatewayEnv" . | indent 10 }}
           {{- include "modelEngine.volumeMounts" . | indent 10 }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}

--- a/charts/model-engine/templates/gateway_vpa.yaml
+++ b/charts/model-engine/templates/gateway_vpa.yaml
@@ -23,5 +23,5 @@ spec:
         maxAllowed:
           cpu: {{ .Values.autoscaling.vertical.maxAllowed.cpu }}
           memory: {{ .Values.autoscaling.vertical.maxAllowed.memory }}
-        controlledResources: ["cpu", "memory"]
+        controlledResources: {{ (.Values.gateway | default dict).vpaControlledResources | default (list "cpu" "memory") | toJson }}
 {{- end }}

--- a/charts/model-engine/values.yaml
+++ b/charts/model-engine/values.yaml
@@ -48,13 +48,21 @@ gateway:
     attempts: 3
     retryOn: connect-failure,unavailable,502,504
     perTryTimeout: null
-  # resources overrides the top-level `resources` for the gateway container only.
+  # resources deep-merges over the top-level `resources` for the gateway container only.
   # That top-level block is shared with the cacher and endpoint-builder, which run a
   # handful of pods each and sit near 1GiB; the gateway runs the whole fleet and holds
   # task results in memory while it proxies them. Sizing all three off one block means
   # either under-declaring the gateway or over-reserving for the other two.
-  # Leave empty to inherit `resources` unchanged.
+  # Keys set here win; keys absent here fall through to `resources`, so a memory-only
+  # override keeps the shared cpu and ephemeral-storage requests. Leave empty to inherit
+  # `resources` unchanged.
   resources: {}
+  # vpaControlledResources sets the gateway VPA's controlledResources. The VPA runs in
+  # updateMode: Initial, so it rewrites requests at pod creation and clamps them to
+  # autoscaling.vertical.maxAllowed — which would silently override any memory request
+  # pinned in `gateway.resources` above. Set to ["cpu"] when pinning memory statically,
+  # so the VPA keeps managing CPU and stops managing memory.
+  vpaControlledResources: ["cpu", "memory"]
 
 # rateLimits [optional] per-pod Envoy local_ratelimit token buckets on the gateway
 # sidecars (inbound). Overflow returns 429 at the proxy without reaching a gateway

--- a/charts/model-engine/values.yaml
+++ b/charts/model-engine/values.yaml
@@ -48,6 +48,13 @@ gateway:
     attempts: 3
     retryOn: connect-failure,unavailable,502,504
     perTryTimeout: null
+  # resources overrides the top-level `resources` for the gateway container only.
+  # That top-level block is shared with the cacher and endpoint-builder, which run a
+  # handful of pods each and sit near 1GiB; the gateway runs the whole fleet and holds
+  # task results in memory while it proxies them. Sizing all three off one block means
+  # either under-declaring the gateway or over-reserving for the other two.
+  # Leave empty to inherit `resources` unchanged.
+  resources: {}
 
 # rateLimits [optional] per-pod Envoy local_ratelimit token buckets on the gateway
 # sidecars (inbound). Overflow returns 429 at the proxy without reaching a gateway


### PR DESCRIPTION
Linear: [MLI-8534](https://linear.app/scale-epd/issue/MLI-8534/model-engine-gateway-declares-no-memory-request-or-limit-set-an-honest)

## Problem

`.Values.resources` is rendered into all three model-engine deployments:

```
templates/gateway_deployment.yaml:80
templates/cacher_deployment.yaml:67
templates/endpoint_builder_deployment.yaml:79
```

Their memory profiles aren't comparable. On `ml-serving-new` right now:

| Component | Pods | Actual memory |
| -- | -- | -- |
| gateway | 100 | median **28.8 GiB**, p90 32.1 GiB, peak **103 GB** |
| cacher | 1 | 1.0 GiB |
| endpoint-builder | 2 | 0.7 GiB each |

The gateway holds async-task results in memory while proxying them inline (#868's rate-limit comments describe the same payload path). The other two don't.

With one shared block the only options are under-declaring the gateway or over-reserving for the other two. Today it's the former: the gateway declares **no memory request at all**, so the scheduler treats those nodes as memory-empty and packs up to 3 gateway pods onto a 120.3 GiB node. On 2026-08-25 that produced **46 OOMKills** across the fleet, node-level rather than container-scoped — so the node OOM killer picks its own victim, which may be an unrelated workload.

## Change

Adds an optional `gateway.resources`, alongside the existing `gateway.*` tuning keys from #867/#868. When unset, the gateway falls back to `.Values.resources` exactly as today.

## Backwards compatibility

Verified with `helm template` against the live prod values:

- **`gateway.resources` unset** — gateway, cacher and builder all render `{cpu: 2, ephemeral-storage: 256Mi}`. Byte-identical to current output, so this is a no-op for every existing consumer including SGP.
- **`gateway.resources` set** — gateway picks it up; cacher and builder are untouched.

`helm lint` clean.

## Not in this PR

No values are changed. The sizing (a memory request that matches reality, and whether a limit ships at all) lands separately in the deploy values, and is still under discussion — see MLI-8534 for why a limit is harder than it looks while the gateway's steady state sits at ~29 GiB and the HPA is pinned at `maxReplicas: 100`.

## One question for review

I bumped `Chart.yaml` to **0.2.10**, since the templates changed.

Worth flagging that the published `0.2.9` in `public.ecr.aws/b2z8n5q1` does **not** match `0.2.9` at current `main` — #868's `sidecarCPURequest` and `readinessProbeTimeoutSeconds` are in source but not in the published tarball, under the same version string. So a bump here means the next publish also ships those. That seemed right to me, but happy to drop the bump if you'd rather sequence it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)








<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The chart adds gateway-specific resource overrides while preserving the shared resource defaults, and makes the gateway VPA’s controlled resource list configurable.
- Deep-merges `gateway.resources` over the shared top-level `resources`.
- Adds `gateway.vpaControlledResources` so operators can keep VPA from rewriting a statically pinned memory request.
- Increments the model-engine chart version to `0.2.10`.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| charts/model-engine/Chart.yaml | Increments the chart version from 0.2.9 to 0.2.10 for the template changes. |
| charts/model-engine/templates/gateway_deployment.yaml | Deep-merges gateway-specific resource settings over a copied shared resource map, preserving inherited keys without mutating values used by sibling deployments. |
| charts/model-engine/templates/gateway_vpa.yaml | Renders a configurable gateway VPA controlledResources list while retaining CPU-and-memory behavior by default. |
| charts/model-engine/values.yaml | Documents and provides defaults for gateway-specific resource and VPA-control settings. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Shared[Top-level resources] --> Merge[Deep merge]
    GatewayOverride[gateway.resources] --> Merge
    Merge --> Gateway[Gateway resources]
    Shared --> Cacher[Cacher resources]
    Shared --> Builder[Endpoint-builder resources]
    VPAConfig[gateway.vpaControlledResources] --> VPA[Gateway VPA controlledResources]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["chore: empty commit to retrigger CI"](https://github.com/scaleapi/llm-engine/commit/6608e751fe73cf4ae8b4195c230e79426af37722) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56807258)</sub>

**Context used:**

- Knowledge Base — [Deployment and operational configuration](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/llm-engine/-/docs/deployment-and-operations.md)
- Knowledge Base — [Helm release and Kubernetes startup watcher](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/llm-engine/-/docs/helm-release-and-startup-watcher.md)

<!-- /greptile_comment -->