### PR TITLE
fix(forwarder): stop the sync deadline capping async tasks at 1h (MLI-8587)

### DIFF
--- a/model-engine/model_engine_server/common/dtos/tasks.py
+++ b/model-engine/model_engine_server/common/dtos/tasks.py
@@ -22,6 +22,7 @@ class TaskStatus(str, Enum):
     STARTED = "STARTED"
     SUCCESS = "SUCCESS"
     FAILURE = "FAILURE"
+    TIMEOUT = "TIMEOUT"
     UNDEFINED = "UNDEFINED"
 
 

--- a/model-engine/model_engine_server/inference/forwarding/celery_forwarder.py
+++ b/model-engine/model_engine_server/inference/forwarding/celery_forwarder.py
@@ -48,6 +48,17 @@ logger = make_logger(logger_name())
 
 tracing_gateway = get_tracing_gateway()
 
+# The Celery hard limit SIGKILLs the worker child, which discards the traceback. Held above the
+# forwarder's own HTTP timeout so that timeout raises first and a deadline hit stays diagnosable.
+CELERY_TIME_LIMIT_GRACE_SECONDS: float = 300
+
+# An async task is bounded by how long its queue will wait for an ack, not by the sync request
+# deadline. The grace is subtracted so the hard limit lands on the visibility boundary rather than
+# past it, where the message has already been redelivered to another worker.
+DEFAULT_ASYNC_TIMEOUT_SECONDS: float = (
+    DEFAULT_TASK_VISIBILITY_SECONDS - CELERY_TIME_LIMIT_GRACE_SECONDS
+)
+
 
 class ErrorResponse(TypedDict):
     """The response payload for any inference request that encountered an error."""
