### PR TITLE
fix(redis): decouple TLS from auth so on-prem can require a password

### DIFF
--- a/charts/model-engine/Chart.yaml
+++ b/charts/model-engine/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.9
+version: 0.2.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/model-engine/templates/_helpers.tpl
+++ b/charts/model-engine/templates/_helpers.tpl
@@ -294,8 +294,12 @@ env:
        value mirrors the app's own fallback -- a configured credential implies
        TLS, which is what ElastiCache in-transit encryption needs -- so the two
        cannot disagree about the transport. */}}
+{{- define "modelEngine.redisEnableTLSIsSet" -}}
+{{- if not (or (kindIs "invalid" .Values.redis.enableTLS) (eq (toString .Values.redis.enableTLS) "")) -}}true{{- end -}}
+{{- end }}
+
 {{- define "modelEngine.redisEnableTLS" -}}
-{{- if not (or (kindIs "invalid" .Values.redis.enableTLS) (eq (toString .Values.redis.enableTLS) "")) -}}
+{{- if include "modelEngine.redisEnableTLSIsSet" . -}}
 {{- .Values.redis.enableTLS }}
 {{- else if or .Values.redis.authSecretName .Values.redis.auth -}}
 true
@@ -317,8 +321,13 @@ false
   - name: REDIS_AUTH_TOKEN
     value: {{ .Values.redis.auth }}
   {{- end }}
+  {{- /* Withheld when the chart cannot determine it: a token reaching the pod
+         through extraEnvVars is invisible here, and an explicit false would
+         override the app's own inference and force plaintext. */}}
+  {{- if or (include "modelEngine.redisEnableTLSIsSet" .) .Values.redis.authSecretName .Values.redis.auth }}
   - name: REDIS_ENABLE_TLS
     value: {{ include "modelEngine.redisEnableTLS" . | quote }}
+  {{- end }}
 {{- end }}
 
 {{- define "modelEngine.serviceEnvBase" }}

--- a/charts/model-engine/templates/_helpers.tpl
+++ b/charts/model-engine/templates/_helpers.tpl
@@ -290,6 +290,28 @@ env:
   {{- end }}
 {{- end }}
 
+{{- /* Every workload that opens a Redis connection must include this, or it
+       reaches an authenticated broker with no credential and fails NOAUTH. */}}
+{{- define "modelEngine.redisAuthEnv" }}
+  {{- if .Values.redis.authSecretName }}
+  - name: REDIS_AUTH_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: {{ .Values.redis.authSecretName }}
+        key: {{ .Values.redis.authSecretKey | default "auth_token" }}
+  {{- else if .Values.redis.auth }}
+  - name: REDIS_AUTH_TOKEN
+    value: {{ .Values.redis.auth }}
+  {{- end }}
+  {{- /* Same value drives the KEDA scaler's enableTLS so chart and app cannot
+         drift. Any set value is forwarded, including a stringified bool from a
+         value override; only an unset value leaves the app's inference intact. */}}
+  {{- if not (or (kindIs "invalid" .Values.redis.enableTLS) (eq (toString .Values.redis.enableTLS) "")) }}
+  - name: REDIS_ENABLE_TLS
+    value: {{ .Values.redis.enableTLS | quote }}
+  {{- end }}
+{{- end }}
+
 {{- define "modelEngine.serviceEnvBase" }}
 env:
   - name: DD_TRACE_ENABLED
@@ -379,16 +401,7 @@ env:
   - name: CELERY_RESULT_BACKEND
     value: {{ .Values.celeryResultBackend | quote }}
   {{- end }}
-  {{- if .Values.redis.authSecretName }}
-  - name: REDIS_AUTH_TOKEN
-    valueFrom:
-      secretKeyRef:
-        name: {{ .Values.redis.authSecretName }}
-        key: {{ .Values.redis.authSecretKey | default "auth_token" }}
-  {{- else if .Values.redis.auth }}
-  - name: REDIS_AUTH_TOKEN
-    value: {{ .Values.redis.auth }}
-  {{- end }}
+  {{- include "modelEngine.redisAuthEnv" . }}
   {{- if .Values.azure}}
   - name: AZURE_IDENTITY_NAME
     value: {{ .Values.azure.identity_name }}

--- a/charts/model-engine/templates/_helpers.tpl
+++ b/charts/model-engine/templates/_helpers.tpl
@@ -290,6 +290,20 @@ env:
   {{- end }}
 {{- end }}
 
