### PR TITLE
[PLA4-44978] Remove Celery autoscaler timing logs

### DIFF
--- a/model-engine/model_engine_server/core/celery/celery_autoscaler.py
+++ b/model-engine/model_engine_server/core/celery/celery_autoscaler.py
@@ -88,7 +88,6 @@ async def list_deployments(apps_api) -> Dict[Tuple[str, str], CeleryAutoscalerPa
     namespaces_to_scan = list(dict.fromkeys([endpoint_namespace, "default"]))
     celery_deployments_params = {}
     for namespace_name in namespaces_to_scan:
-        namespace_start_time = time.time()
         try:
             deployments = await apps_api.list_namespaced_deployment(namespace=namespace_name)
         except ApiException as exc:
@@ -96,9 +95,6 @@ async def list_deployments(apps_api) -> Dict[Tuple[str, str], CeleryAutoscalerPa
             # other. Log and move on; the next iteration of the outer loop will retry.
             logger.error(f"Failed to list deployments in namespace {namespace_name}: {exc}")
             continue
-        logger.info(
-            f"list_namespaced_deployment in {namespace_name} took {time.time() - namespace_start_time} seconds"
-        )
         for deployment in deployments.items:
             deployment_name = deployment.metadata.name
             annotations = deployment.metadata.annotations
@@ -647,7 +643,6 @@ async def main():
         try:
             loop_start = time.time()
             deployments = await list_deployments(apps_api=apps_api)
-            logger.info(f"list_deployments took {time.time() - loop_start} seconds")
             celery_queues = set()
             celery_queues_params = []
             for deployment_and_namespace, params in sorted(
@@ -677,9 +672,7 @@ async def main():
 
             # Get queue sizes
             # (queue_name, db_index) -> QueueSizes
-            start_get_metrics = time.time()
             metrics = await get_metrics(broker, inspect=inspect, queues=celery_queues)
-            logger.info(f"get_metrics took {time.time() - start_get_metrics} seconds")
 
             queue_sizes = metrics.broker_metrics.queue_sizes
             for k, v in sorted(queue_sizes.items()):
@@ -700,7 +693,6 @@ async def main():
 
             # Wait before next iteration
             iteration_len = time.time() - loop_start
-            logger.info(f"Iteration length: {iteration_len} seconds.")
             if iteration_len < 3:
                 await aio.sleep(3 - iteration_len)
 


### PR DESCRIPTION
## Linear

- https://linear.app/scale-epd/issue/PLA4-44978

## Finding

The `celery-autoscaler-sqs` loop emits four INFO timing statements on every iteration and for every scanned namespace:

- `list_namespaced_deployment ... took ... seconds`
- `list_deployments took ... seconds`
- `get_metrics took ... seconds`
- `Iteration length: ... seconds`

This change removes only those timing statements and their now-unused timers. Queue state, scaling actions, errors, and health telemetry remain unchanged.

## Datadog evidence

Frozen window: **2026-09-04 20:08:12 UTC through 2026-09-11 20:08:12 UTC**.

- [Exact matching logs and seven-day volume](https://app.datadoghq.com/logs?query=service%3A%22celery-autoscaler-sqs%22+%28%22list_namespaced_deployment%22+OR+%22list_deployments+took%22+OR+%22get_metrics+took%22+OR+%22Iteration+length%3A%22%29&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice%2Cstatus%2Csource%2Cenv&messageDisplay=inline&sort_m=count&sort_t=count&storage=hot&viz=timeseries&from_ts=1788552492000&to_ts=1789157292000&live=false): **116,003,024 INFO events**
- [All service indexed-event volume](https://app.datadoghq.com/metric/explorer?live=false&from_ts=1788552492000&to_ts=1789157292000&query=sum%3Adatadog.estimated_usage.logs.ingested_events%7Bdatadog_is_excluded%3Afalse%2Cservice%3Acelery-autoscaler-sqs%7D.as_count%28%29): **118.00M events**
- [All service ingested-byte volume](https://app.datadoghq.com/metric/explorer?live=false&from_ts=1788552492000&to_ts=1789157292000&query=sum%3Adatadog.estimated_usage.logs.ingested_bytes%7Bservice%3Acelery-autoscaler-sqs%7D.as_count%28%29): **216.27 GB**
- The selector returned only `info` events and represents approximately 98% of indexed service volume.

## Estimated savings

Contract rates: $0.98 per million indexed events (7-day retention) and $0.10 per ingested GB. Monthly estimates use 30.4375 / 7.

| Cost | Seven-day removable usage | Monthly value |
|---|---:|---:|
| Indexed events | 116,003,024 | $494.32 |
| Ingestion | 212.612 GB estimated | $92.45 |
| **Total** | | **$586.77/month ($7,041.19/year)** |

The ingestion estimate allocates measured service bytes using the exact selector's share of service events. The full census projects 44.46B indexed events against a 26B monthly commitment and 158,475 GB ingestion against a 105,000 GB commitment, so gross usage value and projected invoice impact are currently the same.

## Safety and provenance

- Removal confidence: **95/100**.
- The four timing messages were introduced with the autoscaler in [PR #378](https://github.com/scaleapi/llm-engine/pull/378), merged November 17, 2023.
- Queue-size gauges, worker-count gauges, connection gauges, `celery_autoscaler.heartbeat`, scaling success/failure metrics, deployment-update logs, queue-state logs, and every exception/error path remain intact.
- `pup monitors search` found eight Celery-autoscaler-related monitors and zero exact references to the removed strings. Four log monitors alert on `status:error`; four health monitors use `celery_autoscaler.heartbeat`. Neither dependency is changed.
- Security Monitoring Rules and saved Log Explorer views could not be audited because the current app key receives 403 for those APIs. The PR remains draft for owner review.

The repository has no CODEOWNERS file. The autoscaler chart/workload metadata uses `team: infra`; ownership should be confirmed during review.

## Tests

- Ruff 0.6.8 check on the changed file.
- Black 24.8.0 formatting check.
- Python bytecode compilation.
- `git diff --check`.

## Rollout

Draft only. No deployment or reviewers assigned. After deploy, verify the exact query falls while `status:error` alerts, heartbeat monitors, scaling metrics, and deployment-update logs remain healthy.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=64201875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 5/5</h2>

This PR appears safe to merge.

What we checked:
- Loop pacing stays intact: No. The loop still records its start time, measures the full pass, and sleeps long enough to keep the three-second minimum interval.

<h3>Summary</h3>

The Celery autoscaler stops writing timing logs while keeping its scaling loop and health reporting unchanged. It removes timers used only for those messages, reducing repeated INFO log volume.

<details><summary><h3>Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant A as Autoscaler
    participant K as Kubernetes API
    participant B as Queue broker
    participant D as Datadog
    loop Autoscaler pass
        A->>K: "List deployments"
        K-->>A: "Return deployments"
        A->>B: "Read queue and worker state"
        B-->>A: "Return queue metrics"
        A->>D: "Send queue and worker gauges"
        A->>K: "Update worker counts"
        opt Pass took under three seconds
            A->>A: "Sleep for the remaining time"
        end
        A->>D: "Send heartbeat"
        Note over A,D: Timing INFO logs are no longer sent
    end
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["\[PLA4-44978\] Remove Celery autoscaler ti..."](https://github.com/scaleapi/llm-engine/commit/022f4381b542ed6d7b41924f0e95f6713ac023a1)</sub>

<!-- /greptile_comment -->