@@ -103,7 +114,7 @@ def create_celery_service(
     monitoring_metrics_gateway = DatadogInferenceMonitoringMetricsGateway()
     # requests treats its timeout as socket inactivity. The Celery limit supplies
     # the wall-clock bound when an upstream response keeps trickling bytes.
-    task_time_limit = forwarder.timeout_seconds
+    task_time_limit = forwarder.timeout_seconds + CELERY_TIME_LIMIT_GRACE_SECONDS
 
     class ErrorHandlingTask(Task):
         """Sets a 'custom' field with error in the Task response for FAILURE.
@@ -260,7 +271,13 @@ def entrypoint():
         args.broker_type = str(BrokerType.SQS.value if args.sqs_url else BrokerType.REDIS.value)
 
     forwarder_config = load_named_config(args.config, args.set)
-    forwarder_loader = LoadForwarder(**forwarder_config["async"])
+    # LoadForwarder's own default is the sync deadline; async tasks are bounded by the queue's
+    # task visibility instead, so the config file and --set stay authoritative over both.
+    async_config = {
+        "timeout_seconds": DEFAULT_ASYNC_TIMEOUT_SECONDS,
+        **forwarder_config["async"],
+    }
+    forwarder_loader = LoadForwarder(**async_config)
     forwader = forwarder_loader.load(None, None)
 
     app = create_celery_service(

--- a/model-engine/model_engine_server/inference/forwarding/celery_forwarder.py
+++ b/model-engine/model_engine_server/inference/forwarding/celery_forwarder.py
@@ -53,11 +53,11 @@ tracing_gateway = get_tracing_gateway()
 CELERY_TIME_LIMIT_GRACE_SECONDS: float = 300
 
 # An async task is bounded by how long its queue will wait for an ack, not by the sync request
-# deadline. The grace is subtracted so the hard limit lands on the visibility boundary rather than
-# past it, where the message has already been redelivered to another worker.
-DEFAULT_ASYNC_TIMEOUT_SECONDS: float = (
-    DEFAULT_TASK_VISIBILITY_SECONDS - CELERY_TIME_LIMIT_GRACE_SECONDS
-)
+# deadline: past the visibility timeout the broker redelivers a task that is still running, because
+# task_acks_late is on. The grace is subtracted so the hard limit lands on that boundary rather than
+# past it. This is both the default and the ceiling -- a longer configured deadline cannot be
+# honoured, so it is capped rather than accepted.
+MAX_ASYNC_TIMEOUT_SECONDS: float = DEFAULT_TASK_VISIBILITY_SECONDS - CELERY_TIME_LIMIT_GRACE_SECONDS
 
 
 class ErrorResponse(TypedDict):
@@ -72,6 +72,14 @@ def raw_celery_response(backend, task_id: str) -> Dict[str, Any]:
     info_as_str: str = backend.get(key_info)
     info: dict = json.loads(info_as_str)
     return info
+
+
+def async_task_time_limit(timeout_seconds: float, task_visibility: TaskVisibility) -> float:
+    """Wall-clock bound for an async task: above the forwarder's HTTP timeout, never past the
+    window the queue waits for an ack.
+    """
+    visibility_timeout = TaskVisibility.get_visibility_timeout_in_seconds(task_visibility)
+    return min(timeout_seconds + CELERY_TIME_LIMIT_GRACE_SECONDS, visibility_timeout)
 
 
 def error_response(msg: str, e_unhandled: Exception) -> ErrorResponse:
@@ -113,8 +121,10 @@ def create_celery_service(
 
     monitoring_metrics_gateway = DatadogInferenceMonitoringMetricsGateway()
     # requests treats its timeout as socket inactivity. The Celery limit supplies
-    # the wall-clock bound when an upstream response keeps trickling bytes.
-    task_time_limit = forwarder.timeout_seconds + CELERY_TIME_LIMIT_GRACE_SECONDS
+    # the wall-clock bound when an upstream response keeps trickling bytes. celery_app asserts the
+    # visibility ceiling for its app-level task_time_limit, but a per-task time_limit never reaches
+    # that assertion, so it is held here too.
+    task_time_limit = async_task_time_limit(forwarder.timeout_seconds, task_visibility)
 
     class ErrorHandlingTask(Task):
         """Sets a 'custom' field with error in the Task response for FAILURE.
@@ -271,12 +281,20 @@ def entrypoint():
         args.broker_type = str(BrokerType.SQS.value if args.sqs_url else BrokerType.REDIS.value)
 
     forwarder_config = load_named_config(args.config, args.set)
-    # LoadForwarder's own default is the sync deadline; async tasks are bounded by the queue's
-    # task visibility instead, so the config file and --set stay authoritative over both.
+    # LoadForwarder's own default is the sync deadline; async tasks get the queue's visibility
+    # window instead, and the config file and --set stay authoritative below that ceiling.
     async_config = {
-        "timeout_seconds": DEFAULT_ASYNC_TIMEOUT_SECONDS,
+        "timeout_seconds": MAX_ASYNC_TIMEOUT_SECONDS,
         **forwarder_config["async"],
     }
+    if async_config["timeout_seconds"] > MAX_ASYNC_TIMEOUT_SECONDS:
+        logger.warning(
+            "Capping forwarder.async.timeout_seconds %s at %s: a longer deadline outlives the "
+            "queue's visibility timeout, which redelivers the task while it is still running.",
+            async_config["timeout_seconds"],
+            MAX_ASYNC_TIMEOUT_SECONDS,
+        )
+        async_config["timeout_seconds"] = MAX_ASYNC_TIMEOUT_SECONDS
     forwarder_loader = LoadForwarder(**async_config)
     forwader = forwarder_loader.load(None, None)
 

--- a/model-engine/model_engine_server/infra/gateways/celery_task_queue_gateway.py
+++ b/model-engine/model_engine_server/infra/gateways/celery_task_queue_gateway.py
@@ -26,6 +26,18 @@ except ImportError:
     ServiceBusError = None  # type: ignore[assignment,misc]
 
 logger = make_logger(logger_name())
+
+# Matched by name, not isinstance: the result backend rebuilds the exception from the stored
+# exc_type/exc_module, and synthesizes a stand-in class when that module is not importable here.
+TIMEOUT_EXCEPTION_NAMES = frozenset(
+    {
+        "TimeLimitExceeded",  # celery/billiard hard limit; the worker child was killed
+        "SoftTimeLimitExceeded",
+        "Timeout",  # requests, and the base of the two below
+        "ConnectTimeout",
+        "ReadTimeout",
+    }
+)
 _cloud_provider = infra_config().cloud_provider
 backend_protocol = (
     "abs" if _cloud_provider == "azure" else ("redis" if _cloud_provider == "gcp" else "s3")
@@ -399,9 +411,12 @@ class CeleryTaskQueueGateway(TaskQueueGateway):
             )
 
         elif response_state == "FAILURE":
+            # A deadline hit leaves the user container still running, so it is reported apart from
+            # a crash: the work may yet land and the caller can keep polling rather than discard it.
+            timed_out = type(res.result).__name__ in TIMEOUT_EXCEPTION_NAMES
             return GetAsyncTaskV1Response(
                 task_id=task_id,
-                status=TaskStatus.FAILURE,
+                status=TaskStatus.TIMEOUT if timed_out else TaskStatus.FAILURE,
                 result=str(res.result) if res.result is not None else None,
                 traceback=res.traceback,
                 status_code=None,  # probably

--- a/model-engine/model_engine_server/infra/services/live_batch_job_orchestration_service.py
+++ b/model-engine/model_engine_server/infra/services/live_batch_job_orchestration_service.py
@@ -331,7 +331,7 @@ class LiveBatchJobOrchestrationService(BatchJobOrchestrationService):
             )
             has_new_ready_tasks = False
             curr_timestamp = datetime.utcnow()
-            terminal_task_states = {TaskStatus.SUCCESS, TaskStatus.FAILURE}
+            terminal_task_states = {TaskStatus.SUCCESS, TaskStatus.FAILURE, TaskStatus.TIMEOUT}
             for r in new_results:
                 if r.status in terminal_task_states or curr_timestamp > timeout_timestamp:
                     has_new_ready_tasks = True

--- a/model-engine/specs/openapi-3.0.json
+++ b/model-engine/specs/openapi-3.0.json
@@ -12347,6 +12347,7 @@
           "STARTED",
           "SUCCESS",
           "FAILURE",
+          "TIMEOUT",
           "UNDEFINED"
         ],
         "title": "TaskStatus"