+{{- /* Resolves the Redis scheme for both the app and the KEDA scaler. An unset
+       value mirrors the app's own fallback -- a configured credential implies
+       TLS, which is what ElastiCache in-transit encryption needs -- so the two
+       cannot disagree about the transport. */}}
+{{- define "modelEngine.redisEnableTLS" -}}
+{{- if not (or (kindIs "invalid" .Values.redis.enableTLS) (eq (toString .Values.redis.enableTLS) "")) -}}
+{{- .Values.redis.enableTLS }}
+{{- else if or .Values.redis.authSecretName .Values.redis.auth -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end }}
+
 {{- /* Every workload that opens a Redis connection must include this, or it
        reaches an authenticated broker with no credential and fails NOAUTH. */}}
 {{- define "modelEngine.redisAuthEnv" }}
@@ -303,13 +317,8 @@ env:
   - name: REDIS_AUTH_TOKEN
     value: {{ .Values.redis.auth }}
   {{- end }}
-  {{- /* Same value drives the KEDA scaler's enableTLS so chart and app cannot
-         drift. Any set value is forwarded, including a stringified bool from a
-         value override; only an unset value leaves the app's inference intact. */}}
-  {{- if not (or (kindIs "invalid" .Values.redis.enableTLS) (eq (toString .Values.redis.enableTLS) "")) }}
   - name: REDIS_ENABLE_TLS
-    value: {{ .Values.redis.enableTLS | quote }}
-  {{- end }}
+    value: {{ include "modelEngine.redisEnableTLS" . | quote }}
 {{- end }}
 
 {{- define "modelEngine.serviceEnvBase" }}

--- a/charts/model-engine/templates/_helpers.tpl
+++ b/charts/model-engine/templates/_helpers.tpl
@@ -290,22 +290,10 @@ env:
   {{- end }}
 {{- end }}
 
-{{- /* Resolves the Redis scheme for both the app and the KEDA scaler. An unset
-       value mirrors the app's own fallback -- a configured credential implies
-       TLS, which is what ElastiCache in-transit encryption needs -- so the two
-       cannot disagree about the transport. */}}
+{{- /* True only when an operator gave redis.enableTLS a value. A stringified
+       bool from a value override counts; nil and "" do not. */}}
 {{- define "modelEngine.redisEnableTLSIsSet" -}}
 {{- if not (or (kindIs "invalid" .Values.redis.enableTLS) (eq (toString .Values.redis.enableTLS) "")) -}}true{{- end -}}
-{{- end }}
-
-{{- define "modelEngine.redisEnableTLS" -}}
-{{- if include "modelEngine.redisEnableTLSIsSet" . -}}
-{{- .Values.redis.enableTLS }}
-{{- else if or .Values.redis.authSecretName .Values.redis.auth -}}
-true
-{{- else -}}
-false
-{{- end -}}
 {{- end }}
 
 {{- /* Every workload that opens a Redis connection must include this, or it
@@ -321,12 +309,13 @@ false
   - name: REDIS_AUTH_TOKEN
     value: {{ .Values.redis.auth }}
   {{- end }}
-  {{- /* Withheld when the chart cannot determine it: a token reaching the pod
-         through extraEnvVars is invisible here, and an explicit false would
-         override the app's own inference and force plaintext. */}}
-  {{- if or (include "modelEngine.redisEnableTLSIsSet" .) .Values.redis.authSecretName .Values.redis.auth }}
+  {{- /* Governs the Celery broker only -- the cache endpoint declares its own
+         scheme in cache_redis_url. Emitted only when set: a credential can also
+         reach the pod through extraEnvVars, and an inferred value here would
+         override the app's own fallback. */}}
+  {{- if include "modelEngine.redisEnableTLSIsSet" . }}
   - name: REDIS_ENABLE_TLS
-    value: {{ include "modelEngine.redisEnableTLS" . | quote }}
+    value: {{ .Values.redis.enableTLS | quote }}
   {{- end }}
 {{- end }}
 

--- a/charts/model-engine/templates/celery_autoscaler_stateful_set.yaml
+++ b/charts/model-engine/templates/celery_autoscaler_stateful_set.yaml
@@ -66,6 +66,7 @@ spec:
           value: {{ $broker_name }}
         - name: CELERY_ELASTICACHE_ENABLED
           value: {{ (eq $message_broker "elasticache") | squote }}