--- a/model-engine/specs/openapi.json
+++ b/model-engine/specs/openapi.json
@@ -16898,6 +16898,7 @@
           "STARTED",
           "SUCCESS",
           "FAILURE",
+          "TIMEOUT",
           "UNDEFINED"
         ],
         "title": "TaskStatus"

--- a/model-engine/tests/unit/inference/test_celery_forwarder_worker.py
+++ b/model-engine/tests/unit/inference/test_celery_forwarder_worker.py
@@ -108,7 +108,7 @@ def test_async_forwarder_does_not_inherit_the_sync_deadline(monkeypatch):
     # An async task is bounded by the queue's 24h visibility, not by the sync request deadline.
     kwargs = _run_entrypoint(monkeypatch, {"user_port": 5005})
 
-    assert kwargs["timeout_seconds"] == celery_forwarder.DEFAULT_ASYNC_TIMEOUT_SECONDS
+    assert kwargs["timeout_seconds"] == celery_forwarder.MAX_ASYNC_TIMEOUT_SECONDS
     # The whole budget, hard limit included, fits inside the window the queue waits for an ack.
     assert (
         kwargs["timeout_seconds"] + celery_forwarder.CELERY_TIME_LIMIT_GRACE_SECONDS
@@ -121,3 +121,56 @@ def test_async_forwarder_deadline_is_overridable(monkeypatch):
     kwargs = _run_entrypoint(monkeypatch, {"user_port": 5005, "timeout_seconds": 7200})
 
     assert kwargs["timeout_seconds"] == 7200
+
+
+def test_async_forwarder_deadline_capped_at_the_visibility_window(monkeypatch):
+    # An override past the ceiling would put the hard limit beyond the visibility timeout, where
+    # the broker redelivers a task that is still running (task_acks_late is on).
+    warn = MagicMock()
+    monkeypatch.setattr(celery_forwarder, "logger", SimpleNamespace(warning=warn))
+
+    kwargs = _run_entrypoint(monkeypatch, {"user_port": 5005, "timeout_seconds": 172800})
+
+    assert kwargs["timeout_seconds"] == celery_forwarder.MAX_ASYNC_TIMEOUT_SECONDS
+    warn.assert_called_once()
+    assert "Capping forwarder.async.timeout_seconds" in warn.call_args.args[0]
+
+
+@pytest.mark.parametrize(
+    "visibility, expected",
+    [
+        ("VISIBILITY_24H", 86400),
+        ("VISIBILITY_1H", 3600),
+        ("VISIBILITY_10M", 600),
+        ("VISIBILITY_1M", 60),
+    ],
+)
+def test_task_time_limit_never_exceeds_visibility(visibility, expected):
+    """celery_app asserts this for its app-level limit; a per-task time_limit bypasses that check.
+
+    A forwarder built outside entrypoint() never passed the config-time cap, so the ceiling has to
+    hold here as well.
+    """
+    limit = celery_forwarder.async_task_time_limit(
+        999999, getattr(celery_forwarder.TaskVisibility, visibility)
+    )
+
+    assert limit == expected
+
+
+def test_task_time_limit_stays_above_the_http_timeout_when_it_fits():
+    limit = celery_forwarder.async_task_time_limit(
+        7200, celery_forwarder.TaskVisibility.VISIBILITY_24H
+    )
+
+    assert limit == 7200 + celery_forwarder.CELERY_TIME_LIMIT_GRACE_SECONDS
+    assert limit > 7200
+
+
+def test_default_async_budget_lands_exactly_on_the_visibility_boundary():
+    limit = celery_forwarder.async_task_time_limit(
+        celery_forwarder.MAX_ASYNC_TIMEOUT_SECONDS, celery_forwarder.TaskVisibility.VISIBILITY_24H
+    )
+
+    assert limit == celery_forwarder.DEFAULT_TASK_VISIBILITY_SECONDS
+    assert limit > celery_forwarder.MAX_ASYNC_TIMEOUT_SECONDS

--- a/model-engine/tests/unit/inference/test_celery_forwarder_worker.py
+++ b/model-engine/tests/unit/inference/test_celery_forwarder_worker.py
@@ -6,6 +6,7 @@ retention). It is off by default so prefork behaviour is unchanged, and ignored 
 (which has no per-child recycling). app.Worker is mocked so .start() does not run a real worker.
 """
 
+import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -35,7 +36,11 @@ def test_forwarder_tasks_use_configured_wall_clock_limit(monkeypatch, task_name)
         queue_name="test-queue",
     )
 
-    assert app.tasks[task_name].time_limit == 123.5
+    # Strictly above the forwarder's own HTTP timeout, so that timeout raises before the kill.
+    assert (
+        app.tasks[task_name].time_limit == 123.5 + celery_forwarder.CELERY_TIME_LIMIT_GRACE_SECONDS
+    )
+    assert app.tasks[task_name].time_limit > forwarder.timeout_seconds
 
 
 def _worker_kwargs(monkeypatch, pool, env_value):
@@ -67,3 +72,52 @@ def test_max_tasks_per_child_ignored_under_gevent(monkeypatch):
     kwargs = _worker_kwargs(monkeypatch, "gevent", "500")
     assert kwargs["pool"] == "gevent"
     assert "max_tasks_per_child" not in kwargs
+
+
+def _run_entrypoint(monkeypatch, async_config):
+    """Drive entrypoint() with everything past forwarder construction stubbed out."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "celery_forwarder",
+            "--config",
+            "ignored.yaml",
+            "--task-visibility",
+            "VISIBILITY_24H",
+            "--num-workers",
+            "1",
+            "--queue",
+            "test-queue",
+        ],
+    )
+    monkeypatch.setattr(
+        celery_forwarder, "load_named_config", lambda *_args, **_kwargs: {"async": async_config}
+    )
+    load_forwarder = MagicMock()
+    monkeypatch.setattr(celery_forwarder, "LoadForwarder", load_forwarder)
+    monkeypatch.setattr(celery_forwarder, "create_celery_service", MagicMock())
+    monkeypatch.setattr(celery_forwarder, "start_celery_service", MagicMock())
+
+    celery_forwarder.entrypoint()
+
+    return load_forwarder.call_args.kwargs
+
+
+def test_async_forwarder_does_not_inherit_the_sync_deadline(monkeypatch):
+    # An async task is bounded by the queue's 24h visibility, not by the sync request deadline.
+    kwargs = _run_entrypoint(monkeypatch, {"user_port": 5005})
+
+    assert kwargs["timeout_seconds"] == celery_forwarder.DEFAULT_ASYNC_TIMEOUT_SECONDS
+    # The whole budget, hard limit included, fits inside the window the queue waits for an ack.
+    assert (
+        kwargs["timeout_seconds"] + celery_forwarder.CELERY_TIME_LIMIT_GRACE_SECONDS
+        == celery_forwarder.DEFAULT_TASK_VISIBILITY_SECONDS
+    )
+
+
+def test_async_forwarder_deadline_is_overridable(monkeypatch):
+    # The config file and --set stay authoritative over the default.
+    kwargs = _run_entrypoint(monkeypatch, {"user_port": 5005, "timeout_seconds": 7200})
+
+    assert kwargs["timeout_seconds"] == 7200

--- a/model-engine/tests/unit/infra/gateways/test_celery_task_queue_gateway.py
+++ b/model-engine/tests/unit/infra/gateways/test_celery_task_queue_gateway.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from billiard.exceptions import TimeLimitExceeded
 from model_engine_server.common.dtos.model_endpoints import BrokerType
 from model_engine_server.common.dtos.tasks import TaskStatus
 from model_engine_server.domain.exceptions import BrokerUnavailableException
@@ -8,6 +9,7 @@ from model_engine_server.infra.gateways.celery_task_queue_gateway import (
     CeleryTaskQueueGateway,
     _is_broker_connection_error,
 )
+from requests.exceptions import ConnectTimeout, ReadTimeout
 
 
 # Stand-in for azure.servicebus.exceptions.ServiceBusError so tests run
@@ -87,6 +89,43 @@ def test_get_task_failure_with_none_result(gateway):
     assert response.status == TaskStatus.FAILURE
     assert response.result is None
     assert response.traceback is None
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        TimeLimitExceeded(3600),
+        ReadTimeout("HTTPConnectionPool(host='localhost', port=5005): Read timed out."),
+        ConnectTimeout("connect timed out"),
+    ],
+    ids=["celery_hard_limit", "requests_read_timeout", "requests_connect_timeout"],
+)
+def test_get_task_deadline_reported_as_timeout(gateway, exc):
+    """A forwarder deadline is reported as TIMEOUT so callers can keep polling for late work."""
+    async_result = _make_async_result(state="FAILURE", result=exc, traceback=None)
+
+    with patch.object(gateway, "_get_celery_dest") as mock_dest:
+        mock_dest.return_value.AsyncResult.return_value = async_result
+        response = gateway.get_task("task-timeout")
+
+    assert response.status == TaskStatus.TIMEOUT
+    assert response.traceback is None
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [RuntimeError("boom"), ValueError("bad payload"), MemoryError()],
+    ids=["runtime", "value", "memory"],
+)
+def test_get_task_non_deadline_failures_stay_failure(gateway, exc):
+    """Only deadline exceptions are remapped; every other crash remains terminal FAILURE."""
+    async_result = _make_async_result(state="FAILURE", result=exc, traceback=None)
+
+    with patch.object(gateway, "_get_celery_dest") as mock_dest:
+        mock_dest.return_value.AsyncResult.return_value = async_result
+        response = gateway.get_task("task-crash")
+
+    assert response.status == TaskStatus.FAILURE
 
 
 # ---------------------------------------------------------------------------