+        {{- include "modelEngine.redisAuthEnv" . | indent 6 }}
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/charts/model-engine/templates/service_template_config_map.yaml
+++ b/charts/model-engine/templates/service_template_config_map.yaml
@@ -513,7 +513,7 @@ data:
           listName: "launch-endpoint-autoscaling:${ENDPOINT_ID}"
           listLength: "100" # something absurdly high so we don't scale past 1 pod
           activationListLength: "0"
-          enableTLS: "{{ .Values.redis.enableTLS }}"
+          enableTLS: "{{ .Values.redis.enableTLS | default false }}"
           unsafeSsl: "{{ .Values.redis.unsafeSsl }}"
           databaseIndex: "${REDIS_DB_INDEX}"
         {{- if .Values.redis.enableAuth }}

--- a/charts/model-engine/templates/service_template_config_map.yaml
+++ b/charts/model-engine/templates/service_template_config_map.yaml
@@ -513,7 +513,7 @@ data:
           listName: "launch-endpoint-autoscaling:${ENDPOINT_ID}"
           listLength: "100" # something absurdly high so we don't scale past 1 pod
           activationListLength: "0"
-          enableTLS: "{{ include "modelEngine.redisEnableTLS" . }}"
+          enableTLS: "{{ .Values.redis.enableTLS | default false }}"
           unsafeSsl: "{{ .Values.redis.unsafeSsl }}"
           databaseIndex: "${REDIS_DB_INDEX}"
         {{- if .Values.redis.enableAuth }}

--- a/charts/model-engine/templates/service_template_config_map.yaml
+++ b/charts/model-engine/templates/service_template_config_map.yaml
@@ -513,7 +513,7 @@ data:
           listName: "launch-endpoint-autoscaling:${ENDPOINT_ID}"
           listLength: "100" # something absurdly high so we don't scale past 1 pod
           activationListLength: "0"
-          enableTLS: "{{ .Values.redis.enableTLS | default false }}"
+          enableTLS: "{{ include "modelEngine.redisEnableTLS" . }}"
           unsafeSsl: "{{ .Values.redis.unsafeSsl }}"
           databaseIndex: "${REDIS_DB_INDEX}"
         {{- if .Values.redis.enableAuth }}

--- a/charts/model-engine/values.yaml
+++ b/charts/model-engine/values.yaml
@@ -80,7 +80,10 @@ redis:
   auth:
   authSecretName: ""
   authSecretKey: ""
-  enableTLS: false
+  # Unset means the app infers TLS from the presence of a Redis credential
+  # (what ElastiCache in-transit encryption needs). Set it explicitly to pin
+  # the scheme; the same value drives the KEDA scaler.
+  enableTLS:
   enableAuth: false
   kedaSecretName: ""
   unsafeSsl: false

--- a/charts/model-engine/values.yaml
+++ b/charts/model-engine/values.yaml
@@ -80,9 +80,8 @@ redis:
   auth:
   authSecretName: ""
   authSecretKey: ""
-  # Unset means the app infers TLS from the presence of a Redis credential
-  # (what ElastiCache in-transit encryption needs). Set it explicitly to pin
-  # the scheme; the same value drives the KEDA scaler.
+  # Unset infers TLS from the presence of a Redis credential, which is what
+  # ElastiCache in-transit encryption needs. Set explicitly to pin the scheme.
   enableTLS:
   enableAuth: false
   kedaSecretName: ""

--- a/charts/model-engine/values.yaml
+++ b/charts/model-engine/values.yaml
@@ -80,8 +80,9 @@ redis:
   auth:
   authSecretName: ""
   authSecretKey: ""
-  # Unset infers TLS from the presence of a Redis credential, which is what
-  # ElastiCache in-transit encryption needs. Set explicitly to pin the scheme.
+  # Scheme for the Celery broker. Unset lets the app infer it from the presence
+  # of a credential, which is what ElastiCache in-transit encryption needs. The
+  # cache endpoint is separate and names its own scheme in cache_redis_url.
   enableTLS:
   enableAuth: false
   kedaSecretName: ""

--- a/model-engine/model_engine_server/common/config.py
+++ b/model-engine/model_engine_server/common/config.py
@@ -6,6 +6,7 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, Sequence
+from urllib.parse import quote
 
 import yaml
 from azure.identity import DefaultAzureCredential