--- a/model-engine/tests/unit/infra/services/test_live_batch_job_orchestration_service.py
+++ b/model-engine/tests/unit/infra/services/test_live_batch_job_orchestration_service.py
@@ -1,5 +1,5 @@
 import json
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any
 from unittest.mock import patch
 
@@ -293,3 +293,35 @@ def test_prediction_response_json_encoding():
         id="refid",
         status_code=200,
     )
+
+
+def test_poll_tasks_treats_timeout_as_terminal(
+    live_batch_job_orchestration_service: LiveBatchJobOrchestrationService,
+):
+    """A deadline is terminal for the poller, not a reason to keep polling.
+
+    The poll loop has no sleep, so a status it does not consider terminal becomes a hot loop of
+    result-backend reads until the batch job's own timeout expires.
+    """
+    calls = []
+
+    def fake_get_task(task_id):
+        calls.append(task_id)
+        # Fail instead of hanging CI if TIMEOUT stops being terminal.
+        assert len(calls) <= 5, "poller did not terminate on TaskStatus.TIMEOUT"
+        return GetAsyncTaskV1Response(task_id=task_id, status=TaskStatus.TIMEOUT)
+
+    live_batch_job_orchestration_service.async_model_endpoint_inference_gateway.get_task = (
+        fake_get_task
+    )
+
+    responses = live_batch_job_orchestration_service._poll_tasks(
+        owner="owner",
+        job_id="job-id",
+        task_ids=[BatchEndpointInProgressTask("task-1", "ref-1")],
+        # Far future, so only genuine terminality can end the loop, not the timeout backstop.
+        timeout_timestamp=datetime.utcnow() + timedelta(days=1),
+    )
+
+    assert len(calls) == 1
+    assert [r.response.status for r in responses] == [TaskStatus.TIMEOUT]


### PR DESCRIPTION
## What broke

`#868` gave the sync forwarder an explicit timeout to lift aiohttp's `total=300s` default off long non-streaming generations — a real fix. But the same `timeout_seconds` field also feeds the `requests.post` in `Forwarder.__call__`, which **only the Celery worker calls**, and `requests` has no default timeout. So the async path went from **unbounded to 3600s**. The same commit also derived the Celery hard `time_limit` from that field, giving async tasks a **second** 1-hour deadline that SIGKILLs the worker child.

Async endpoints then failed at exactly 60 minutes while the user container kept running and finished 30–90 minutes later, so callers discarded completed work. Because the hard limit fires before the HTTP timeout, the usual presentation is `FAILURE` with a **null traceback** — on `archie-qc-async`, **18 hard kills to 3 `ReadTimeout`s** over five days.

Reported in MLI-8587 (blocking terminal-bench-3). The endpoint crossed over at `2026-08-22T15:50:02Z`, when its next rebuild swept in the newer forwarder image.

## What this changes

- **The async forwarder no longer inherits the sync deadline.** It defaults to the queue's visibility window instead. The grace is subtracted from it so the hard limit lands *on* the visibility boundary rather than past it, where the message would already have been redelivered to another worker. `86100s` HTTP + `300s` grace = `86400s` = `DEFAULT_TASK_VISIBILITY_SECONDS`.
- **The Celery hard limit is held above the HTTP timeout**, so the forwarder's own `ReadTimeout` raises first and a deadline hit arrives with a traceback instead of as a bare kill.
- **`GetAsyncTaskV1Response` reports `TaskStatus.TIMEOUT`** for a deadline rather than `FAILURE`. A timed-out task leaves the container running, so the result may still land; callers previously could not tell that from a crash, because the API stringifies the exception and `str(TimeLimitExceeded(3600))` is just `"3600"`. Every non-deadline failure stays `FAILURE`.

The config file and `--set` stay authoritative over the new default.

## Blast radius this addresses

515 async endpoints carry a `celery-forwarder`; only 10 had picked up the affected image, because the forwarder tag is frozen at endpoint **build** time and each endpoint converts on its next rebuild. The remaining ~505 would have acquired the cap one at a time over the following weeks.

## Risk

Sync and streaming endpoints are untouched. `Forwarder.__call__` has exactly **one** caller in the tree (`celery_forwarder.py`); `http_forwarder.py` uses `await forwarder.forward(...)`, the aiohttp path. `#868`'s 300s → 3600s improvement for sync is unchanged.

## Tests