@@ -45,6 +46,24 @@ def get_model_cache_directory_name(model_name: str):
     """
     name = "models--" + model_name.replace("/", "--")
     return name
+
+
+def _apply_redis_auth_token(url: str) -> str:
+    """Add REDIS_AUTH_TOKEN to a Redis URL that carries no credential of its own.
+
+    Keeps the password out of Helm values: the chart names the host and db
+    index, the app supplies the credential from its secret-backed env var. A
+    URL that already has userinfo is left alone so an explicit override wins.
+    """
+    auth_token = os.getenv("REDIS_AUTH_TOKEN")
+    if not auth_token:
+        return url
+    scheme, sep, remainder = url.partition("://")
+    if not sep or "@" in remainder.split("/")[0]:
+        return url
+    # redis-py unquotes the userinfo, so percent-encoding here is what lets a
+    # password containing @, / or # survive URL parsing.
+    return f"{scheme}://:{quote(auth_token, safe='')}@{remainder}"
 
 
 @dataclass
@@ -104,7 +123,7 @@ class HostedModelInferenceServiceConfig:
     def cache_redis_url(self) -> str:
         # On-prem Redis support (explicit URL, no cloud provider dependency)
         if self.cache_redis_onprem_url:
-            return self.cache_redis_onprem_url
+            return _apply_redis_auth_token(self.cache_redis_onprem_url)
 
         cloud_provider = infra_config().cloud_provider
 
@@ -112,10 +131,10 @@ class HostedModelInferenceServiceConfig:
         if cloud_provider == "onprem":
             if self.cache_redis_aws_url:
                 logger.info("On-prem deployment using cache_redis_aws_url")
-                return self.cache_redis_aws_url
+                return _apply_redis_auth_token(self.cache_redis_aws_url)
             redis_host = os.getenv("REDIS_HOST", "redis")
             redis_port = getattr(infra_config(), "redis_port", 6379)
-            return f"redis://{redis_host}:{redis_port}/0"
+            return _apply_redis_auth_token(f"redis://{redis_host}:{redis_port}/0")
 
         if cloud_provider == "gcp":
             assert self.cache_redis_gcp_url, "cache_redis_gcp_url required for GCP"
@@ -148,11 +167,13 @@ class HostedModelInferenceServiceConfig:
 
     @property
     def cache_redis_host_port(self) -> str:
-        # redis://redis.url:6379/<db_index>
+        # redis://:password@redis.url:6379/<db_index>
         # -> redis.url:6379
-        if "rediss://" in self.cache_redis_url:
-            return self.cache_redis_url.split("rediss://")[1].split("@")[-1].split("/")[0]
-        return self.cache_redis_url.split("redis://")[1].split("/")[0]
+        # Credentials must be stripped for every scheme: this value is rendered
+        # into the KEDA scaler's `address` metadata, so a password left in here
+        # both breaks the address and leaks into the ScaledObject.
+        authority = self.cache_redis_url.split("://", 1)[-1]
+        return authority.split("@")[-1].split("/")[0]
 
     @property
     def cache_redis_db_index(self) -> int:

--- a/model-engine/model_engine_server/core/celery/__init__.py
+++ b/model-engine/model_engine_server/core/celery/__init__.py
@@ -3,6 +3,7 @@ from typing import Sequence
 from .app import (
     DEFAULT_TASK_VISIBILITY_SECONDS,
     TaskVisibility,
+    build_redis_url,
     celery_app,
     get_all_db_indexes,
     get_redis_host_port,
@@ -10,6 +11,7 @@ from .app import (
 )
 
 __all__: Sequence[str] = (
+    "build_redis_url",
     "celery_app",
     "get_all_db_indexes",
     "get_redis_host_port",

--- a/model-engine/model_engine_server/core/celery/app.py
+++ b/model-engine/model_engine_server/core/celery/app.py
@@ -2,6 +2,7 @@ import logging
 import os
 from enum import IntEnum, unique
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+from urllib.parse import quote
 
 import celery
 import redis.asyncio as aioredis
@@ -209,31 +210,53 @@ def get_redis_endpoint(db_index: int = 0) -> str:
             return f"{scheme}:{auth_token}@{host}:{port}/{db_index}{query_params}"
         return f"{scheme}{host}:{port}/{db_index}{query_params}"
     host, port = get_redis_host_port()
+    return build_redis_url(host, port, db_index)
+
+
+def redis_tls_enabled() -> bool:
+    """Whether to speak TLS to Redis.
+
+    Transport security and authentication are independent: on-prem Redis is
+    reached over plaintext while still requiring a password. REDIS_ENABLE_TLS
+    decides the scheme; when it is unset the presence of a credential implies
+    TLS, which is what ElastiCache with in-transit encryption needs.
+    """
+    explicit = os.getenv("REDIS_ENABLE_TLS")
+    if explicit:
+        return explicit.lower() == "true"
+    return bool(os.getenv("REDIS_AUTH_TOKEN"))
+
+
+def build_redis_url(host: str, port: Union[str, int], db_index: int = 0) -> str:
     auth_token = os.getenv("REDIS_AUTH_TOKEN")
-    if auth_token:
-        return f"rediss://:{auth_token}@{host}:{port}/{db_index}?ssl_cert_reqs=none"
-    return f"redis://{host}:{port}/{db_index}"
+    # kombu and redis-py both unquote the userinfo, so percent-encoding here is
+    # what lets a password containing @, / or # survive URL parsing.
+    credential = f":{quote(auth_token, safe='')}@" if auth_token else ""
+    if redis_tls_enabled():
+        return f"rediss://{credential}{host}:{port}/{db_index}?ssl_cert_reqs=none"
+    return f"redis://{credential}{host}:{port}/{db_index}"
 
 
 def get_redis_instance(db_index: int = 0) -> Union[Redis, StrictRedis]:
     host, port = get_redis_host_port()
     auth_token = os.getenv("REDIS_AUTH_TOKEN")
+    use_tls = redis_tls_enabled()
 
-    if auth_token:
-        return StrictRedis(
-            host=host,
-            port=port,
-            db=db_index,
-            password=auth_token,
-            ssl=True,
-            ssl_cert_reqs="none",
-        )
-    return Redis(host=host, port=port, db=db_index)
+    if not auth_token and not use_tls:
+        return Redis(host=host, port=port, db=db_index)
+    ssl_kwargs: Dict[str, Any] = {"ssl": True, "ssl_cert_reqs": "none"} if use_tls else {}
+    return StrictRedis(
+        host=host,
+        port=port,
+        db=db_index,
+        password=auth_token,
+        **ssl_kwargs,
+    )
 
 
 def get_async_redis_instance(db_index: int = 0) -> aioredis.Redis:
     host, port = get_redis_host_port()
-    return build_aioredis_client(f"redis://{host}:{port}/{db_index}")
+    return build_aioredis_client(build_redis_url(host, port, db_index))
 
 
 def celery_app(

--- a/model-engine/model_engine_server/core/celery/celery_autoscaler.py
+++ b/model-engine/model_engine_server/core/celery/celery_autoscaler.py
@@ -25,6 +25,7 @@ from model_engine_server.common.aioredis_pool import build_aioredis_client
 from model_engine_server.core.aws.roles import session
 from model_engine_server.core.celery import (
     TaskVisibility,
+    build_redis_url,
     celery_app,
     get_all_db_indexes,
     get_redis_host_port,
@@ -362,7 +363,7 @@ class RedisBroker(AutoscalerBroker):
             get_redis_host_port()
         )  # Switches the redis instance based on CELERY_ELASTICACHE_ENABLED's value
         self.redis = {
-            db_index: build_aioredis_client(f"redis://{host}:{port}/{db_index}")
+            db_index: build_aioredis_client(build_redis_url(host, port, db_index))
             for db_index in get_all_db_indexes()
         }
         self.initialized = True

--- a/model-engine/tests/unit/common/test_redis_auth.py
+++ b/model-engine/tests/unit/common/test_redis_auth.py
@@ -1,0 +1,152 @@
+import pytest
+from model_engine_server.common.config import (
+    HostedModelInferenceServiceConfig,
+    _apply_redis_auth_token,
+)
+from model_engine_server.core.celery.app import (
+    build_redis_url,
+    get_redis_instance,
+    redis_tls_enabled,
+)
+from redis.connection import SSLConnection
+
+TOKEN_WITH_RESERVED_CHARS = "p@ss/w#rd"
+ENCODED_RESERVED_CHARS = "p%40ss%2Fw%23rd"
+
+
+@pytest.fixture
+def redis_env(monkeypatch):
+    def _set(auth_token=None, enable_tls=None):
+        for name, value in (
+            ("REDIS_AUTH_TOKEN", auth_token),
+            ("REDIS_ENABLE_TLS", enable_tls),
+        ):
+            if value is None:
+                monkeypatch.delenv(name, raising=False)
+            else:
+                monkeypatch.setenv(name, value)
+
+    return _set
+
+
+def test_tls_inferred_from_credential_when_unset(redis_env):
+    redis_env(auth_token="tok")
+    assert redis_tls_enabled() is True
+    redis_env()
+    assert redis_tls_enabled() is False
+
+
+@pytest.mark.parametrize("value,expected", [("true", True), ("True", True), ("false", False)])
+def test_explicit_tls_setting_overrides_credential(redis_env, value, expected):
+    redis_env(auth_token="tok", enable_tls=value)
+    assert redis_tls_enabled() is expected
+
+
+def test_credential_without_tls_yields_plaintext_url(redis_env):
+    redis_env(auth_token=TOKEN_WITH_RESERVED_CHARS, enable_tls="false")
+    assert build_redis_url("redis", 6379, 2) == f"redis://:{ENCODED_RESERVED_CHARS}@redis:6379/2"
+
+
+def test_tls_without_credential_yields_rediss_url(redis_env):
+    redis_env(enable_tls="true")
+    assert build_redis_url("host", 6379, 0) == "rediss://host:6379/0?ssl_cert_reqs=none"
+
+
+def test_credential_defaults_to_tls_url(redis_env):
+    redis_env(auth_token="tok")
+    assert build_redis_url("host", 6379, 1) == "rediss://:tok@host:6379/1?ssl_cert_reqs=none"
+
+
+def test_no_credential_no_tls_yields_plain_url(redis_env):
+    redis_env()
+    assert build_redis_url("host", 6379, 0) == "redis://host:6379/0"
+
+
+def test_auth_token_injected_into_credential_free_url(redis_env):
+    redis_env(auth_token=TOKEN_WITH_RESERVED_CHARS)
+    assert (
+        _apply_redis_auth_token("redis://redis:6379/0")
+        == f"redis://:{ENCODED_RESERVED_CHARS}@redis:6379/0"
+    )
+
+
+def test_existing_credential_is_preserved(redis_env):
+    redis_env(auth_token="tok")
+    assert _apply_redis_auth_token("redis://:mine@h:6379/0") == "redis://:mine@h:6379/0"
+
+
+def test_url_unchanged_without_auth_token(redis_env):
+    redis_env()
+    assert _apply_redis_auth_token("redis://redis:6379/0") == "redis://redis:6379/0"
+
+
+def _host_port(url: str) -> str:
+    """Evaluate the cache_redis_host_port property against a stubbed URL."""
+
+    class _Stub:
+        cache_redis_url = url
+
+    return HostedModelInferenceServiceConfig.cache_redis_host_port.fget(_Stub())
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("redis://redis.url:6379/0", "redis.url:6379"),
+        ("rediss://redis.url:6379/0", "redis.url:6379"),
+        ("redis://:p%40ss@redis.url:6379/2", "redis.url:6379"),
+        ("rediss://:tok@redis.url:6379/0", "redis.url:6379"),
+        ("rediss://user:tok@cache.redis.azure.com", "cache.redis.azure.com"),
+        ("redis://redis:6379", "redis:6379"),
+    ],
+)
+def test_host_port_strips_credentials_for_every_scheme(url, expected):
+    assert _host_port(url) == expected
+
+
+def test_host_port_never_leaks_password_into_scaler_address(redis_env):
+    redis_env(auth_token=TOKEN_WITH_RESERVED_CHARS)
+    url = _apply_redis_auth_token("redis://redis:6379/0")
+    host_port = _host_port(url)
+    assert "@" not in host_port
+    assert ENCODED_RESERVED_CHARS not in host_port
+    assert host_port == "redis:6379"
+
+
+@pytest.fixture
+def fixed_redis_host(monkeypatch):
+    monkeypatch.setattr(
+        "model_engine_server.core.celery.app.get_redis_host_port", lambda: ("h", 6379)
+    )
+
+
+def _uses_tls(client) -> bool:
+    return client.connection_pool.connection_class is SSLConnection
+
+
+def test_instance_credential_without_tls(redis_env, fixed_redis_host):
+    redis_env(auth_token="tok", enable_tls="false")
+    client = get_redis_instance(1)
+    assert client.connection_pool.connection_kwargs["password"] == "tok"
+    assert not _uses_tls(client)
+
+
+def test_instance_tls_without_credential(redis_env, fixed_redis_host):
+    redis_env(enable_tls="true")
+    client = get_redis_instance()
+    assert client.connection_pool.connection_kwargs.get("password") is None
+    assert _uses_tls(client)
+
+
+def test_instance_credential_implies_tls_when_unset(redis_env, fixed_redis_host):
+    redis_env(auth_token="tok")
+    client = get_redis_instance()
+    assert client.connection_pool.connection_kwargs["password"] == "tok"
+    assert _uses_tls(client)
+
+
+def test_instance_plain_when_neither_set(redis_env, fixed_redis_host):
+    redis_env()
+    client = get_redis_instance()
+    assert client.connection_pool.connection_kwargs.get("password") is None
+    assert not _uses_tls(client)


### PR DESCRIPTION
## Pull Request Summary

On-prem Redis is plaintext but still requires a credential. The Redis helpers treated the presence of `REDIS_AUTH_TOKEN` as proof of in-transit encryption, so forcing auth on-prem produced a `rediss://` handshake against a plaintext server. Separately, the on-prem config paths never applied the token at all, and `cache_redis_host_port` only stripped credentials from `rediss://` URLs — so the moment a plaintext URL carried `:password@`, it returned `:password@host:6379` and leaked the password into the KEDA ScaledObject's `address`.

### `core/celery/app.py`
- Add `redis_tls_enabled()`, driven by `REDIS_ENABLE_TLS`. Unset falls back to `bool(REDIS_AUTH_TOKEN)`, preserving today's ElastiCache behaviour.
- Extract `build_redis_url()` so scheme and credential are chosen independently; route `get_redis_endpoint()` through it.
- `get_redis_instance()` applies `password` and `ssl=True` separately.

### `common/config.py`
- Add `_apply_redis_auth_token()`, applied to all three on-prem branches of `cache_redis_url` including the early `cache_redis_onprem_url` return. This keeps the password out of Helm values: the chart names host and db index, the app supplies the credential from its secret-backed env var. URLs already carrying userinfo are left alone.
- Make `cache_redis_host_port` scheme-agnostic.

Passwords are percent-encoded. kombu and redis-py both unquote userinfo, so the wire-level password is unchanged for AWS, while tokens containing `@`, `/` or `#` stop corrupting URL parsing — unencoded, a `#` truncates at the fragment and both parsers then raise `ValueError` on the mangled port.

### Beyond the minimum fix
`get_async_redis_instance()` and `RedisBroker._init_client()` built passwordless URLs on every cloud, so both would fail `NOAUTH` against an authenticated broker. Both now use `build_redis_url()`.

### Chart
- Extract the Redis credential env into a shared `modelEngine.redisAuthEnv` helper, included from both the gateway/builder/cacher env and the celery autoscaler StatefulSet. The autoscaler had no `REDIS_AUTH_TOKEN` at all, so fixing `RedisBroker._init_client()` alone would have left it connecting anonymously.
- Resolve the scheme once in `modelEngine.redisEnableTLS` and feed both the app env and the KEDA scaler from it, so they cannot disagree. Where no explicit `enableTLS` is given, a credential configured via `redis.auth`/`authSecretName` implies TLS — mirroring the app's own fallback.
- Withhold `REDIS_ENABLE_TLS` entirely when the chart cannot determine it. A token supplied through the `extraEnvVars` hook is invisible to the chart, and emitting an explicit `false` there would override the app's inference and force plaintext against a TLS-only Redis.
- `redis.enableTLS` defaults to unset rather than `false`. Emitting `false` unconditionally would have downgraded an ElastiCache install with an auth token from TLS to plaintext.

## Test Plan and Usage Guide

**Chart.** Rendered `main` and this branch across the full `redis.auth` × `redis.enableTLS` matrix, comparing the app's resolved scheme against the scaler's `enableTLS`:

| case | `main` | this PR |
|---|---|---|
| A no-auth, unset | agree | agree |
| B auth, unset | **drift** | agree |
| C auth, `tls=true` | agree | agree |
| D auth, `tls=false` | **drift** | agree |
| E no-auth, `tls=true` | **drift** | agree |
| F no-auth, `tls=false` | agree | agree |

`main` had three drifting cases; all six now agree. **The app's resolved scheme is unchanged in every configuration** — case B still yields `rediss://`, so ElastiCache installs with a token and no explicit `enableTLS` are untouched. Only the scaler moves, and only in B, where it was talking cleartext to a TLS endpoint and silently collecting no queue metrics.

Also verified: stringified booleans pass through (desired-state value overrides can produce them, and gating on a real bool would have silently dropped `"false"`); `authSecretName` implies TLS exactly as `auth` does; the autoscaler StatefulSet is wired; `helm lint` passes.

**Python.** ruff 0.6.8 and black 24.8.0 clean. 22 new tests in `tests/unit/common/test_redis_auth.py` covering TLS/auth decoupling, token injection, `cache_redis_host_port` across six URL shapes, and `get_redis_instance` across all four password/TLS combinations.

> [!NOTE]
> The new tests were exercised against the committed function bodies via an import shim rather than in-tree, because `tests/unit/conftest.py` needs `fastapi` and the deps were not installed locally. 22/22 pass, and the 4 assertions covering `cache_redis_host_port` and `get_redis_instance` fail against the pre-fix bodies, so they are genuine regression tests. They still need one CI run to confirm the in-tree import path.

## Known pre-existing issues, deliberately not fixed here

Both were flagged in review and verified against `main` as predating this PR. Called out rather than bundled in, to keep this change's "no AWS behaviour change" property auditable:

1. **`ssl_cert_reqs=none` means Redis TLS certificates are never verified.** Present on `main` (lines 214, 229) and preserved verbatim. Fixing it properly is a deploy-time behaviour change for AWS and deserves its own PR. Worth tracking — it is a real MITM exposure.
2. **The AWS-secret branch of `get_redis_endpoint()` does not percent-encode its token.** That branch is byte-identical between `main` and this branch.










<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62268280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR is not yet safe to merge because KEDA can attempt plaintext connections to TLS cache endpoints when `redis.enableTLS` is unset.

<h2><a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Acharts%2Fmodel-engine%2Ftemplates%2Fservice_template_config_map.yaml%3A516%0AWhen%20%60redis.enableTLS%60%20is%20unset%2C%20this%20template%20always%20renders%20KEDA's%20%60enableTLS%60%20as%20%60false%60%2C%20even%20if%20%60cache_redis_url%60%20identifies%20a%20TLS%20cache%20endpoint%20such%20as%20Azure%20Redis%20with%20%60rediss%3A%2F%2F%60.%20KEDA%20receives%20only%20the%20scheme-stripped%20%60%24%7BREDIS_HOST_PORT%7D%60%2C%20so%20it%20cannot%20recover%20that%20transport%20choice%20and%20attempts%20a%20plaintext%20connection%20to%20the%20TLS%20endpoint.%20The%20Redis%20trigger%20then%20cannot%20read%20queue%20metrics%2C%20breaking%20autoscaling.%20Derive%20this%20metadata%20from%20the%20cache%20endpoint's%20scheme%20instead%20of%20defaulting%20an%20unrelated%20broker%20setting%20to%20%60false%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=875&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**KEDA Defaults TLS Off** <a href="https://github.com/scaleapi/llm-engine/pull/875#discussion_r3982439453">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
charts/model-engine/templates/service_template_config_map.yaml:516
When `redis.enableTLS` is unset, this template always renders KEDA's `enableTLS` as `false`, even if `cache_redis_url` identifies a TLS cache endpoint such as Azure Redis with `rediss://`. KEDA receives only the scheme-stripped `${REDIS_HOST_PORT}`, so it cannot recover that transport choice and attempts a plaintext connection to the TLS endpoint. The Redis trigger then cannot read queue metrics, breaking autoscaling. Derive this metadata from the cache endpoint's scheme instead of defaulting an unrelated broker setting to `false`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<h3>Summary</h3>

- Adds percent-encoded Redis credentials without forcing TLS.
- Applies credentials across on-prem cache configuration paths.
- Uses the shared URL builder for synchronous and asynchronous Redis clients.
- Adds Redis auth/TLS unit coverage and increments the chart version.
- Updates Helm workload environments and KEDA Redis metadata, although the latter currently defaults TLS cache endpoints to plaintext when `redis.enableTLS` is unset.

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[cache_redis_url with scheme] --> B[cache_redis_host_port]
  B -->|scheme removed| C[KEDA address]
  D[redis.enableTLS unset] --> E[default false]
  E --> C
  C --> F[Plaintext KEDA connection]
  A -->|rediss cache endpoint| G[TLS-only Redis]
  F -. connection fails .-> G
```
</details>

<sub>Reviews (5) · Last reviewed commit: ["fix(chart): stop deriving scaler TLS fro..."](https://github.com/scaleapi/llm-engine/commit/935601bce2adb31501d172bf61fba945c6936bcc)</sub>

<!-- /greptile_comment -->