- `test_celery_forwarder_worker.py` — the existing wall-clock-limit test now asserts the ordering invariant (hard limit strictly above the HTTP timeout); new tests cover the async default not inheriting the sync deadline, the whole budget fitting inside the visibility window, and config/`--set` still winning.
- `test_celery_task_queue_gateway.py` — deadline exceptions (celery hard limit, `ReadTimeout`, `ConnectTimeout`) map to `TIMEOUT`; `RuntimeError`/`ValueError`/`MemoryError` stay `FAILURE`.
- `model-engine/tests/unit`: **846 passed, 9 skipped**. One pre-existing failure, `test_image_cache_gateway::test_create_or_update_image_cache`, also fails on a clean `origin/main` tree — unrelated to this change.
- black / isort / ruff / mypy clean on the touched files.

## Deliberately out of scope

- **Per-endpoint tunability.** There is still no way to set the async deadline for a single endpoint: the chart only passes `predict_route` and `healthcheck_route` through to the celery-forwarder, and adding a knob needs the endpoint builder and resource types too. Worth a follow-up; kept out so this can land as the unblock.
- **Per-request `timeout_seconds` on the async predict body** (MLI-8587 ask #3). The forwarder deadline is fixed at load time and the Celery limit at task-decoration time, so this needs changes in both components.
- **`result=str(res.result)` discards the exception type for *all* async failures**, not just timeouts. `TaskStatus.TIMEOUT` covers the reported case; changing the `result` shape is a wider contract change.
- The committed OpenAPI specs are **already stale on `main`** (regenerating pulls in 8 added / 8 removed schemas and 4 changed paths from earlier work). Only the `TaskStatus` enum is updated here rather than importing that drift.

Related: **MLI-8206** is the ticket `#868`'s forwarder-timeout sub-commit was written for — its fix is this regression's cause, and it is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR separates asynchronous inference deadlines from the synchronous forwarder timeout and reports deadline failures distinctly.
- Defaults the async HTTP timeout to 86,100 seconds and caps overrides so the 300-second Celery grace remains within the 24-hour visibility window.
- Maps recognized deadline exceptions to the new `TIMEOUT` task status and treats that status as terminal during batch polling.
- Updates the public schemas and adds focused timeout, visibility-budget, status-mapping, and polling tests.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| model-engine/model_engine_server/inference/forwarding/celery_forwarder.py | Separates the async timeout default from the sync deadline, caps configured overrides, and bounds the Celery hard limit by queue visibility. |
| model-engine/model_engine_server/infra/gateways/celery_task_queue_gateway.py | Maps recognized timeout exception types from failed Celery results to the new public TIMEOUT status. |
| model-engine/model_engine_server/common/dtos/tasks.py | Adds TIMEOUT to the shared task-status contract. |
| model-engine/model_engine_server/infra/services/live_batch_job_orchestration_service.py | Treats TIMEOUT as terminal so batch polling completes instead of repeatedly reading the result backend. |
| model-engine/specs/openapi-3.0.json | Adds TIMEOUT to the OpenAPI 3.0 TaskStatus enum. |
| model-engine/specs/openapi.json | Adds TIMEOUT to the committed OpenAPI TaskStatus enum. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Broker as Celery Broker
    participant Worker as Async Forwarder
    participant Model as Model Service
    participant Backend as Result Backend
    Client->>Broker: Submit async inference
    Broker->>Worker: Deliver task
    Worker->>Model: HTTP request (86,100s maximum)
    alt Model responds before deadline
        Model-->>Worker: Result
        Worker->>Backend: Store SUCCESS
    else HTTP deadline expires
        Worker->>Backend: Store timeout exception
        Backend-->>Client: TIMEOUT
    else Celery hard limit reached at visibility boundary
        Worker--xWorker: Hard termination
        Backend-->>Client: TIMEOUT
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(batch): treat TIMEOUT as terminal in..."](https://github.com/scaleapi/llm-engine/commit/0e2b214fe029bcfb32d86c6f60a67263f007de8f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57583457)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Inference runtime](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/llm-engine/-/docs/inference-runtime.md)
- Knowledge Base — [Asynchronous inference](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/llm-engine/-/docs/asynchronous-inference.md)
- Knowledge Base — [Batch-job orchestration and image builds](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/llm-engine/-/docs/batch-job-orchestration.md)
- Knowledge Base — [Service composition and background workers](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/llm-engine/-/docs/service-composition-and-workers.md)
</details>


<!-- /greptile_comment -->